### PR TITLE
ITM 197 - visualize survey results

### DIFF
--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -4,6 +4,8 @@ import { Model } from 'survey-core'
 import { Survey } from "survey-react-ui"
 import surveyConfig from './surveyConfig.json';
 import surveyTheme from './surveyTheme.json';
+import { StaticTemplate } from "./staticTemplate";
+import { DynamicTemplate } from "./dynamicTemplate";
 import gql from "graphql-tag";
 import { Mutation } from '@apollo/react-components';
 import { StaticTemplate } from "./staticTemplate";
@@ -162,8 +164,12 @@ class SurveyPage extends Component {
         // iterate through each page in the survey
         for (const pageName in this.pageStartTimes) {
             if (this.pageStartTimes.hasOwnProperty(pageName)) {
+                const page = this.survey.getPageByName(pageName)?.jsonObj;
                 this.surveyData[pageName] = {
                     timeSpentOnPage: this.surveyData[pageName]?.timeSpentOnPage,
+                    scenarioIndex: page?.scenarioIndex,
+                    pageType: page?.pageType,
+                    pageName: page?.name,
                     questions: {}
                 };
 

--- a/dashboard-ui/src/components/SurveyResults/surveyResults.css
+++ b/dashboard-ui/src/components/SurveyResults/surveyResults.css
@@ -1,0 +1,89 @@
+.selection-btn {
+    background-color: transparent;
+    border: 2px solid black;
+    border-radius: 4px;
+    padding: 4px 8px;
+    margin: auto 8px;
+}
+
+.selection-btn:disabled {
+    background-color: rgb(142, 142, 142);
+    border: 2px solid rgb(73, 73, 73);
+    color: white;
+}
+
+.selection-btn:hover:enabled {
+    cursor: pointer;
+    background-color: rgb(224, 224, 224);
+}
+
+.selection-btn:active:enabled {
+    background-color: rgb(199, 199, 199);
+}
+
+.button-section {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+}
+
+.selection-box {
+    padding: 12px 8px 12px 24px;
+    border-bottom: 1px solid black;
+    margin-bottom: 12px;
+    position: sticky;
+    top: 0;
+    background-color: #F8F8F8;
+    z-index: 1;
+}
+
+.scenario-group {
+    border: 1px solid black;
+}
+
+.singletons {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+}
+
+.singletons>* {
+    width: 50%;
+    border-right: 1px solid black;
+    padding: 8px;
+}
+
+.singletons>*:last-child {
+    border-right: none;
+}
+
+.scenario-header {
+    text-align: center;
+    padding-bottom: 8px;
+    border-bottom: 1px solid black;
+}
+
+.sa-question-layouted {
+    width: 100%;
+}
+
+.sa-toolbar {
+    display: none;
+}
+
+.sa-visualizer__toolbar {
+    display: none;
+}
+
+.sa-visualizer__footer {
+    display: none;
+}
+
+.modebar-container {
+    display: none;
+}
+
+.page-name {
+    margin-left: 8px;
+    text-decoration: underline;
+}

--- a/dashboard-ui/src/components/SurveyResults/surveyResults.jsx
+++ b/dashboard-ui/src/components/SurveyResults/surveyResults.jsx
@@ -1,0 +1,260 @@
+import React from 'react';
+import gql from "graphql-tag";
+import { useQuery } from '@apollo/react-hooks';
+import { VisualizationPanel } from 'survey-analytics';
+import 'survey-analytics/survey.analytics.min.css';
+import './surveyResults.css';
+import { Model } from 'survey-core';
+
+const GET_SURVEY_RESULTS = gql`
+    query GetSurveyResults{
+        getAllSurveyResults
+    }`;
+
+const surveyChoiceScale = [
+    { value: 5, text: "Strongly agree" },
+    { value: 4, text: "Agree" },
+    { value: 3, text: "Neither agree nor disagree" },
+    { value: 2, text: "Disagree" },
+    { value: 1, text: "Strongly disagree" }
+];
+
+function responseToNumber(response) {
+    for (const x of surveyChoiceScale) {
+        if (response === x.text) {
+            return x.value;
+        }
+    }
+    return 0;
+}
+
+const vizPanelOptions = {
+    allowHideQuestions: false
+}
+
+function ScenarioGroup({ scenario, data }) {
+    const [singles, setSingles] = React.useState([]);
+    const [comparisons, setComparisons] = React.useState([]);
+
+    React.useEffect(() => {
+        if (data) {
+            const singleData = [];
+            const comparisonData = [];
+            for (const k of Object.keys(data)) {
+                if (k.includes('singleMedic')) {
+                    singleData.push(data[k]);
+                }
+                else if (k.includes('comparison')) {
+                    comparisonData.push(data[k]);
+                }
+            }
+            setSingles([...singleData]);
+            setComparisons([...comparisonData]);
+        }
+    }, [data]);
+
+    return (<div className='scenario-group'>
+        <h2 className='scenario-header'>Scenario {scenario}</h2>
+        <div className='singletons'>
+            {singles?.map((singleton) => { return <SingletonGraphs key={singleton[0].pageName} data={singleton}></SingletonGraphs> })}
+        </div>
+        <div className='comparisons'>
+            {comparisons?.map((comparison) => { return <ComparisonGraphs key={comparison[0].pageName} data={comparison}></ComparisonGraphs> })}
+        </div>
+    </div>);
+}
+
+function SingletonGraphs({ data }) {
+    const [survey, setSurvey] = React.useState(null);
+    const [vizPanel, setVizPanel] = React.useState(null);
+    const [pageName, setPageName] = React.useState('Unknown Set');
+    const [surveyResults, setSurveyResults] = React.useState([]);
+
+    React.useEffect(() => {
+        if (data.length > 0) {
+
+            setPageName(data[0].pageName + ": Survey Results");
+            // create a survey config based off of answers in the survey data
+            const surveyJson = { elements: [] };
+            const questionsCaptured = [];
+            const curResults = [];
+            for (const entry of data) {
+                const entryResults = {};
+                for (const q of Object.keys(entry.questions)) {
+                    if (entry.questions[q].response) {
+                        if (!questionsCaptured.includes(q)) {
+                            surveyJson.elements.push({
+                                name: q,
+                                title: q,
+                                type: "radiogroup",
+                                choices: surveyChoiceScale
+                            });
+                            questionsCaptured.push(q);
+                        }
+                        entryResults[q] = responseToNumber(entry.questions[q].response);
+                    }
+                }
+                curResults.push(entryResults);
+            }
+            setSurveyResults([...curResults]);
+            const survey = new Model(surveyJson);
+            setSurvey(survey);
+        }
+    }, [data]);
+
+    if (!vizPanel && !!survey) {
+        const vizPanel = new VisualizationPanel(
+            survey.getAllQuestions(),
+            surveyResults,
+            vizPanelOptions
+        );
+        vizPanel.showToolbar = false;
+        setVizPanel(vizPanel);
+    }
+
+    React.useEffect(() => {
+        if (vizPanel) {
+            vizPanel.render("viz_" + pageName);
+            return () => {
+                document.getElementById("viz_" + pageName).innerHTML = "";
+            }
+        }
+    }, [vizPanel]);
+
+
+    return (<div>
+        <h3 className="page-name">{pageName}</h3>
+        <div id={"viz_" + pageName} />
+    </div>);
+}
+
+function ComparisonGraphs({ data }) {
+    const [survey, setSurvey] = React.useState(null);
+    const [vizPanel, setVizPanel] = React.useState(null);
+    const [pageName, setPageName] = React.useState('Unknown Set');
+    const [surveyResults, setSurveyResults] = React.useState([]);
+
+    React.useEffect(() => {
+        if (data.length > 0) {
+
+            setPageName(data[0].pageName + ": Survey Results");
+            // create a survey config based off of answers in the survey data
+            const surveyJson = { elements: [] };
+            const questionsCaptured = [];
+            const curResults = [];
+            for (const entry of data) {
+                console.log(entry);
+                const entryResults = {};
+                for (const q of Object.keys(entry.questions)) {
+                    if (entry.questions[q].response) {
+                        if (!questionsCaptured.includes(q)) {
+                            surveyJson.elements.push({
+                                name: q,
+                                title: q,
+                                type: "radiogroup",
+                                choices: surveyChoiceScale
+                            });
+                            questionsCaptured.push(q);
+                        }
+                        entryResults[q] = responseToNumber(entry.questions[q].response);
+                    }
+                }
+                curResults.push(entryResults);
+            }
+            setSurveyResults([...curResults]);
+            const survey = new Model(surveyJson);
+            setSurvey(survey);
+        }
+    }, [data]);
+
+    if (!vizPanel && !!survey) {
+        const vizPanel = new VisualizationPanel(
+            survey.getAllQuestions(),
+            surveyResults,
+            vizPanelOptions
+        );
+        vizPanel.showToolbar = false;
+        setVizPanel(vizPanel);
+    }
+
+    React.useEffect(() => {
+        if (vizPanel) {
+            vizPanel.render("viz_" + pageName);
+            return () => {
+                document.getElementById("viz_" + pageName).innerHTML = "";
+            }
+        }
+    }, [vizPanel]);
+    return (<>
+        <h3 className="page-name">{pageName}</h3>
+        <div id={"viz_" + pageName} />
+    </>);
+}
+
+export function SurveyResults() {
+    const { loading, error, data } = useQuery(GET_SURVEY_RESULTS);
+    const [scenarioIndices, setScenarioIndices] = React.useState(null);
+    const [selectedScenario, setSelectedScenario] = React.useState(-1);
+    const [resultData, setResultData] = React.useState(null);
+
+    React.useEffect(() => {
+        if (data) {
+            const separatedData = {};
+            for (const result of data.getAllSurveyResults) {
+                if (result.results) {
+                    for (const x of Object.keys(result.results)) {
+                        const res = result.results[x];
+                        if (res.scenarioIndex === selectedScenario) {
+                            // TODO: prep data to send to surveyGroup
+                            const indexBy = res.pageType + '_' + res.pageName;
+                            if (Object.keys(separatedData).includes(indexBy)) {
+                                separatedData[indexBy].push(res);
+                            } else {
+                                separatedData[indexBy] = [res];
+                            }
+                        }
+                    }
+                }
+            }
+            setResultData(separatedData);
+        }
+    }, [selectedScenario]);
+
+    if (!scenarioIndices && data) {
+        // go through data to find all scenario indicies
+        let indices = [];
+        for (const result of data.getAllSurveyResults) {
+            if (result.results) {
+                for (const x of Object.keys(result.results)) {
+                    if (result.results[x].scenarioIndex) {
+                        indices.push(result.results[x].scenarioIndex);
+                    }
+                }
+            }
+        }
+        indices = Array.from(new Set(indices));
+        indices.sort((a, b) => a - b);
+        setScenarioIndices([...indices]);
+        if (indices.length > 0) {
+            setSelectedScenario(1);
+        }
+    }
+
+
+    return (<>
+        {loading && <p>Loading</p>}
+        {error && <p>Error</p>}
+        {data && <>
+            <div className="selection-box">
+                {scenarioIndices?.length > 0 ? <h3>Select a Scenario to See Results:</h3> : <h3>No Survey Results Found</h3>}
+                <section className="button-section">
+                    {scenarioIndices?.map((index) => {
+                        return <button key={"scenario_btn_" + index} disabled={index === selectedScenario} onClick={() => setSelectedScenario(index)} className="selection-btn">Scenario {index}</button>
+                    })}
+                </section>
+            </div>
+            {selectedScenario > 0 && <ScenarioGroup scenario={selectedScenario} data={resultData}></ScenarioGroup>}
+
+        </>}
+    </>);
+}

--- a/dashboard-ui/src/components/SurveyResults/surveyResults.jsx
+++ b/dashboard-ui/src/components/SurveyResults/surveyResults.jsx
@@ -143,7 +143,7 @@ export function SurveyResults() {
                 if (result.results) {
                     for (const x of Object.keys(result.results)) {
                         const res = result.results[x];
-                        if (res.scenarioIndex === selectedScenario) {
+                        if (res?.scenarioIndex === selectedScenario) {
                             // TODO: prep data to send to surveyGroup
                             const indexBy = res.pageType + '_' + res.pageName;
                             if (Object.keys(separatedData).includes(indexBy)) {
@@ -165,7 +165,7 @@ export function SurveyResults() {
         for (const result of data.getAllSurveyResults) {
             if (result.results) {
                 for (const x of Object.keys(result.results)) {
-                    if (result.results[x].scenarioIndex) {
+                    if (result.results[x]?.scenarioIndex) {
                         indices.push(result.results[x].scenarioIndex);
                     }
                 }


### PR DESCRIPTION
To test, clear out your mongo database of survey results, as this uses a new format, and take the survey at least once, then go to the survey results page.

Right now, the visualization is very simplistic. It shows, by scenario, how many people answered each choice for each question. Ewart will hopefully be providing more guidance later this week. I think he may have also wanted to see who answered what choices specifically based on who they delegated to, so that may be a next step. 

**Goal of this PR:** to get a review of the initial survey results format and to encourage new ideas and tasks based on the endless possibilities of analyzing data