### PR TITLE
Filter results on participant id

### DIFF
--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -261,8 +261,12 @@ const resolvers = {
       return await dashboardDB.db.collection('humanRuns').find({ "bytes": { $exists: true } }).toArray().then(result => { return result; });
     },
     getAllSurveyResults: async (obj, args, context, inflow) => {
-      return await dashboardDB.db.collection('surveyResults').find().toArray().then(result => { return result; });
+      // return all survey results except for those containing "test" in participant ID
+      return await dashboardDB.db.collection('surveyResults').find({
+        "results.Participant ID.questions.Participant ID.response": { $not: /test/i }
+      }).toArray().then(result => { return result; });
     }
+    
   },
   Mutation: {
     updateAdminUser: async (obj, args, context, infow) => {


### PR DESCRIPTION
Small change to graphql query on survey vis page to filter out any data that has a participant id that contains the word "test" anywhere in it