### PR TITLE
Don't pull survey results with "test" in participantID

### DIFF
--- a/dashboard-ui/src/components/SurveyResults/resultsTable.jsx
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.jsx
@@ -98,15 +98,21 @@ export function ResultsTable({ data }) {
                 allObjs.push(entryObj);
             }
         }
+        const found_headers = [];
         for (let obj of allObjs) {
             for (const header of allHeaders) {
                 if (!(header in obj)) {
                     obj[header] = '-';
+                } else {
+                    // only include headers that have at least one response
+                    if (!found_headers.includes(header)) {
+                        found_headers.push(header);
+                    }
                 }
             }
         }
         setFormattedData(allObjs);
-        setHeaders(allHeaders);
+        setHeaders(found_headers);
         setVersions(tmpVersion);
     }, [data, filterBySurveyVersion]);
 


### PR DESCRIPTION
This was originally a branch off of ITM-197-Tabulated but it looks like the order in which things got merged was ITM-197-Tabulated into main and then this change into ITM-197-Tabulated. So this change never made it to main. It filters out the surveyResults collection to exclude any entries that have a participantId that contains the word "test"