### PR TITLE
ITM_20 - added nginx config for Jenkins instance

### DIFF
--- a/docker_setup/resources/nginx.conf
+++ b/docker_setup/resources/nginx.conf
@@ -103,6 +103,20 @@ http {
       proxy_set_header  Connection        "Upgrade";
       proxy_set_header  Upgrade           $http_upgrade;
     }
+
+    location /jenkins {
+      set $upstream http://10.216.38.67:8080;
+      proxy_pass $upstream;
+
+      proxy_set_header  Host              $host;   # required for docker client's sake
+      proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
+      proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+      proxy_set_header  X-Forwarded-Proto $scheme;
+      proxy_read_timeout                  900;
+      proxy_set_header  Connection        "Upgrade";
+      proxy_set_header  Upgrade           $http_upgrade;
+    }
+
   }
 
 }


### PR DESCRIPTION
Just a note, also created an AWS Security Group for inter VPC communication (i.e. ITM-Server needs to talk to Jenkins [https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#SecurityGroup:groupId=sg-071954474e8c4b41a])

Change only adds a redirect in nginx.conf.

I manually updated the nginx.conf in prod, only way to test it. It's up and running now but a new release will overwrite until this PR get's in.

Can be accessed at:
https://darpaitm.caci.com/jenkins