### PR TITLE
ITM-15 added nginx config for Eval API

### DIFF
--- a/docker_setup/resources/nginx.conf
+++ b/docker_setup/resources/nginx.conf
@@ -56,7 +56,28 @@ http {
       proxy_set_header 	Upgrade 	  $http_upgrade;
     }
 
+    location ^~ /ui/openapi.json {
+      set $upstream http://itm-server:8080/openapi.json;
+      proxy_pass $upstream;
+    }
+
+    location ^~ /openapi.json {
+      set $upstream http://itm-server:8080/openapi.json;
+      proxy_pass $upstream;
+    }
+
     location /ui/ {
+      set $upstream http://itm-server:8080/$request_uri;
+      proxy_pass $upstream;
+
+      proxy_set_header  Host              $host/ui;   # required for docker client's sake
+      proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
+      proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+      proxy_set_header  X-Forwarded-Proto $scheme;
+      proxy_read_timeout                  900;
+    }
+
+    location /ta2 {
       set $upstream http://itm-server:8080/$request_uri;
       proxy_pass $upstream;
 


### PR DESCRIPTION
tested in prod, config is there now if you want to test it.  but an eval dashboard release before this get's in will overwrite the config.

TA3 Eval API Access Point:
https://darpaitm.caci.com/ui

Tested API to make sure it worked.

Ran(through the swagger endpoint): https://darpaitm.caci.com/ta2/startSession?adm_name=phi&session_type=eval&kdma_training=false

Got response: "b09b67d2-c428-4381-810e-71c70c63ab07"
