### PR TITLE
Itm 285

### DIFF
--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -12,6 +12,7 @@ import gql from "graphql-tag";
 import { Mutation } from '@apollo/react-components';
 import { getUID, shuffle } from './util';
 import Bowser from "bowser";
+import { Prompt } from 'react-router-dom'
 
 const UPLOAD_SURVEY_RESULTS = gql`
   mutation UploadSurveyResults( $surveyId: String, $results: JSON) {
@@ -29,7 +30,7 @@ class SurveyPage extends Component {
             surveyId: null,
             surveyVersion: surveyConfig.version,
             iPad: false,
-            browserInfo: null
+            browserInfo: null,
         };
 
         // clone surveyConfig, don't edit directly
@@ -45,6 +46,7 @@ class SurveyPage extends Component {
         this.survey.onValueChanged.add(this.onValueChanged)
         this.survey.onComplete.add(this.onSurveyComplete);
         this.uploadButtonRef = React.createRef();
+        this.shouldBlockNavigation = true
     }
 
     initializeSurvey = () => {
@@ -152,7 +154,7 @@ class SurveyPage extends Component {
             shuffledGroupedPages.push(...groupPages);
         });
 
-        this.surveyConfigClone.pages = [ ...ungroupedPages, ...shuffledGroupedPages, ...omnibusPages, postScenarioPage];
+        this.surveyConfigClone.pages = [...ungroupedPages, ...shuffledGroupedPages, ...omnibusPages, postScenarioPage];
     }
 
     onAfterRenderPage = (sender, options) => {
@@ -246,6 +248,7 @@ class SurveyPage extends Component {
     onSurveyComplete = (survey) => {
         // final upload
         this.uploadSurveyData(survey);
+        this.shouldBlockNavigation = false;
     }
 
     onValueChanged = (sender, options) => {
@@ -276,6 +279,12 @@ class SurveyPage extends Component {
     render() {
         return (
             <>
+                {this.shouldBlockNavigation && (
+                    <Prompt
+                        when={this.shouldBlockNavigation}
+                        message='Please finish the survey before leaving the page. By hitting "OK" you will be leaving the survey before completing.'
+                    />
+                )}
                 <Survey model={this.survey} />
                 {this.state.uploadData && (
                     <Mutation mutation={UPLOAD_SURVEY_RESULTS}>

--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -282,7 +282,7 @@ class SurveyPage extends Component {
                 {this.shouldBlockNavigation && (
                     <Prompt
                         when={this.shouldBlockNavigation}
-                        message='Please finish the survey before leaving the page. By hitting "OK" you will be leaving the survey before completing.'
+                        message='Please finish the survey before leaving the page. By hitting "OK", you will be leaving the survey before completion and will be required to start the survey over from the beginning.'
                     />
                 )}
                 <Survey model={this.survey} />

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -213,7 +213,7 @@ class TextBasedScenariosPage extends Component {
                     {this.shouldBlockNavigation && (
                         <Prompt
                             when={this.shouldBlockNavigation}
-                            message='Please finish the scenarios before leaving the page. By hitting "OK" you will be leaving before completing.'
+                            message='Please finish the survey before leaving the page. By hitting "OK", you will be leaving the scenarios before completion and will be required to start the scenarios over from the beginning.'
                         />
                     )}
                     </>

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -16,6 +16,7 @@ import gql from "graphql-tag";
 import { Mutation } from '@apollo/react-components';
 import { AdeptVitals } from './adeptTemplate'
 import { STVitals } from './stTemplate'
+import { Prompt } from 'react-router-dom'
 
 const UPLOAD_SCENARIO_RESULTS = gql`
     mutation uploadScenarioResults($results: [JSON]) {
@@ -54,6 +55,7 @@ class TextBasedScenariosPage extends Component {
         this.introSurvey.applyTheme(surveyTheme);
         this.pageStartTimes = {};
         this.uploadButtonRef = React.createRef();
+        this.shouldBlockNavigation = true
     }
 
     introSurveyComplete = (survey) => {
@@ -135,6 +137,7 @@ class TextBasedScenariosPage extends Component {
                 this.uploadButtonRef.current.click();
             }
         });
+        this.shouldBlockNavigation = false
     }
 
     onSurveyComplete = (survey) => {
@@ -205,7 +208,15 @@ class TextBasedScenariosPage extends Component {
                     <Survey model={this.introSurvey} />
                 )}
                 {this.state.currentConfig && (
+                    <>
                     <Survey model={this.survey} />
+                    {this.shouldBlockNavigation && (
+                        <Prompt
+                            when={this.shouldBlockNavigation}
+                            message='Please finish the scenarios before leaving the page. By hitting "OK" you will be leaving before completing.'
+                        />
+                    )}
+                    </>
                 )}
                 {this.state.uploadData && (
                     <Mutation mutation={UPLOAD_SCENARIO_RESULTS}>


### PR DESCRIPTION
Users shouldn't be able to leave using the back arrow on the browser on survey or text-based scenarios without being prompted for confirmation that they want to leave. The text-based scenario doesn't confirm until they are actually in one of the scenarios (no restriction from leaving the landing page for text-based scenarios).