### PR TITLE
ITM-323: Fix for table now showing all version 2.x results

### DIFF
--- a/dashboard-ui/src/components/SurveyResults/resultsTable.jsx
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.jsx
@@ -47,7 +47,10 @@ export function ResultsTable({ data }) {
             }
             entryObj['Participant Id'] = entry['Participant ID']?.questions['Participant ID']?.response;
             if (!entryObj['Participant Id']) {
-                continue;
+                entryObj['Participant Id'] = entry['Participant ID Page']?.questions['Participant ID']?.response;
+                if (!entryObj['Participant Id']) { 
+                    continue;
+                }
             }
             entryObj['Username'] = entry?.user?.username;
             entryObj['Survey Version'] = version;


### PR DESCRIPTION
It appears that at some point the page for "Participant ID" was changed to "Participant ID Page", this change should catch records that appear either way.