### PR TITLE
Itm 312 external ta1 server access

### DIFF
--- a/docker_setup/resources/nginx.conf
+++ b/docker_setup/resources/nginx.conf
@@ -43,6 +43,17 @@ http {
     
     resolver 127.0.0.11 ipv6=off;
 
+    # returning 404 for adept/soartech swagger doc
+    # without a context path for adept/soartech servers their swagger server 
+    #  requests openapi.json at root which is where TA3 openapi.json is
+    location /adept/ui/ {
+      return 404;
+    }
+    location /soartech/docs/ {
+      return 404;
+    }
+
+
     location / {
       set $upstream http://dashboard-ui:3000/$request_uri;
       proxy_pass $upstream;


### PR DESCRIPTION
tested on prod. It's on prod now for testing, but a release before this branch gets merged will overwrite config.


**SoarTech**

https://darpaitm.caci.com/soartech/docs

https://darpaitm.caci.com/soartech/api/v1/scenarios

**Adept**

https://darpaitm.caci.com/adept/ui/

https://darpaitm.caci.com/adept/api/v1/scenario/MetricsEval.MD3