### PR TITLE
ITM-178: Add evaluator and admin roles and admin functionality

### DIFF
--- a/dashboard-ui/src/components/Account/adminPage.jsx
+++ b/dashboard-ui/src/components/Account/adminPage.jsx
@@ -15,9 +15,14 @@ const GET_USERS = gql`
 const UPDATE_ADMIN_USER = gql`
     mutation updateAdminUser($username: String!, $isAdmin: Boolean!){
         updateAdminUser(username: $username, isAdmin: $isAdmin) 
-  }`;
+    }`;
 
-function DualInputBox({options, selectedOptions}) {
+const UPDATE_EVALUATOR_USER = gql`
+    mutation updateEvaluatorUser($username: String!, $isEvaluator: Boolean!){
+        updateEvaluatorUser(username: $username, isEvaluator: $isEvaluator) 
+    }`;
+
+function AdminInputBox({options, selectedOptions}) {
     const [selected, setSelected] = useState(selectedOptions.sort());
     const [updateAdminUserCall] = useMutation(UPDATE_ADMIN_USER);
 
@@ -56,6 +61,45 @@ function DualInputBox({options, selectedOptions}) {
     );
 }
 
+function EvaluatorInputBox({options, selectedOptions}) {
+    const [selected, setSelected] = useState(selectedOptions.sort());
+    const [updateEvaluatorUserCall] = useMutation(UPDATE_EVALUATOR_USER);
+
+    const setEvaluator = (newSelect) => {
+        for(let i=0; i < newSelect.length; i++) {
+            if(!selected.includes(newSelect[i])) {
+                updateEvaluatorUserCall({ variables: { 
+                    username: newSelect[i],
+                    isEvaluator: true
+                }});
+            }
+        }
+        for(let i=0; i < selected.length; i++) {
+            if(!newSelect.includes(selected[i])) {
+                updateEvaluatorUserCall({ variables: { 
+                    username: selected[i],
+                    isEvaluator: false
+                }});
+            }
+        }
+        setSelected(newSelect);
+    }
+
+    options.sort((a, b) => (a.value > b.value) ? 1 : -1);
+
+    return (
+        <DualListBox 
+            options={options} 
+            selected={selected} 
+            onChange={setEvaluator} 
+            showHeaderLabels={true}
+            lang={{
+                availableHeader: "All Users",
+                selectedHeader: "Evaluators"
+            }}/>
+    );
+}
+
 class AdminPage extends React.Component {
 
     constructor(props) {
@@ -77,28 +121,51 @@ class AdminPage extends React.Component {
                     let options = [];
                     let selectedOptions = [];
 
+                    let evaluatorOptions = [];
+                    let evaluatorSelectedOptions = [];
+
                     const users = data[getUsersQueryName]
                     for(let i=0; i < users.length; i++) {
                         options.push({value: users[i].username, label: users[i].username + " (" + users[i].emails[0].address + ")"});
+                        evaluatorOptions.push({value: users[i].username, label: users[i].username + " (" + users[i].emails[0].address + ")"});
 
                         if(users[i].admin) {
                             selectedOptions.push(users[i].username)
                         }
+
+                        if(users[i].evaluator) {
+                            evaluatorSelectedOptions.push(users[i].username)
+                        }
                     }
 
                     return (
-                        <div className="admin-container">
-                            <h3>Administrator</h3>
-                            <div className="admin-description">
-                                Manage administrator settings.
+                        <>
+                            <div className="admin-container">
+                                <h3>Administrator</h3>
+                                <div className="admin-description">
+                                    Manage administrator settings.
+                                </div>
+                                <div className="modify-admins-header">
+                                    <h5>Modify Current Admins</h5>
+                                </div>
+                                <div className="dual-input-container">
+                                    <AdminInputBox options={options} selectedOptions={selectedOptions}/>
+                                </div>
                             </div>
-                            <div className="modify-admins-header">
-                                <h5>Modify Current Admins</h5>
+
+                            <div className="admin-container">
+                                <h3>Evaluators</h3>
+                                <div className="admin-description">
+                                    Manage evaluator settings.
+                                </div>
+                                <div className="modify-admins-header">
+                                    <h5>Modify Current Evaluators</h5>
+                                </div>
+                                <div className="dual-input-container">
+                                    <EvaluatorInputBox options={evaluatorOptions} selectedOptions={evaluatorSelectedOptions}/>
+                                </div>
                             </div>
-                            <div className="dual-input-container">
-                                <DualInputBox options={options} selectedOptions={selectedOptions}/>
-                            </div>
-                        </div>
+                        </>
                     )
                 }
             }

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -37,8 +37,9 @@ const history = createBrowserHistory();
 function Home({ newState }) {
     if (newState.currentUser == null) {
         history.push('/login');
+    } else {
+        return <HomePage currentUser={newState.currentUser}/>;
     }
-    return <HomePage currentUser={newState.currentUser}/>;
 }
 
 function Results() {
@@ -65,33 +66,35 @@ function AdmResults() {
     return <ADMChartPage/>
 }
 
-
 function Login({ newState, userLoginHandler, updateHandler }) {
-    if (newState !== null && newState.currentUser !== null) {
-        return <Home newState={newState} currentUser={newState.currentUser}/>;
+    if (newState !== null) {
+        if(newState.currentUser !== null) {
+            return <Home newState={newState} currentUser={newState.currentUser}/>;
+        } else {
+            return <LoginApp userLoginHandler={userLoginHandler} />;
+        }
     } else {
         return <LoginApp userLoginHandler={userLoginHandler} />;
     }
 }
 
 function MyAccount({ newState, userLoginHandler }) {
-    if (newState.currentUser == null) {
+    if (newState.currentUser === null) {
         history.push("/login");
+    } else {
+        return <MyAccountPage currentUser={newState.currentUser} updateUserHandler={userLoginHandler} />
     }
-
-    return <MyAccountPage currentUser={newState.currentUser} updateUserHandler={userLoginHandler} />
 }
 
 function Admin({ newState, userLoginHandler }) {
-    if (newState.currentUser == null) {
+    if (newState.currentUser === null) {
         history.push("/login");
-    }
-
-    // Do not let users who aren't admins somehow go to the admin page
-    if (newState.currentUser !== null && newState.currentUser.admin === true) {
-        return <AdminPage currentUser={newState.currentUser} updateUserHandler={userLoginHandler} />
     } else {
-        return <Home newState={newState} />;
+        if(newState.currentUser.admin === true) {
+            return <AdminPage currentUser={newState.currentUser} updateUserHandler={userLoginHandler} />
+        } else {
+            return <Home newState={newState} />;
+        }
     }
 }
 

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -38,7 +38,7 @@ function Home({ newState }) {
     if (newState.currentUser == null) {
         history.push('/login');
     }
-    return <HomePage />;
+    return <HomePage currentUser={newState.currentUser}/>;
 }
 
 function Results() {
@@ -67,8 +67,8 @@ function AdmResults() {
 
 
 function Login({ newState, userLoginHandler, updateHandler }) {
-    if (newState.currentUser !== null) {
-        return <Home newState={newState} />;
+    if (newState !== null && newState.currentUser !== null) {
+        return <Home newState={newState} currentUser={newState.currentUser}/>;
     } else {
         return <LoginApp userLoginHandler={userLoginHandler} />;
     }
@@ -159,31 +159,35 @@ export class App extends React.Component {
                                         Complete Text Scenarios
                                     </NavDropdown.Item>
                                 </NavDropdown>
-                                <NavDropdown title="Human Evaluation Segments">
-                                    <NavDropdown.Item as={Link} className="dropdown-item" to="/survey-results">
-                                        Delegation Survey Results
-                                    </NavDropdown.Item>
-                                    <NavDropdown.Item as={Link} className="dropdown-item" to="/text-based-results">
-                                        Text Scenario Results
-                                    </NavDropdown.Item>
-                                    <NavDropdown.Item as={Link} className="dropdown-item" to="/humanSimParticipant">
-                                        Human Sim Participant Data
-                                    </NavDropdown.Item>
-                                    <NavDropdown.Item as={Link} className="dropdown-item" to="/humanProbeData">
-                                        Human Sim Probe Values
-                                    </NavDropdown.Item>
-                                    <NavDropdown.Item as={Link} className="dropdown-item" to="/human-results">
-                                        Play by Play: Humans in Sim
-                                    </NavDropdown.Item>
-                                </NavDropdown>
-                                <NavDropdown title="ADM Evaluation Segments">
-                                    <NavDropdown.Item as={Link} className="dropdown-item" to="/results">
-                                        ADM Data
-                                    </NavDropdown.Item>
-                                    <NavDropdown.Item as={Link} className="dropdown-item" to="/adm-results">
-                                        ADM Alignment Results
-                                    </NavDropdown.Item>
-                                </NavDropdown>
+                                {(this.state.currentUser.admin === true || this.state.currentUser.evaluator === true) && (
+                                    <>
+                                        <NavDropdown title="Human Evaluation Segments">
+                                            <NavDropdown.Item as={Link} className="dropdown-item" to="/survey-results">
+                                                Delegation Survey Results
+                                            </NavDropdown.Item>
+                                            <NavDropdown.Item as={Link} className="dropdown-item" to="/text-based-results">
+                                                Text Scenario Results
+                                            </NavDropdown.Item>
+                                            <NavDropdown.Item as={Link} className="dropdown-item" to="/humanSimParticipant">
+                                                Human Sim Participant Data
+                                            </NavDropdown.Item>
+                                            <NavDropdown.Item as={Link} className="dropdown-item" to="/humanProbeData">
+                                                Human Sim Probe Values
+                                            </NavDropdown.Item>
+                                            <NavDropdown.Item as={Link} className="dropdown-item" to="/human-results">
+                                                Play by Play: Humans in Sim
+                                            </NavDropdown.Item>
+                                        </NavDropdown>
+                                        <NavDropdown title="ADM Evaluation Segments">
+                                            <NavDropdown.Item as={Link} className="dropdown-item" to="/results">
+                                                ADM Data
+                                            </NavDropdown.Item>
+                                            <NavDropdown.Item as={Link} className="dropdown-item" to="/adm-results">
+                                                ADM Alignment Results
+                                            </NavDropdown.Item>
+                                        </NavDropdown>
+                                    </>
+                                )}
                             </ul>
                             <ul className="navbar-nav ml-auto">
                                 <li className="login-user">

--- a/dashboard-ui/src/components/Home/home.jsx
+++ b/dashboard-ui/src/components/Home/home.jsx
@@ -2,18 +2,36 @@ import React from 'react';
 import AggregateResults from '../AggregateResults/aggregateResults';
 
 class HomePage extends React.Component {
+    constructor(props) {
+        super();
+    }
 
     render() {
         return (
-            <div className="home-container">
-                <div className="home-navigation-container">
-                    <div className="evaluation-selector-container">
-                        <div className="evaluation-selector-label"><h3>Program Questions:</h3></div>
+            <>
+                {(this.props.currentUser.admin === true || this.props.currentUser.evaluator === true) && (
+                    <div className="home-container">
+                        <div className="home-navigation-container">
+                            <div className="evaluation-selector-container">
+                                <div className="evaluation-selector-label"><h3>Program Questions:</h3></div>
+                            </div>
+                        </div>
+                        <AggregateResults type="Program" />
                     </div>
-                </div>
-                <AggregateResults type="Program" />
-            </div>
-            
+                )}
+                {(this.props.currentUser.admin !== true && this.props.currentUser.evaluator !== true) && (
+                    <div className="home-container">
+                        <div className="home-navigation-container">
+                            <div className="evaluation-selector-container">
+                                <div className="evaluation-selector-label"><h3>Welcome to the ITM Program!</h3></div>
+                            </div>
+                        </div>
+                        <div className="data-collection-only">
+                            Thank you for your interest in the DARPA In the Moment Program.  Please use the drop down above to select if you will be completing the delegation survey or the text based scenarios.
+                        </div>
+                    </div>
+                )}
+            </>
         );
     }
 }

--- a/dashboard-ui/src/css/app.css
+++ b/dashboard-ui/src/css/app.css
@@ -207,3 +207,8 @@ body {
     left: 50%;
     transform: translateX(-50%);
   }
+
+  .data-collection-only {
+    margin: 50px;
+    padding: 10px;
+  }

--- a/dashboard-ui/src/services/accountsService.js
+++ b/dashboard-ui/src/services/accountsService.js
@@ -29,6 +29,7 @@ const accountsGraphQL = new GraphQLClient({
       }
       username
       admin
+      evaluator
     }
   `,
 });

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -17,6 +17,7 @@ const typeDefs = gql`
 
   extend type User {
     admin: Boolean
+    evaluator: Boolean
   }
 
   type Player {
@@ -187,6 +188,7 @@ const typeDefs = gql`
 
   type Mutation {
     updateAdminUser(username: String, isAdmin: Boolean): JSON
+    updateEvaluatorUser(username: String, isEvaluator: Boolean): JSON
     uploadSurveyResults(surveyId: String, results: JSON): JSON
     uploadScenarioResults(results: [JSON]): JSON
   }
@@ -313,12 +315,21 @@ const resolvers = {
     getAllRawSimData: async (obj, args, context, inflow) => {
       return await dashboardDB.db.collection('humanSimulatorRaw').find().toArray().then(result => { return result; });
     },
+    getUsers: async(obj, args, context, infow) => {
+      return await dashboardDB.db.collection('users').find().project({"services":0, "createdAt":0, "updatedAt": 0}).toArray().then(result => {return result});
+    }
   },
   Mutation: {
     updateAdminUser: async (obj, args, context, inflow) => {
       return await dashboardDB.db.collection('users').update(
         { "username": args["username"] },
         { $set: { "admin": args["isAdmin"] } }
+      );
+    },
+    updateEvaluatorUser: async (obj, args, context, inflow) => {
+      return await dashboardDB.db.collection('users').update(
+        { "username": args["username"] },
+        { $set: { "evaluator": args["isEvaluator"] } }
       );
     },
     uploadSurveyResults: async (obj, args, context, inflow) => {


### PR DESCRIPTION
NOTE:  You will want to run the script in 'itm-ingest' with your username so you can test the Admin functionality.

1. You should under your profile on the right, now have a drop down item for "Admin"
2. Admins can assign users Admin or Evaluator roles.
3. Only Admins or Evaluators are able to see the data, other users only get the Data Collection items and a very bare home page.
4. You might need to create a local test user to verify 3 on this list

Additional note - going to create a ticket to lock down all the direct URLS with some of this functionality as a follow on ticket. 