### PR TITLE
Omnibus review modals, logging should be same as other review modals

### DIFF
--- a/dashboard-ui/src/components/Survey/omnibusComparison.jsx
+++ b/dashboard-ui/src/components/Survey/omnibusComparison.jsx
@@ -123,7 +123,6 @@ export class OmnibusComparison extends SurveyQuestionElementBase {
     }
 
     renderElement() {
-        console.log(this.state)
         return (
             <>
                 {this.state.dmDetails &&

--- a/dashboard-ui/src/components/Survey/omnibusComparison.jsx
+++ b/dashboard-ui/src/components/Survey/omnibusComparison.jsx
@@ -72,39 +72,37 @@ export class OmnibusComparison extends SurveyQuestionElementBase {
         return this.question.decisionMakers;
     }
 
-    componentDidMount() {
-        let decisionMakers = this.decisionMakers;
-        // in case of duplicates somehow
+    getSurveyDetails(decisionMakers) {
         decisionMakers = [...new Set(decisionMakers)];
         let relevantPages = this.config.pages.filter(page => decisionMakers.includes(page.name));
-        let dmDetails = relevantPages.map(page => page.elements[0]);
-        //extra cleansing of any potential duplicates
-        dmDetails = Array.from(new Set(dmDetails.map(detail => JSON.stringify(detail)))).map(str => JSON.parse(str));
+        let details = relevantPages.map(page => page.elements[0]);
+        // Extra cleansing of any potential duplicates
+        details = Array.from(new Set(details.map(detail => JSON.stringify(detail)))).map(str => JSON.parse(str));
+        return details;
+    }
+
+    componentDidMount() {
+        const dmDetails = this.getSurveyDetails(this.decisionMakers);
         this.setState({ dmDetails });
     }
 
     handleShowModal = (content) => {
-        this.dm = content
-        this.getOmnibusDetails(content.decisionMakers)
+        this.dm = content;
+        this.getOmnibusDetails(content.decisionMakers);
+        this.setState({ showModal: true});
         const newLog = { dmName: this.dm.dmName, actionName: "Opened DM Review Modal", timestamp: new Date().toISOString() };
-        this.updateActionLogs(newLog)
-        this.setState({ showModal: true });
+        this.updateActionLogs(newLog);
     };
 
+    // Updated getOmnibusDetails to use the helper function
     getOmnibusDetails(decisionMakers) {
-        // in case of duplicates somehow
-        decisionMakers = [...new Set(decisionMakers)];
-        let relevantPages = this.config.pages.filter(page => decisionMakers.includes(page.name));
-        let omnibusDetails = relevantPages.map(page => page.elements[0]);
-        //extra cleansing of any potential duplicates
-        omnibusDetails = Array.from(new Set(omnibusDetails.map(detail => JSON.stringify(detail)))).map(str => JSON.parse(str));
-
+        const omnibusDetails = this.getSurveyDetails(decisionMakers);
         this.setState({ omnibusDetails });
     }
 
     handleCloseModal = () => {
         const newLog = { dmName: this.dm.dmName, actionName: "Closed DM Review Modal", timestamp: new Date().toISOString() };
-        this.updateActionLogs(newLog)
+        this.updateActionLogs(newLog);
         this.setState({ showModal: false });
     };
 
@@ -112,7 +110,7 @@ export class OmnibusComparison extends SurveyQuestionElementBase {
         this.setState(prevState => ({
             userActions: [...prevState.userActions, newAction]
         }), () => {
-            this.question.value = this.state.userActions
+            this.question.value = this.state.userActions;
         })
     }
 

--- a/dashboard-ui/src/components/Survey/omnibusComparison.jsx
+++ b/dashboard-ui/src/components/Survey/omnibusComparison.jsx
@@ -1,0 +1,170 @@
+import React from "react";
+import { ElementFactory, Question, Serializer } from "survey-core";
+import { SurveyQuestionElementBase } from "survey-react-ui";
+import { Button, Modal } from "react-bootstrap";
+import Dynamic from "./dynamic";
+import { Accordion } from "react-bootstrap";
+import surveyConfig2x from './surveyConfig2x.json';
+import './template.css'
+
+
+const CUSTOM_TYPE = "omnibusComparison";
+
+export class OmnibusComparisonModel extends Question {
+    getType() {
+        return CUSTOM_TYPE;
+    }
+
+    setValueCore(newValue) {
+        super.setValueCore(newValue);
+    }
+
+    get decisionMakers() {
+        return this.getPropertyValue("decisionMakers");
+    }
+
+    set decisionMakers(decisionMakers) {
+        this.setPropertyValue("decisionMakers", decisionMakers);
+    }
+}
+
+Serializer.addClass(
+    CUSTOM_TYPE,
+    [
+        {
+            name: "decisionMakers",
+            default: []
+        },
+    ],
+    function () {
+        return new OmnibusComparisonModel("");
+    },
+    "question"
+);
+
+ElementFactory.Instance.registerElement(CUSTOM_TYPE, (name) => {
+    return new OmnibusComparisonModel(name);
+});
+
+
+export class OmnibusComparison extends SurveyQuestionElementBase {
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            dmDetails: [],
+            showModal: false,
+            userActions: [],
+            omnibusDetails: []
+        }
+
+        this.dm = ' '
+        this.config = surveyConfig2x
+        this.updateActionLogs = this.updateActionLogs.bind(this)
+    }
+
+    get question() {
+        return this.questionBase;
+    }
+
+    get decisionMakers() {
+        return this.question.decisionMakers;
+    }
+
+    componentDidMount() {
+        let decisionMakers = this.decisionMakers;
+        // in case of duplicates somehow
+        decisionMakers = [...new Set(decisionMakers)];
+        let relevantPages = this.config.pages.filter(page => decisionMakers.includes(page.name));
+        let dmDetails = relevantPages.map(page => page.elements[0]);
+        //extra cleansing of any potential duplicates
+        dmDetails = Array.from(new Set(dmDetails.map(detail => JSON.stringify(detail)))).map(str => JSON.parse(str));
+        this.setState({ dmDetails });
+    }
+
+    handleShowModal = (content) => {
+        this.dm = content
+        this.getOmnibusDetails(content.decisionMakers)
+        const newLog = { dmName: this.dm.dmName, actionName: "Opened DM Review Modal", timestamp: new Date().toISOString() };
+        this.updateActionLogs(newLog)
+        this.setState({ showModal: true });
+    };
+
+    getOmnibusDetails(decisionMakers) {
+        // in case of duplicates somehow
+        decisionMakers = [...new Set(decisionMakers)];
+        let relevantPages = this.config.pages.filter(page => decisionMakers.includes(page.name));
+        let omnibusDetails = relevantPages.map(page => page.elements[0]);
+        //extra cleansing of any potential duplicates
+        omnibusDetails = Array.from(new Set(omnibusDetails.map(detail => JSON.stringify(detail)))).map(str => JSON.parse(str));
+
+        this.setState({ omnibusDetails });
+    }
+
+    handleCloseModal = () => {
+        const newLog = { dmName: this.dm.dmName, actionName: "Closed DM Review Modal", timestamp: new Date().toISOString() };
+        this.updateActionLogs(newLog)
+        this.setState({ showModal: false });
+    };
+
+    updateActionLogs = (newAction) => {
+        this.setState(prevState => ({
+            userActions: [...prevState.userActions, newAction]
+        }), () => {
+            this.question.value = this.state.userActions
+        })
+    }
+
+    getScenarioHeader(title) {
+        const scenarios = ['Desert', 'Jungle', 'Submarine', 'Urban'];
+        const foundScenario = scenarios.find(scenario => title.includes(scenario));
+        return foundScenario;
+    }
+
+    renderElement() {
+        console.log(this.state)
+        return (
+            <>
+                {this.state.dmDetails &&
+                    <>
+                        {this.state.dmDetails.map((dm, index) => (
+                            <Button key={dm.name} className="mx-3" variant="outline-light" style={{ backgroundColor: "#b15e2f" }} onClick={() => this.handleShowModal(dm)}>
+                                {dm.dmName}
+                            </Button>
+                        ))}
+                        <Modal show={this.state.showModal} onHide={this.handleCloseModal} size="xl">
+                            <Modal.Header closeButton>
+                                <Modal.Title>{this.dm.name}</Modal.Title>
+                            </Modal.Header>
+                            <Modal.Body>
+
+                                <Accordion alwaysOpen defaultActiveKey={['0', '1', '2', '3']}>
+                                    {this.state.omnibusDetails.map((dm, index) => (
+                                        <Accordion.Item eventKey={index.toString()} key={dm.name}>
+                                            <Accordion.Header>{this.getScenarioHeader(dm.title)} Scenario</Accordion.Header>
+                                            <Accordion.Body>
+                                                <Dynamic
+                                                    actions={dm.actions}
+                                                    decision={dm.decision}
+                                                    explanation={dm.explanation}
+                                                    dmName={dm.name}
+                                                    patients={dm.patients}
+                                                    situation={dm.situation}
+                                                    supplies={dm.supplies}
+                                                    showModal={false}
+                                                    updateActionLogs={this.updateActionLogs}
+                                                />
+                                            </Accordion.Body>
+                                        </Accordion.Item>
+                                    ))}
+                                </Accordion>
+
+                            </Modal.Body>
+                        </Modal>
+                    </>
+                }
+            </>
+        )
+    }
+}

--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -8,6 +8,7 @@ import { StaticTemplate } from "./staticTemplate";
 import { DynamicTemplate } from "./dynamicTemplate";
 import { Omnibus } from "./omnibusTemplate";
 import { Comparison } from "./comparison";
+import { OmnibusComparison } from "./omnibusComparison";
 import gql from "graphql-tag";
 import { Mutation } from '@apollo/react-components';
 import { getUID, shuffle } from './util';
@@ -50,7 +51,6 @@ class SurveyPage extends Component {
     }
 
     initializeSurvey = () => {
-        this.assignOmnibus(this.surveyConfigClone.soarTechDMs, this.surveyConfigClone.adeptDMs)
         const { groupedDMs, comparisonPages, removed } = this.prepareSurveyInitialization();
         this.applyPageRandomization(groupedDMs, comparisonPages, removed);
     }
@@ -78,33 +78,6 @@ class SurveyPage extends Component {
         })
 
         return { groupedDMs, comparisonPages, removed };
-    }
-
-    assignOmnibus = (soarTechDMs, adeptDMs) => {
-        /*
-        * Medics A and C should have High attribute DMs from soartech and adept, respectively. 
-        * Medics B and D are the low attribute DMs
-        */
-
-        let medicA = this.surveyConfigClone.pages.find(page => page.name === "Omnibus: Medic-A")
-        let medicB = this.surveyConfigClone.pages.find(page => page.name === "Omnibus: Medic-B")
-        let medicC = this.surveyConfigClone.pages.find(page => page.name === "Omnibus: Medic-C")
-        let medicD = this.surveyConfigClone.pages.find(page => page.name === "Omnibus: Medic-D")
-
-        soarTechDMs.forEach(pairing => {
-            if (medicA.elements[0].decisionMakers.length < 4 && medicB.elements[0].decisionMakers.length < 4) {
-                medicA.elements[0].decisionMakers.push(pairing[0]);
-                medicB.elements[0].decisionMakers.push(pairing[1]);
-            }
-        })
-
-        adeptDMs.forEach(pairing => {
-            if (medicC.elements[0].decisionMakers.length < 4 && medicD.elements[0].decisionMakers.length < 4) {
-                medicC.elements[0].decisionMakers.push(pairing[0]);
-                medicD.elements[0].decisionMakers.push(pairing[1]);
-            }
-        }
-        )
     }
 
     applyPageRandomization = (groupedDMs, comparisonPages, removedPages) => {
@@ -324,4 +297,8 @@ ReactQuestionFactory.Instance.registerQuestion("omnibus", (props) => {
 
 ReactQuestionFactory.Instance.registerQuestion("comparison", (props) => {
     return React.createElement(Comparison, props)
+})
+
+ReactQuestionFactory.Instance.registerQuestion("omnibusComparison", (props) => {
+    return React.createElement(OmnibusComparison, props)
 })


### PR DESCRIPTION
https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?assignee=60ba425da547eb00686ee0ce&selectedIssue=ITM-417

The review modals should behave the same way as they did for the individual DM's, except here it obviously opens up the whole omnibus the delegator already saw. 

To Test:
- Confirm you can open the modal and interact with the information the same way you would be able to in the regular omnibus
- Check that the logging works (should look like this in Mongo Compass):
<img width="526" alt="Screenshot 2024-05-20 at 9 49 42 AM" src="https://github.com/NextCenturyCorporation/itm-evaluation-dashboard/assets/73036954/2b0fd7d2-7154-4ad3-8355-96a2cc708555">
