### PR TITLE
orderLog available in the excel download

### DIFF
--- a/dashboard-ui/src/components/SurveyResults/resultsTable.jsx
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.jsx
@@ -38,7 +38,6 @@ export function ResultsTable({ data }) {
         const allHeaders = [...STARTING_HEADERS];
         const tmpVersion = ['All'];
         for (let entry of data) {
-            console.log(data)
             entry = entry.results ?? entry;
             const entryObj = {};
             let addToTable = true;
@@ -73,7 +72,6 @@ export function ResultsTable({ data }) {
             } else {
                 entryObj['Order Log'] = entry['orderLog'] || '-';
             }
-            console.log(entry['orderLog'])
 
             for (const page of Object.keys(entry)) {
                 if (!NON_PAGES.includes(page) && typeof (entry[page]) === 'object') {
@@ -128,7 +126,6 @@ export function ResultsTable({ data }) {
                 }
             }
         }
-        console.log(allObjs)
         setFormattedData(allObjs);
         setHeaders(found_headers);
         setVersions(tmpVersion);

--- a/dashboard-ui/src/components/SurveyResults/resultsTable.jsx
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.jsx
@@ -11,7 +11,6 @@ import Checkbox from '@mui/material/Checkbox';
 /* A list of names that are not pages to record in the excel sheet */
 const NON_PAGES = ['user', 'surveyVersion', 'startTime', 'timeComplete', 'Participant ID'];
 
-
 function formatTime(seconds) {
     seconds = Math.round(seconds);
     let minutes = (Math.floor(seconds / 60) % 60);
@@ -21,7 +20,7 @@ function formatTime(seconds) {
     return `${minutes}:${formatted_seconds}`
 }
 
-const STARTING_HEADERS = ['Participant Id', 'Survey Version', 'Start Time', 'End Time', 'Total Time', 'Completed Simulation'];
+const STARTING_HEADERS = ['Participant Id', 'Survey Version', 'Start Time', 'End Time', 'Total Time', 'Completed Simulation', 'Order Log'];
 
 export function ResultsTable({ data }) {
     const [formattedData, setFormattedData] = React.useState([]);
@@ -39,6 +38,7 @@ export function ResultsTable({ data }) {
         const allHeaders = [...STARTING_HEADERS];
         const tmpVersion = ['All'];
         for (let entry of data) {
+            console.log(data)
             entry = entry.results ?? entry;
             const entryObj = {};
             let addToTable = true;
@@ -66,6 +66,15 @@ export function ResultsTable({ data }) {
             } else {
                 entryObj['Completed Simulation'] = (!entry['Participant ID Page']?.questions?.['VR Scenarios Completed']?.response?.includes('none')).toString();
             }
+
+            // Handle Order Log
+            if (Array.isArray(entry['orderLog'])) {
+                entryObj['Order Log'] = JSON.stringify(entry['orderLog']);
+            } else {
+                entryObj['Order Log'] = entry['orderLog'] || '-';
+            }
+            console.log(entry['orderLog'])
+
             for (const page of Object.keys(entry)) {
                 if (!NON_PAGES.includes(page) && typeof (entry[page]) === 'object') {
                     // get all keys from the page and name them nicely within the excel
@@ -119,15 +128,25 @@ export function ResultsTable({ data }) {
                 }
             }
         }
+        console.log(allObjs)
         setFormattedData(allObjs);
         setHeaders(found_headers);
         setVersions(tmpVersion);
     }, [data, filterBySurveyVersion, selectAll]);
 
-
     const exportToExcel = async () => {
+        // Create a new workbook and worksheet
+        const wb = XLSX.utils.book_new();
         const ws = XLSX.utils.json_to_sheet(formattedData);
-        const wb = { Sheets: { 'data': ws }, SheetNames: ['data'] };
+
+        // Adjust column widths
+        const colWidths = headers.map(header => ({wch: Math.max(header.length, 20)}));
+        ws['!cols'] = colWidths;
+
+        // Add the worksheet to the workbook
+        XLSX.utils.book_append_sheet(wb, ws, 'Survey Data');
+
+        // Generate Excel file
         const excelBuffer = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
         const data = new Blob([excelBuffer], { type: fileType });
         FileSaver.saveAs(data, 'survey_data_v' + filterBySurveyVersion.join('_v') + fileExtension);
@@ -156,7 +175,6 @@ export function ResultsTable({ data }) {
                     setVersionOption(filterBySurveyVersion.filter((x) => x !== selected.target.value));
                 }
             }
-
         }
     };
 
@@ -199,11 +217,8 @@ export function ResultsTable({ data }) {
                                 })}
                             </tr>);
                         })}
-
                     </tbody>
                 </table>
             </div></>}
     </>);
 }
-
-


### PR DESCRIPTION
Ewart needs to see the orderLog from the survey 3.0 results. 

To test, click through the survey (don't put 'test' in the participant ID) and then go to the survey results page. Click 'View Tabulated Data' and then make sure only survey version 3.0 is selected. Download the data to Excel and ensure you can see the orderLog field populated with an array of strings (should be 24 elements). This list will let Ewart know what order participants saw ADM/Scenario pairings along with additional info.

Note: The code for the survey results is getting pretty unmaintainable so this will be something to refactor once I get the chance.