### PR TITLE
Ta1 feedback

### DIFF
--- a/dashboard-ui/src/components/ReviewTextBased/ReviewTextBased.jsx
+++ b/dashboard-ui/src/components/ReviewTextBased/ReviewTextBased.jsx
@@ -71,6 +71,11 @@ export function ReviewTextBasedPage() {
             try {
                 const surveyModel = new Model(config);
                 surveyModel.applyTheme(surveyTheme);
+                /*
+                * stops default behavior of highlighting first option when
+                * trying to progress without answering (ST request)
+                */
+                surveyModel.focusOnFirstError = false
                 setSelectedConfig(surveyModel);
             } catch (error) {
                 console.error('Error creating survey model:', error);

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -270,7 +270,7 @@ class TextBasedScenariosPage extends Component {
 
         this.survey = new Model(config);
         this.survey.applyTheme(surveyTheme);
-
+        this.survey.focusOnFirstError = false
         this.survey.onAfterRenderPage.add(this.onAfterRenderPage);
         this.survey.onComplete.add(this.onSurveyComplete);
 

--- a/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
@@ -156,6 +156,7 @@ export class MedicalScenario extends SurveyQuestionElementBase {
     if (this.transitionInfo && !this.transitionEdgeCase()) {
       this.setState({ showTransitionModal: true });
     }
+    this.overideBlockedVitals();
   }
 
   handleCloseTransitionModal = () => {
@@ -174,6 +175,24 @@ export class MedicalScenario extends SurveyQuestionElementBase {
       return true
     }
     return false
+  }
+
+  overideBlockedVitals = () => {
+    const survey = this.question.survey;
+    const currentPage = survey?.currentPage?.name;
+    const probe = survey.getValue('probe Probe 2');
+
+    if (!['Probe 2B-1', 'Probe 2A-1'].includes(currentPage) || !probe?.includes("Assess")) {
+      return;
+    }
+
+    const lowerResponse = probe.toLowerCase();
+    this.question.blockedVitals = this.question.blockedVitals.filter(
+      blockedID => !lowerResponse.includes(blockedID.toLowerCase())
+    );
+
+    // trick to re render by updating state (with nothing)
+    this.setState({});
   }
 
   renderElement() {

--- a/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
@@ -171,7 +171,7 @@ export class MedicalScenario extends SurveyQuestionElementBase {
     }
 
     const probe = survey.getValue('probe Probe 4-B.1-B.1')
-    if (probe && probe == 'Do some treatment on US military member.') {
+    if (probe && probe !== 'Do some treatment on US military member.') {
       return true
     }
     return false

--- a/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
@@ -340,13 +340,19 @@ export class MedicalScenario extends SurveyQuestionElementBase {
           <Modal.Body>
             {this.state.selectedPatient?.unstructured}
             {this.state.selectedImage && (
-              <div style={{ minHeight: '400px', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+              <div style={{
+                height: '70vh',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                overflow: 'hidden'
+              }}>
                 <img
                   src={`data:image/png;base64,${this.state.selectedImage}`}
                   alt="Patient"
                   style={{
-                    maxWidth: '100%',
-                    maxHeight: '70vh',
+                    width: '100%',
+                    height: '100%',
                     objectFit: 'contain'
                   }}
                 />

--- a/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
@@ -213,7 +213,7 @@ export class MedicalScenario extends SurveyQuestionElementBase {
                     onClick={this.handleSituationClick}
                   >
                     <FaInfoCircle size={28} color="#17a2b8" />
-                    <span className="ms-2 small text-muted">More Info</span>
+                    <span className="ms-2 small text-muted">Click For More Info</span>
                   </div>
                 }
                 <Card.Title className="text-center mb-3 h4">Scenario</Card.Title>
@@ -338,7 +338,13 @@ export class MedicalScenario extends SurveyQuestionElementBase {
             <Modal.Title>{this.state.selectedPatient?.name}</Modal.Title>
           </Modal.Header>
           <Modal.Body>
-            {this.state.selectedPatient?.unstructured}
+            {this.state.selectedPatient?.demographics.age && (
+              <p className="mb-2 text-muted">
+                {this.state.selectedPatient.demographics.age} years old, 
+                {this.state.selectedPatient.demographics.sex === 'F' ? 'Female' : 'Male'}
+              </p>
+            )}
+            <p className="mb-3">{this.state.selectedPatient?.unstructured}</p>
             {this.state.selectedImage && (
               <div style={{
                 height: '70vh',
@@ -482,7 +488,7 @@ export class MedicalScenario extends SurveyQuestionElementBase {
     const vitalNames = {
       avpu: "AVPU",
       ambulatory: "Ambulatory",
-      breathing: "BR",
+      breathing: "RR",
       heart_rate: "HR",
       spo2: "SPO2",
       mental_status: "Mental Status",
@@ -509,7 +515,7 @@ export class MedicalScenario extends SurveyQuestionElementBase {
                 bg={vitalsVisible ? this.getVitalBadgeColor(key, value) : 'info'}
                 className="vital-badge"
               >
-                {vitalsVisible ? value.toString() : "Unknown"}
+                {vitalsVisible ? value.toString().toUpperCase()  : "Unknown"}
               </Badge>
             </div>
           </div>
@@ -523,7 +529,7 @@ export class MedicalScenario extends SurveyQuestionElementBase {
       <div key={i} className="mb-2">
         <strong>{this.capitalizeWords(injury.location)} {injury.name}</strong>
         <br />
-        Severity: <Badge bg={this.getInjurySeverityColor(injury.severity)}>{this.capitalizeWords(injury.severity)}</Badge>
+        Severity: <Badge bg={this.getInjurySeverityColor(injury.severity)}>{injury.severity.toUpperCase()}</Badge>
       </div>
     ));
   }
@@ -531,6 +537,10 @@ export class MedicalScenario extends SurveyQuestionElementBase {
   capitalizeWords = (str) => {
     return str.replace(/\b\w/g, (char) => char.toUpperCase());
   };
+
+  firstLetterCapital = (str) => {
+    return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase()
+  }
 
   getVitalBadgeColor(key, value) {
     switch (key) {

--- a/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
@@ -171,10 +171,7 @@ export class MedicalScenario extends SurveyQuestionElementBase {
     }
 
     const probe = survey.getValue('probe Probe 4-B.1-B.1')
-    if (probe && probe !== 'Do some treatment on US military member.') {
-      return true
-    }
-    return false
+    return probe !== 'Do some treatment on US military member.'
   }
 
   overideBlockedVitals = () => {

--- a/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
@@ -153,7 +153,7 @@ export class MedicalScenario extends SurveyQuestionElementBase {
   };
 
   componentDidMount() {
-    if (this.transitionInfo && !this.transitionEdgeCase()) {
+    if (this.transitionInfo && this.transitionEdgeCase()) {
       this.setState({ showTransitionModal: true });
     }
     this.overideBlockedVitals();
@@ -169,8 +169,13 @@ export class MedicalScenario extends SurveyQuestionElementBase {
       // should never happen
       return
     }
+    
+    if (survey.title != "DryRunEval-MJ2-eval") { 
+      return true 
+    }
+
     const probe = survey.getValue('probe Probe 4-B.1-B.1')
-    return probe && probe !== 'Do some treatment on US military member.'
+    return probe && probe == 'Do some treatment on US military member.'
   }
 
   overideBlockedVitals = () => {

--- a/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
@@ -169,9 +169,8 @@ export class MedicalScenario extends SurveyQuestionElementBase {
       // should never happen
       return
     }
-
     const probe = survey.getValue('probe Probe 4-B.1-B.1')
-    return probe !== 'Do some treatment on US military member.'
+    return probe && probe !== 'Do some treatment on US military member.'
   }
 
   overideBlockedVitals = () => {

--- a/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
@@ -153,7 +153,7 @@ export class MedicalScenario extends SurveyQuestionElementBase {
   };
 
   componentDidMount() {
-    if (this.transitionInfo) {
+    if (this.transitionInfo && !this.transitionEdgeCase()) {
       this.setState({ showTransitionModal: true });
     }
   }
@@ -161,6 +161,20 @@ export class MedicalScenario extends SurveyQuestionElementBase {
   handleCloseTransitionModal = () => {
     this.setState({ showTransitionModal: false });
   };
+
+  transitionEdgeCase = () => {
+    const survey = this.question.survey
+    if (!survey) {
+      // should never happen
+      return
+    }
+
+    const probe = survey.getValue('probe Probe 4-B.1-B.1')
+    if (probe && probe == 'Do some treatment on US military member.') {
+      return true
+    }
+    return false
+  }
 
   renderElement() {
     return (


### PR DESCRIPTION
See [ingest pr](https://github.com/NextCenturyCorporation/itm-ingest/compare/TA1-Content-Changes?expand=1) first. 
 
 [Confluence doc ](https://nextcentury.atlassian.net/wiki/spaces/ITMC/pages/3206873089/Dry+Run+and+Phase+1+Evaluation)

Changes to support adept edge cases. 

Specifically Probe 2B-1 and Probe 2B-A, if you selected to assess one of the patients in the previous probe, their vitals should be visible even though assessing them is available in the action mapping.  

The transition in jungle scene (MJ4) where Bennett tells you to go help the other patients should now only appear if you never selected to go back to the other patients (keep selecting to treat Bennett)

Use http://localhost:3000/review-text-based to test (I will be addressing any bugs with data collection in a separate pr)

Edit: In the Adept scenarios vitals should be hidden now when there is a later assess option. For example, when you are in the helicopter in MJ5 and asked who you would intend to evac, you can't see vitals until you later assess these patients. I confirmed with Jordan from ST that on the intent probes, they would still like the vitals to be visible (this is the reason for slightly different behavior in these instances between Adept and ST).

[ST change requests](https://nextcentury.atlassian.net/wiki/spaces/ITMC/pages/3367501866/Text+Scenario+Review+Comments+Round+2)