### PR TITLE
ITM-574: fixes headers in adm-results for DryRun

### DIFF
--- a/dashboard-ui/src/components/AdmCharts/admCharts.jsx
+++ b/dashboard-ui/src/components/AdmCharts/admCharts.jsx
@@ -37,12 +37,19 @@ class AdmCharts extends React.Component {
             } else {
                 return ("Soartech: " + id + " " + name);
             }
-        } else {
+        } else if (this.state.currentEval == 3) {
             if(id.toLowerCase().indexOf("metricseval") > -1 ) {
                 return ("ADEPT: " + id + " " + name);
             } else {
                 return ("Soartech: " + name);
             }
+        } else {
+            if(id.toLowerCase().includes("qol") || id.toLowerCase().includes("vol") ) {
+                return ("Soartech: " + name + " (" + id + ")");
+            } else {
+                return ("Adept: " + name + " (" + id + ")");
+            }
+        
         }
     }
 

--- a/dashboard-ui/src/components/Results/resultsTable.jsx
+++ b/dashboard-ui/src/components/Results/resultsTable.jsx
@@ -128,11 +128,17 @@ class ResultsTable extends React.Component {
             } else {
                 return ("Soartech: " + id);
             }
-        } else {
+        } else if (this.state.currentEval == 3) {
             if (id.toLowerCase().indexOf("metricseval") > -1) {
                 return ("ADEPT: " + id);
             } else {
                 return ("Soartech: " + id);
+            }
+        } else {
+            if(id.toLowerCase().includes("qol") || id.toLowerCase().includes("vol") ) {
+                return ("Soartech: " + id);
+            } else {
+                return ("Adept: " + id);
             }
         }
     }


### PR DESCRIPTION
Small fix to correct ADM Results header.  Right now on prod they all say SoarTech.

To test, download the latest mongo backup from s3:
`aws s3 cp s3://itm-backups/mongodb/dashboard-mongodb-daily_20240829_004601.tar.gz .`

You can down/up your mongo to start a fresh mongo:
docker-compose -f ./docker_setup/docker-compose-dev.yml down
docker-compose -f ./docker_setup/docker-compose-dev.yml up

untar the backup file (dashboard-mongodb.dump)

With the mongo docker started, to restore:
`docker exec -i dashboard-mongo sh -c 'mongorestore --authenticationDatabase admin -u dashroot -p dashr00tp@ssw0rd --db dashboard --archive --port 27030' < dashboard-mongodb.dump`

Headers on adm-results should be correct now:
![image](https://github.com/user-attachments/assets/dccde5f1-6f7b-4af5-8d16-98f659e269c4)


**EDIT**

Missed scenario listitems on (http://localhost:3000/results)


![image](https://github.com/user-attachments/assets/513d3f4d-1996-4056-bb90-a3d5c8d28e3f)



