### PR TITLE
Ta1 delegation updates

### DIFF
--- a/dashboard-ui/src/components/Survey/dynamic.jsx
+++ b/dashboard-ui/src/components/Survey/dynamic.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Accordion, Card, Row, Col, Button, ListGroup, Modal } from "react-bootstrap";
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import ZoomInIcon from '@material-ui/icons/ZoomIn';
+import { FaInfoCircle } from 'react-icons/fa';
 import SituationModal from "./situationModal";
 import VitalsDropdown from "./vitalsDropdown";
 import './template.css';
@@ -9,6 +10,7 @@ import { renderSituation } from './util';
 import { isDefined } from '../AggregateResults/DataFunctions';
 import Patient from '../TextBasedScenarios/patient';
 import Supplies from '../TextBasedScenarios/supplies';
+import MoreDetailsModal from '../TextBasedScenarios/moreDetailsModal';
 
 const Dynamic = ({ patients, situation, supplies, decision, dmName, actions, scenes, explanation, showModal, updateActionLogs }) => {
     const [visiblePatients, setVisiblePatients] = useState({});
@@ -18,6 +20,7 @@ const Dynamic = ({ patients, situation, supplies, decision, dmName, actions, sce
     const [activeTitle, setActiveTitle] = useState('');
     const [activeDescription, setActiveDescription] = useState('');
     const [showSituationModal, setShowSituationModal] = useState(showModal);
+    const [showMoreDetailsModal, setShowMoreDetailsModal] = useState(false);
     const [actionLogs, setActionLogs] = useState([]);
 
     // log actions
@@ -67,6 +70,16 @@ const Dynamic = ({ patients, situation, supplies, decision, dmName, actions, sce
         logAction('Show situation modal');
     };
 
+    const handleShowMoreDetailsModal = () => {
+        setShowMoreDetailsModal(true);
+        logAction('Show more details modal');
+    };
+
+    const handleCloseMoreDetailsModal = () => {
+        setShowMoreDetailsModal(false);
+        logAction('Close more details modal');
+    };
+
     function Scene({ sceneId, sceneSupplies, sceneActions, sceneCharacters }) {
         const patientButtons = patients.map(patient => (
             <div className="patient-buttons" key={patient.name}>{
@@ -92,27 +105,27 @@ const Dynamic = ({ patients, situation, supplies, decision, dmName, actions, sce
                                 onImageClick={() => toggleImageModal(patient.imgUrl, patient.name, patient.description)}
                                 blockedVitals={[]}
                             />
-                        </div> : 
-                    <Card key={patient.name} className="patient-card" style={{ display: 'inline-block' }}>
-                        <Card.Header>
-                            <div>{patient.name} <Card.Text>{patient.age && <><span>{patient.age} years old, {patient.sex == 'F' ? 'Female' : 'Male'}</span><br /></>}<span>{patient.description}</span></Card.Text></div>
-                        </Card.Header>
-                        <Row className="g-0">
-                            <Col md={8} className="mr-4">
-                                <div style={{ position: 'relative' }}>
-                                    <img src={`data:image/jpeg;base64,${patient.imgUrl}`} alt={patient.name} className="patient-image" />
-                                    <ZoomInIcon className="magnifying-glass" onClick={() => toggleImageModal(patient.imgUrl, patient.name, patient.description)} />
-                                </div>
-                            </Col>
-                            <Col md={4}>
-                                <VitalsDropdown
-                                    vitals={patient.vitals}
-                                    patientName={patient.name}
-                                    isVisible={visibleVitals[patient.name]}
-                                    toggleVisibility={() => toggleVitalsVisibility(patient.name)}
-                                />
-                            </Col>
-                        </Row>
+                        </div> :
+                            <Card key={patient.name} className="patient-card" style={{ display: 'inline-block' }}>
+                                <Card.Header>
+                                    <div>{patient.name} <Card.Text>{patient.age && <><span>{patient.age} years old, {patient.sex == 'F' ? 'Female' : 'Male'}</span><br /></>}<span>{patient.description}</span></Card.Text></div>
+                                </Card.Header>
+                                <Row className="g-0">
+                                    <Col md={8} className="mr-4">
+                                        <div style={{ position: 'relative' }}>
+                                            <img src={`data:image/jpeg;base64,${patient.imgUrl}`} alt={patient.name} className="patient-image" />
+                                            <ZoomInIcon className="magnifying-glass" onClick={() => toggleImageModal(patient.imgUrl, patient.name, patient.description)} />
+                                        </div>
+                                    </Col>
+                                    <Col md={4}>
+                                        <VitalsDropdown
+                                            vitals={patient.vitals}
+                                            patientName={patient.name}
+                                            isVisible={visibleVitals[patient.name]}
+                                            toggleVisibility={() => toggleVitalsVisibility(patient.name)}
+                                        />
+                                    </Col>
+                                </Row>
                             </Card>
                     }</>
                 );
@@ -159,6 +172,11 @@ const Dynamic = ({ patients, situation, supplies, decision, dmName, actions, sce
         );
     }
 
+    let mission = {}
+    mission.roe = 'test roe'
+    mission.medical_policies = ['policy1, policy2']
+    mission.unstructured = ['mission details']
+
     return (
         <div>
             {showSituationModal &&
@@ -168,8 +186,27 @@ const Dynamic = ({ patients, situation, supplies, decision, dmName, actions, sce
                     situation={situation} />
             }
             <Card className="mb-3">
-                <Card.Header>Situation <ZoomInIcon className="magnifying-glass-icon" onClick={handleShowSituationModal} /></Card.Header>
-                <Card.Body className='overflow-auto' style={{ maxHeight: '200px' }}>
+                <Card.Header className="d-flex justify-content-between align-items-center">
+                    <div className="d-flex align-items-center">
+                        Situation
+                        <ZoomInIcon
+                            className="magnifying-glass-icon ms-2"
+                            onClick={handleShowSituationModal}
+                            style={{ cursor: 'pointer' }}
+                        />
+                    </div>
+                    {mission?.roe && mission.roe !== "" && (
+                        <div
+                            className="d-flex align-items-center scenario-info-icon"
+                            style={{ cursor: 'pointer' }}
+                            onClick={handleShowMoreDetailsModal}
+                        >
+                            <FaInfoCircle size={28} color="#17a2b8" />
+                            <span className="ms-2 small text-muted">Click For More Info</span>
+                        </div>
+                    )}
+                </Card.Header>
+                <Card.Body className="overflow-auto" style={{ maxHeight: '200px' }}>
                     {renderSituation(situation)}
                 </Card.Body>
             </Card>
@@ -188,6 +225,12 @@ const Dynamic = ({ patients, situation, supplies, decision, dmName, actions, sce
                     <img src={`data:image/jpeg;base64,${activeImage}`} alt="Enlarged view" style={{ width: '100%' }} />
                 </Modal.Body>
             </Modal>
+
+            <MoreDetailsModal
+                show={showMoreDetailsModal}
+                onHide={handleCloseMoreDetailsModal}
+                mission={mission}
+            />
         </div>
     );
 };

--- a/dashboard-ui/src/components/Survey/dynamic.jsx
+++ b/dashboard-ui/src/components/Survey/dynamic.jsx
@@ -12,7 +12,7 @@ import Patient from '../TextBasedScenarios/patient';
 import Supplies from '../TextBasedScenarios/supplies';
 import MoreDetailsModal from '../TextBasedScenarios/moreDetailsModal';
 
-const Dynamic = ({ patients, situation, supplies, decision, dmName, actions, scenes, explanation, showModal, updateActionLogs }) => {
+const Dynamic = ({ patients, situation, supplies, decision, dmName, actions, scenes, explanation, showModal, updateActionLogs, mission }) => {
     const [visiblePatients, setVisiblePatients] = useState({});
     const [visibleVitals, setVisibleVitals] = useState({});
     const [showPatientModal, setShowPatientModal] = useState(false);
@@ -171,11 +171,6 @@ const Dynamic = ({ patients, situation, supplies, decision, dmName, actions, sce
             </Accordion>
         );
     }
-
-    let mission = {}
-    mission.roe = 'test roe'
-    mission.medical_policies = ['policy1, policy2']
-    mission.unstructured = ['mission details']
 
     return (
         <div>

--- a/dashboard-ui/src/components/Survey/dynamicTemplate.jsx
+++ b/dashboard-ui/src/components/Survey/dynamicTemplate.jsx
@@ -77,6 +77,14 @@ export class DynamicTemplateModel extends Question {
     set explanation(explanation) {
         this.setPropertyValue("explanation", explanation)
     }
+
+    get mission() {
+        return this.getPropertyValue("mission")
+    }
+
+    set mission(mission) {
+        this.setPropertyValue("mission", mission)
+    }
 }
 
 // Add question type metadata for further serialization into JSON
@@ -114,6 +122,10 @@ Serializer.addClass(
         {
             name: "explanation",
             defualt: ""
+        },
+        {
+            name: "mission",
+            default: null
         }
     ],
     function () {
@@ -164,6 +176,10 @@ export class DynamicTemplate extends SurveyQuestionElementBase {
         return isDefined(this.question.scenes) ? this.question.scenes : null;
     }
 
+    get mission () {
+        return this.question.mission
+    }
+
     updateActionLogs = (newAction) => {
         this.setState( prevState => ({
             userActions: [...prevState.userActions, newAction]
@@ -184,6 +200,7 @@ export class DynamicTemplate extends SurveyQuestionElementBase {
                 actions={this.actions}
                 scenes={this.scenes}
                 explanation={this.explanation}
+                mission={this.mission}
                 showModal={false}
                 updateActionLogs={this.updateActionLogs}
             />

--- a/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/medicalScenario.jsx
@@ -1,12 +1,11 @@
 import React from "react";
-import { Container, Row, Col, Card, ListGroup, Badge, Modal } from 'react-bootstrap';
+import { Container, Row, Col, Card, Modal } from 'react-bootstrap';
 import { ElementFactory, Question, Serializer } from "survey-core";
 import { SurveyQuestionElementBase } from "survey-react-ui";
-import { FaHeartbeat, FaLungs, FaBrain, FaPercent, FaEye, FaAmbulance, FaMapMarkedAlt, FaBell, FaInfoCircle, FaBook, FaMedkit, FaClipboardList } from 'react-icons/fa';
-import { BsPersonFillGear } from 'react-icons/bs'
-import ZoomInIcon from '@material-ui/icons/ZoomIn';
+import { FaBell, FaInfoCircle, } from 'react-icons/fa';
 import Supplies from './supplies';
 import Patient from './patient';
+import MoreDetailsModal from "./moreDetailsModal";
 import '../../css/medical-scenario.css';
 
 const CUSTOM_TYPE = "medicalScenario";
@@ -292,74 +291,11 @@ export class MedicalScenario extends SurveyQuestionElementBase {
           </Modal.Body>
         </Modal>
 
-        <Modal
+        <MoreDetailsModal
           show={this.state.showSituationModal}
           onHide={this.handleCloseSituationModal}
-          size="lg"
-          centered
-          className="scenario-info-modal"
-        >
-          <Modal.Header closeButton className="border-0 bg-primary text-white">
-            <Modal.Title>
-              <FaInfoCircle className="me-2" />
-              Additional Mission Information
-            </Modal.Title>
-          </Modal.Header>
-          <Modal.Body className="p-4">
-            {this.mission ? (
-              <Row>
-                {this.mission.roe && (
-                  <Col md={12} className="mb-4">
-                    <Card className="border-0 shadow-sm h-100 info-card">
-                      <Card.Body>
-                        <h5 className="card-title">
-                          <FaBook className="me-2 text-primary" />
-                          Rules of Engagement
-                        </h5>
-                        <p className="card-text">{this.mission.roe}</p>
-                      </Card.Body>
-                    </Card>
-                  </Col>
-                )}
-                {this.mission.medical_policies && this.mission.medical_policies.length > 0 && (
-                  <Col md={6} className="mb-4">
-                    <Card className="border-0 shadow-sm h-100 info-card">
-                      <Card.Body>
-                        <h5 className="card-title">
-                          <FaMedkit className="me-2 text-danger" />
-                          Medical Policies
-                        </h5>
-                        <ListGroup variant="flush">
-                          {this.mission.medical_policies.map((policy, index) => (
-                            <ListGroup.Item key={index} className="border-0 ps-0">
-                              <FaClipboardList className="me-2 text-muted" />
-                              {policy}
-                            </ListGroup.Item>
-                          ))}
-                        </ListGroup>
-                      </Card.Body>
-                    </Card>
-                  </Col>
-                )}
-                {this.mission.unstructured && (
-                  <Col md={this.mission.medical_policies && this.mission.medical_policies.length > 0 ? 6 : 12} className="mb-4">
-                    <Card className="border-0 shadow-sm h-100 info-card">
-                      <Card.Body>
-                        <h5 className="card-title">
-                          <FaMapMarkedAlt className="me-2 text-success" />
-                          Mission Details
-                        </h5>
-                        <p className="card-text">{this.mission.unstructured}</p>
-                      </Card.Body>
-                    </Card>
-                  </Col>
-                )}
-              </Row>
-            ) : (
-              <p className="text-center text-muted">No additional mission information available.</p>
-            )}
-          </Modal.Body>
-        </Modal>
+          mission={this.mission}
+        />
         <Modal
           show={this.state.showTransitionModal}
           onHide={this.handleCloseTransitionModal}

--- a/dashboard-ui/src/components/TextBasedScenarios/moreDetailsModal.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/moreDetailsModal.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Modal, Row, Col, Card, ListGroup } from 'react-bootstrap';
+import { FaInfoCircle, FaBook, FaMedkit, FaClipboardList, FaMapMarkedAlt } from 'react-icons/fa';
+
+const MoreDetailsModal = ({ show, onHide, mission }) => {
+  return (
+    <Modal
+      show={show}
+      onHide={onHide}
+      size="lg"
+      centered
+      className="scenario-info-modal"
+    >
+      <Modal.Header closeButton className="border-0 bg-primary text-white">
+        <Modal.Title>
+          <FaInfoCircle className="me-2" />
+          Additional Mission Information
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body className="p-4">
+        {mission ? (
+          <Row>
+            {mission.roe && (
+              <Col md={12} className="mb-4">
+                <Card className="border-0 shadow-sm h-100 info-card">
+                  <Card.Body>
+                    <h5 className="card-title">
+                      <FaBook className="me-2 text-primary" />
+                      Rules of Engagement
+                    </h5>
+                    <p className="card-text">{mission.roe}</p>
+                  </Card.Body>
+                </Card>
+              </Col>
+            )}
+            {mission.medical_policies && mission.medical_policies.length > 0 && (
+              <Col md={6} className="mb-4">
+                <Card className="border-0 shadow-sm h-100 info-card">
+                  <Card.Body>
+                    <h5 className="card-title">
+                      <FaMedkit className="me-2 text-danger" />
+                      Medical Policies
+                    </h5>
+                    <ListGroup variant="flush">
+                      {mission.medical_policies.map((policy, index) => (
+                        <ListGroup.Item key={index} className="border-0 ps-0">
+                          <FaClipboardList className="me-2 text-muted" />
+                          {policy}
+                        </ListGroup.Item>
+                      ))}
+                    </ListGroup>
+                  </Card.Body>
+                </Card>
+              </Col>
+            )}
+            {mission.unstructured && (
+              <Col md={mission.medical_policies && mission.medical_policies.length > 0 ? 6 : 12} className="mb-4">
+                <Card className="border-0 shadow-sm h-100 info-card">
+                  <Card.Body>
+                    <h5 className="card-title">
+                      <FaMapMarkedAlt className="me-2 text-success" />
+                      Mission Details
+                    </h5>
+                    <p className="card-text">{mission.unstructured}</p>
+                  </Card.Body>
+                </Card>
+              </Col>
+            )}
+          </Row>
+        ) : (
+          <p className="text-center text-muted">No additional mission information available.</p>
+        )}
+      </Modal.Body>
+    </Modal>
+  );
+};
+
+export default MoreDetailsModal;

--- a/dashboard-ui/src/css/medical-scenario.css
+++ b/dashboard-ui/src/css/medical-scenario.css
@@ -114,14 +114,14 @@
   transform: scale(1.1);
 }
 
-@keyframes pulse {
+@keyframes subtlePulse {
   0% { transform: scale(1); }
-  50% { transform: scale(1.1); }
+  50% { transform: scale(1.05); }
   100% { transform: scale(1); }
 }
 
 .scenario-info-icon {
-  animation: pulse 2s infinite ease-in-out;
+  animation: subtlePulse 3s infinite ease-in-out;
 }
 
 .scenario-info-modal .modal-content {


### PR DESCRIPTION
Run Kaitlyn's[ ingest pr ](https://github.com/NextCenturyCorporation/itm-ingest/pull/35) first. 

Go to http://localhost:3000/review-delegation and check that the soartech scenarios have the following 'click for more info tab'. Only on ST scenarios, adept doesn't have this information in their state objects
<img width="1273" alt="Screenshot 2024-09-09 at 5 00 40 PM" src="https://github.com/user-attachments/assets/99ca05c3-5e2f-4bf3-8dea-e47b8df559ff">
<img width="908" alt="Screenshot 2024-09-09 at 5 05 52 PM" src="https://github.com/user-attachments/assets/4829b8ae-0d78-4b57-a8a2-47b3fedc0913">
