### PR TITLE
ITM -555 optimized a couple of queries

### DIFF
--- a/dashboard-ui/.env
+++ b/dashboard-ui/.env
@@ -4,9 +4,9 @@ REACT_APP_SURVEY_VERSION=4.0
 #REACT_APP_ADEPT_URL=http://127.0.0.1:8080
 
 # PROD with prod servers
-REACT_APP_ADEPT_URL=http://10.216.38.101:8080
-REACT_APP_SOARTECH_URL=http://10.216.38.125:8084
+# REACT_APP_ADEPT_URL=http://10.216.38.101:8080
+# REACT_APP_SOARTECH_URL=http://10.216.38.125:8084
 
 # Using prod servers locally 
-#REACT_APP_ADEPT_URL=https://darpaitm.caci.com/adept
-#REACT_APP_SOARTECH_URL=https://darpaitm.caci.com/soartech
+REACT_APP_ADEPT_URL=https://darpaitm.caci.com/adept
+REACT_APP_SOARTECH_URL=https://darpaitm.caci.com/soartech

--- a/dashboard-ui/.env
+++ b/dashboard-ui/.env
@@ -4,9 +4,9 @@ REACT_APP_SURVEY_VERSION=4.0
 #REACT_APP_ADEPT_URL=http://127.0.0.1:8080
 
 # PROD with prod servers
-# REACT_APP_ADEPT_URL=http://10.216.38.101:8080
-# REACT_APP_SOARTECH_URL=http://10.216.38.125:8084
+REACT_APP_ADEPT_URL=http://10.216.38.101:8080
+REACT_APP_SOARTECH_URL=http://10.216.38.125:8084
 
 # Using prod servers locally 
-REACT_APP_ADEPT_URL=https://darpaitm.caci.com/adept
-REACT_APP_SOARTECH_URL=https://darpaitm.caci.com/soartech
+#REACT_APP_ADEPT_URL=https://darpaitm.caci.com/adept
+#REACT_APP_SOARTECH_URL=https://darpaitm.caci.com/soartech

--- a/dashboard-ui/src/components/AggregateResults/programQuestions.jsx
+++ b/dashboard-ui/src/components/AggregateResults/programQuestions.jsx
@@ -147,9 +147,15 @@ export default function ProgramQuestions({ allData, kdmaScatter, chartData }) {
             for (const x of data.getAllHistoryByEvalNumber) {
                 if (x.history.length > 0) {
                     const admName = x.history[0].parameters.adm_name;
-                    let scenario = x.history[0].response.id;
+                    //let scenario = x.history[0].response.id
+                    let scenario;
+                    if (!x.history[0].hasOwnProperty('response'))
+                        scenario = false;
+
+                    else
+                        scenario = x.history[0].response.id;
                     if (!scenario) {
-                        scenario = x.history[1].response.id;
+                            scenario = x.history[1].response.id;
                     }
                     const target = x.history[x.history.length - 1].parameters.target_id;
                     const kdma = x.history[x.history.length - 1].response.kdma_values[0].value;

--- a/dashboard-ui/src/components/AggregateResults/programQuestions.jsx
+++ b/dashboard-ui/src/components/AggregateResults/programQuestions.jsx
@@ -147,15 +147,13 @@ export default function ProgramQuestions({ allData, kdmaScatter, chartData }) {
             for (const x of data.getAllHistoryByEvalNumber) {
                 if (x.history.length > 0) {
                     const admName = x.history[0].parameters.adm_name;
-                    //let scenario = x.history[0].response.id
                     let scenario;
                     if (!x.history[0].hasOwnProperty('response'))
                         scenario = false;
-
                     else
                         scenario = x.history[0].response.id;
                     if (!scenario) {
-                            scenario = x.history[1].response.id;
+                        scenario = x.history[1].response.id;
                     }
                     const target = x.history[x.history.length - 1].parameters.target_id;
                     const kdma = x.history[x.history.length - 1].response.kdma_values[0].value;

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -220,7 +220,14 @@ const resolvers = {
       return await dashboardDB.db.collection('test').find().toArray().then(result => { return result; });
     },
     getAllHistoryByEvalNumber: async (obj, args, context, inflow) => {
-      return await dashboardDB.db.collection('test').find({ "evalNumber": args["evalNumber"] }).toArray().then(result => { return result; });
+      return await dashboardDB.db.collection('test').find({ "evalNumber": args["evalNumber"] }, {projection:{
+        "history.parameters.adm_name": 1, 
+        "history.response.id": 1, 
+        "history.parameters.target_id": 1,
+        "history.response.kdma_values.value": 1,
+        "history.parameters.target_id": 1,
+        "history.response.score": 1
+      }}).toArray().then(result => { return result; });
     },
     getEvalIds: async (obj, args, context, inflow) => {
       return await dashboardDB.db.collection('evaluationIDS').find().toArray().then(result => { return result; });
@@ -230,7 +237,7 @@ const resolvers = {
           [{"$group": {"_id": {evalNumber: "$evalNumber", evalName: "$evalName"}}}]).sort({'evalNumber': -1}).toArray().then(result => {return result});
     },    
     getAllHistoryByID: async (obj, args, context, inflow) => {
-      return await dashboardDB.db.collection('test').find({ "history.response.id": args.historyId }).toArray().then(result => { return result; });
+      return await dashboardDB.db.collection('test').find({ "history.response.id": args.historyId },{ projection:{"history.parameters.adm_name":1, "history.response.score":1}}).toArray().then(result => { return result; });
     },
     getScenario: async (obj, args, context, inflow) => {
       return await dashboardDB.db.collection('scenarios').findOne({ "id": args["scenarioId"] }).then(result => { return result; });


### PR DESCRIPTION
Added projections to a couple of queries to reduce their size. The queries should be much smaller now:
/adm-results 123mb -> 1.88mb
**before:**
![image](https://github.com/user-attachments/assets/9ea21284-29fc-4b3f-8b3e-042d783a2f5c)


**after:**
![image](https://github.com/user-attachments/assets/e8ce3911-cf8d-4917-ba7f-25fe244adc9c)

/programQuestions  153mb (before eval filter and projection) -> 251kbs
**before:**
![image](https://github.com/user-attachments/assets/58a95453-27ef-4c96-b4d5-1996afe1e188)

**after:**
![image](https://github.com/user-attachments/assets/3785cd65-64ae-4053-a274-afaaa0e61ba9)

