### PR TITLE
Text based refinement

### DIFF
--- a/dashboard-ui/src/components/Survey/dynamic.jsx
+++ b/dashboard-ui/src/components/Survey/dynamic.jsx
@@ -98,7 +98,7 @@ const Dynamic = ({ patients, situation, supplies, decision, dmName, actions, sce
         const patientCards = patients.map(patient => {
             if (visiblePatients[patient.name] && sceneCharacters.includes(patient.name)) {
                 return (
-                    <>{
+                    <Col md={6}>{
                         patient.demographics ? <div className='patient-card'>
                             <Patient
                                 patient={patient}
@@ -127,7 +127,7 @@ const Dynamic = ({ patients, situation, supplies, decision, dmName, actions, sce
                                     </Col>
                                 </Row>
                             </Card>
-                    }</>
+                    }</Col>
                 );
             } else {
                 return null;
@@ -163,7 +163,9 @@ const Dynamic = ({ patients, situation, supplies, decision, dmName, actions, sce
                                 {patientButtons}
                             </div>
                             <div className="card-container">
-                                {patientCards}
+                                <Row>
+                                    {patientCards}
+                                </Row>
                             </div>
                         </Col>
                     </Accordion.Body>

--- a/dashboard-ui/src/components/Survey/template.css
+++ b/dashboard-ui/src/components/Survey/template.css
@@ -42,7 +42,7 @@
 }
 
 .patient-card {
-  width: 33%;
+  width: 100%;
   margin-right: 0.33%;
   display: inline-block;
   vertical-align: top;

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -265,7 +265,7 @@ class TextBasedScenariosPage extends Component {
             });
         });
 
-
+        scenarioData.scenarioOrder = [this.state.matchedParticipantLog['Text-1'], this.state.matchedParticipantLog['Text-2']]
         await this.getAlignmentScore(scenarioData)
         const sanitizedData = this.sanitizeKeys(scenarioData);
 

--- a/dashboard-ui/src/components/TextBasedScenarios/patient.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/patient.jsx
@@ -135,7 +135,7 @@ const Patient = ({ patient, onImageClick, blockedVitals }) => {
   const renderInjuries = (injuries) => {
     return injuries.map((injury, i) => (
       <div key={i} className="mb-2">
-        <strong>{capitalizeWords(injury.location)} {injury.name}</strong>
+        <strong>{injury.location != 'internal' ? capitalizeWords(injury.location) : ''} {injury.name}</strong>
         <br />
         Severity: <Badge bg={getInjurySeverityColor(injury.severity)}>{injury.severity.toUpperCase()}</Badge>
       </div>

--- a/dashboard-ui/src/components/TextBasedScenarios/patient.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/patient.jsx
@@ -109,7 +109,7 @@ const Patient = ({ patient, onImageClick, blockedVitals }) => {
 
     const vitalsVisible = !blockedVitals?.includes(patient.id);
     return (
-      <div className="d-flex flex-column gap-1" style={{ minHeight: '200px', overflow: 'visible' }}>
+      <div className="d-flex flex-column gap-1 h-100">
         {Object.entries(vitals).map(([key, value]) => (
           <div key={key} className="vital-item">
             <span className="vital-icon">
@@ -144,7 +144,7 @@ const Patient = ({ patient, onImageClick, blockedVitals }) => {
 
   return (
     <Card className="h-100 border-0 shadow-sm">
-      <Card.Body style={{ overflow: 'visible' }}>
+      <Card.Body>
         <Card.Title className="h4 mb-1">
           {patient.name}
         </Card.Title>
@@ -157,48 +157,59 @@ const Patient = ({ patient, onImageClick, blockedVitals }) => {
           {patient.unstructured}
         </Card.Text>
         <Row className="mb-3">
-          <Col md={7} className="d-flex mb-3 mb-md-0">
-            <div className="bg-primary text-white p-3 text-center d-flex align-items-center justify-content-center w-100 rounded" style={{ position: 'relative', minHeight: '150px', overflow: 'hidden' }}>
-              {patient.imgUrl ? (
-                <img
-                  src={`data:image/png;base64,${patient.imgUrl}`}
-                  alt={`${patient.id ?? patient.name}`}
-                  style={{
-                    width: '100%',
-                    height: '100%',
-                    objectFit: 'cover',
-                    position: 'absolute',
-                    top: 0,
-                    left: 0,
-                  }}
-                />
-              ) : (
-                "No image available"
-              )}
-              <ZoomInIcon
-                className="magnifying-glass"
-                style={{
-                  position: 'absolute',
-                  bottom: '8px',
-                  left: '8px',
-                  fontSize: '24px',
-                  cursor: 'pointer',
-                  zIndex: 1,
-                }}
-                onClick={() => onImageClick(patient)}
-              />
-            </div>
-          </Col>
-          <Col md={5} className="d-flex flex-column">
-            <Card className="w-100 border-0 flex-grow-1 vitals-card" style={{ backgroundColor: '#e7f1ff', overflow: 'visible' }}>
-              <Card.Body className="p-2 d-flex flex-column" style={{ overflow: 'visible' }}>
-                <Card.Title className="h5 mb-2 vitals-title">Vitals</Card.Title>
-                <div className="vitals-container flex-grow-1">
-                  {renderVitals(patient.vitals)}
+          {patient.imgUrl ? (
+            <>
+              <Col md={7} className="d-flex mb-3 mb-md-0">
+                <div className="bg-primary text-white p-3 text-center d-flex align-items-center justify-content-center w-100 rounded" style={{ position: 'relative', minHeight: '150px', overflow: 'hidden' }}>
+                  <img
+                    src={`data:image/png;base64,${patient.imgUrl}`}
+                    alt={`${patient.id ?? patient.name}`}
+                    style={{
+                      width: '100%',
+                      height: '100%',
+                      objectFit: 'cover',
+                      position: 'absolute',
+                      top: 0,
+                      left: 0,
+                    }}
+                  />
+                  <ZoomInIcon
+                    className="magnifying-glass"
+                    style={{
+                      position: 'absolute',
+                      bottom: '8px',
+                      left: '8px',
+                      fontSize: '24px',
+                      cursor: 'pointer',
+                      zIndex: 1,
+                    }}
+                    onClick={() => onImageClick(patient)}
+                  />
                 </div>
-              </Card.Body>
-            </Card>
-          </Col>
+              </Col>
+              <Col md={5} className="d-flex flex-column">
+                <Card className="w-100 border-0 flex-grow-1 vitals-card" style={{ backgroundColor: '#e7f1ff' }}>
+                  <Card.Body className="p-2 d-flex flex-column">
+                    <Card.Title className="h5 mb-2 vitals-title">Vitals</Card.Title>
+                    <div className="vitals-container flex-grow-1">
+                      {renderVitals(patient.vitals)}
+                    </div>
+                  </Card.Body>
+                </Card>
+              </Col>
+            </>
+          ) : (
+            <Col md={12}>
+              <Card className="w-100 border-0 h-100 vitals-card" style={{ backgroundColor: '#e7f1ff' }}>
+                <Card.Body className="p-3 d-flex flex-column">
+                  <Card.Title className="h5 mb-3 vitals-title">Vitals</Card.Title>
+                  <div className="vitals-container flex-grow-1">
+                    {renderVitals(patient.vitals)}
+                  </div>
+                </Card.Body>
+              </Card>
+            </Col>
+          )}
         </Row>
         <Card className="mb-0 border-0" style={{ backgroundColor: '#fff0f0' }}>
           <Card.Body className="p-3">


### PR DESCRIPTION
No ingest script this time.

Changes:
- Running through the text-based scenario using a PID from the participant log will attach the order of the scenarios seen to the documents posted in Mongo. (i.e `scenarioOrder: ['AD-1', 'ST-2']`)
- internal injuries had a `location` of internal and a `name` of internal so it was printed as "Internal Internal" in the patient injuries section. It makes sense to include location if it is something like "Broken Right Arm" but I added in a check if the location is internal to not repeat the word. 
- Improved layout of patient cards in delegation survey. Before they were scrunched and the vitals were getting truncated on all of them. Should look a lot better now.
- Removed the 'no image available' container from Adept's training scenarios. If you look at IO1 and MJ1 on the review page you will see that the vitals just fill the space now. 