### PR TITLE
account for MJ2 Gauze edge case

### DIFF
--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -429,20 +429,25 @@ class TextBasedScenariosPage extends Component {
                 if (question.response && !questionName.includes("Follow Up")) {
                     const mapping = question.question_mapping[question.response]
                     const responseUrl = `${urlBase}/api/v1/response`
-                    const responsePayload = {
-                        "response": {
-                            "choice": mapping['choice'],
-                            "justification": "justification",
-                            "probe_id": mapping['probe_id'],
-                            "scenario_id": scenarioID,
-                        },
-                        "session_id": sessionID
-                    }
-                    try {
-                        const response = await axios.post(responseUrl, responsePayload)
-                    } catch (err) {
-                        console.log(err)
-                        continue
+                    
+                    const choices = Array.isArray(mapping['choice']) ? mapping['choice'] : [mapping['choice']]
+                    
+                    for (const choice of choices) {
+                        const responsePayload = {
+                            "response": {
+                                "choice": choice,
+                                "justification": "justification",
+                                "probe_id": mapping['probe_id'],
+                                "scenario_id": scenarioID,
+                            },
+                            "session_id": sessionID
+                        }
+                        try {
+                            const response = await axios.post(responseUrl, responsePayload)
+                        } catch (err) {
+                            console.log(err)
+                            continue
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Scene 2A in Adept's MJ2 had to be tweaked to fit the text-based format. I had worked with Dustin to figure out how those mappings should work. I forgot to handle several probe responses to be sent from one answer (i.e 3 units of gauze for Babson and 2 for Alderson). This change allows for 5 probe responses to be sent off of selecting that answer.