### PR TITLE
changed soartech adm loading logic

### DIFF
--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -537,7 +537,7 @@ class SurveyPage extends Component {
                 misalignedStatus = validAdms['misalignedStatus'];
                 break;
             case 'qol-dre-1-eval':
-                cols1to3 = ['qol-human-1774519-SplitEvenBinary', 'qol-human-9157688-SplitEvenBinary'];
+                cols1to3 = ['qol-human-1774519-SplitEvenBinary'];
                 set1 = ['qol-synth-HighCluster', 'qol-human-3447902-SplitHighMulti'];
                 validAdms = this.getValidADM(ALL_QOL_TARGETS, qolTargets, cols1to3, set1, [], []);
                 alignedTarget = validAdms['aligned'];
@@ -546,7 +546,7 @@ class SurveyPage extends Component {
                 misalignedStatus = validAdms['misalignedStatus'];
                 break;
             case 'qol-dre-2-eval':
-                cols1to3 = ['qol-human-1774519-SplitEvenBinary', 'qol-human-9157688-SplitEvenBinary'];
+                cols1to3 = ['qol-human-1774519-SplitEvenBinary'];
                 set1 = ['qol-synth-HighExtreme', 'qol-human-2932740-HighExtreme', 'qol-human-6403274-SplitHighBinary'];
                 validAdms = this.getValidADM(ALL_QOL_TARGETS, qolTargets, cols1to3, set1, [], []);
                 alignedTarget = validAdms['aligned'];
@@ -555,7 +555,7 @@ class SurveyPage extends Component {
                 misalignedStatus = validAdms['misalignedStatus'];
                 break;
             case 'qol-dre-3-eval':
-                cols1to3 = ['qol-human-6403274-SplitHighBinary', 'qol-human-3043871-SplitHighBinary', 'qol-human-9157688-SplitEvenBinary', 'qol-human-1774519-SplitEvenBinary'];
+                cols1to3 = ['qol-human-6403274-SplitHighBinary', 'qol-human-9157688-SplitEvenBinary', 'qol-human-1774519-SplitEvenBinary'];
                 set1 = ['qol-synth-HighExtreme', 'qol-synth-HighCluster'];
                 validAdms = this.getValidADM(ALL_QOL_TARGETS, qolTargets, cols1to3, set1, [], []);
                 alignedTarget = validAdms['aligned'];
@@ -564,7 +564,7 @@ class SurveyPage extends Component {
                 misalignedStatus = validAdms['misalignedStatus'];
                 break;
             case 'vol-dre-1-eval':
-                cols1to3 = ['vol-human-7040555-SplitEvenBinary', 'vol-human-6403274-SplitEvenBinary', 'vol-synth-HighCluster'];
+                cols1to3 = ['vol-human-7040555-SplitEvenBinary', 'vol-synth-HighCluster'];
                 set1 = ['vol-human-8478698-SplitLowMulti', 'vol-synth-LowCluster', 'vol-synth-LowExtreme'];
                 validAdms = this.getValidADM(ALL_VOL_TARGETS, volTargets, cols1to3, set1, [], []);
                 alignedTarget = validAdms['aligned'];
@@ -573,7 +573,7 @@ class SurveyPage extends Component {
                 misalignedStatus = validAdms['misalignedStatus'];
                 break;
             case 'vol-dre-2-eval':
-                cols1to3 = ['vol-human-7040555-SplitEvenBinary', 'vol-human-6403274-SplitEvenBinary'];
+                cols1to3 = ['vol-human-7040555-SplitEvenBinary'];
                 set1 = ['vol-synth-LowExtreme', 'vol-synth-LowCluster'];
                 set2 = ['vol-human-1774519-SplitHighMulti', 'vol-human-6403274-SplitEvenBinary', 'vol-synth-HighExtreme'];
                 validAdms = this.getValidADM(ALL_VOL_TARGETS, volTargets, cols1to3, set1, set2, []);
@@ -583,7 +583,7 @@ class SurveyPage extends Component {
                 misalignedStatus = validAdms['misalignedStatus'];
                 break;
             case 'vol-dre-3-eval':
-                cols1to3 = ['vol-human-6403274-SplitEvenBinary', 'vol-human-7040555-SplitEvenBinary'];
+                cols1to3 = ['vol-human-6403274-SplitEvenBinary'];
                 set1 = ['vol-synth-HighCluster', 'vol-synth-HighExtreme'];
                 validAdms = this.getValidADM(ALL_VOL_TARGETS, volTargets, cols1to3, set1, [], []);
                 alignedTarget = validAdms['aligned'];
@@ -665,7 +665,7 @@ class SurveyPage extends Component {
                 }
                 break;
             case 'qol-dre-1-eval':
-                cols1to3 = ['qol-human-3447902-SplitHighMulti', 'qol-human-6349649-SplitHighMulti', 'qol-human-7040555-SplitHighMulti'];
+                cols1to3 = ['qol-human-3447902-SplitHighMulti'];
                 set1 = ['qol-human-2932740-HighExtreme', 'qol-synth-HighCluster'];
                 set2 = ['qol-human-1774519-SplitEvenBinary', 'qol-human-9157688-SplitEvenBinary']
                 validAdms = this.getValidADM(ALL_QOL_TARGETS, qolTargets, cols1to3, set1, set2, []);
@@ -675,7 +675,7 @@ class SurveyPage extends Component {
                 misalignedStatus = validAdms['misalignedStatus'];
                 break;
             case 'qol-dre-2-eval':
-                cols1to3 = ['qol-human-8022671-SplitLowMulti', 'qol-human-5032922-SplitLowMulti'];
+                cols1to3 = ['qol-human-8022671-SplitLowMulti'];
                 set1 = ['qol-human-3043871-SplitHighBinary', 'qol-human-6349649-SplitHighMulti'];
                 validAdms = this.getValidADM(ALL_QOL_TARGETS, qolTargets, cols1to3, set1, [], []);
                 alignedTarget = validAdms['aligned'];
@@ -684,7 +684,7 @@ class SurveyPage extends Component {
                 misalignedStatus = validAdms['misalignedStatus'];
                 break;
             case 'qol-dre-3-eval':
-                cols1to3 = ['qol-human-6349649-SplitHighMulti', 'qol-human-6349649-SplitHighMulti', 'qol-human-3447902-SplitHighMulti', 'qol-human-7040555-SplitHighMulti'];
+                cols1to3 = ['qol-human-6349649-SplitHighMulti'];
                 validAdms = this.getValidADM(ALL_QOL_TARGETS, qolTargets, cols1to3, [], [], []);
                 alignedTarget = validAdms['aligned'];
                 misalignedTarget = validAdms['misaligned'];
@@ -694,7 +694,7 @@ class SurveyPage extends Component {
             case 'vol-dre-1-eval':
             case 'vol-dre-2-eval':
             case 'vol-dre-3-eval':
-                cols1to3 = ['vol-human-3043871-SplitLowMulti', 'vol-human-5032922-SplitLowMulti'];
+                cols1to3 = ['vol-human-3043871-SplitLowMulti'];
                 validAdms = this.getValidADM(ALL_VOL_TARGETS, volTargets, cols1to3, [], [], []);
                 alignedTarget = validAdms['aligned'];
                 misalignedTarget = validAdms['misaligned'];


### PR DESCRIPTION
ST no longer cares about overlaps with adms that are in the same category as the baseline adm. I removed these from the col1to3 variable in order to free them to be used by the aligned and misaligned adms. 

https://nextcentury.atlassian.net/wiki/spaces/ITMC/pages/3213885465/Dry+Run+Evaluation+Delegation+Materials