### PR TITLE
Itm 601 sim play-by-play

### DIFF
--- a/dashboard-ui/src/components/AggregateResults/DataFunctions.js
+++ b/dashboard-ui/src/components/AggregateResults/DataFunctions.js
@@ -467,52 +467,54 @@ function getAttributeAlignment(res, att, medics, q, trans) {
     return { 'align': alignTally > 0 ? align / alignTally : null, 'misalign': misalignTally > 0 ? misalign / misalignTally : null };
 }
 
-function populateHumanDataRow(rowObject) {
+function populateHumanDataRow(rowObject, version) {
     let adept = 0;
     let soartech = 1;
     if(rowObject[0]._id.indexOf("_st_") > -1) {
         adept = 1;
         soartech = 0;
     }
+    let returnObj = {};
+    if (version == 3) {
+        returnObj = {
+            "Participant": rowObject[0].pid,
+            "SimEnv": rowObject[0].env,
+            "SimOrder": rowObject[0].simOrder,
+            "AD_P1": rowObject[adept].data.data.length > 0 ? rowObject[adept].data.data[0].probe.kdma_association["MoralDesert"] : "",
+            "AD_P2": rowObject[adept].data.data.length > 1 ? rowObject[adept].data.data[1].probe.kdma_association["MoralDesert"] : "",
+            "AD_P3": rowObject[adept].data.data.length > 2 ? rowObject[adept].data.data[2].probe.kdma_association["MoralDesert"] : "",
+            "ST_1.1": "",
+            "ST_1.2": "",
+            "ST_1.3": "",
+            "ST_2.2": "",
+            "ST_2.3": "",
+            "ST_3.1": "",
+            "ST_3.2": "",
+            "ST_4.1": "",
+            "ST_4.2": "",
+            "ST_4.3": "",
+            "ST_5.1": "",
+            "ST_5.2": "",
+            "ST_5.3": "",
+            "ST_6.1": "",
+            "ST_6.2": "",
+            "ST_8.1": "",
+            "ST_8.2": "",
+            "AD_KDMA_Env": rowObject[adept]?.data?.alignment?.kdma_values?.length > 0 ? Math.round(rowObject[adept].data.alignment.kdma_values[0].value * 100) / 100 : "",
+            "ST_KDMA_Env": rowObject[soartech]?.data?.alignment?.kdma_values?.length > 0 ? Math.round(rowObject[soartech].data.alignment.kdma_values[0].value * 100) / 100 : "",
+            "AD_KDMA": isNaN(Math.round(rowObject[adept].avgKDMA * 100) / 100) ? "" : Math.round(rowObject[adept].avgKDMA * 100) / 100,
+            "ST_KDMA": isNaN(Math.round(rowObject[soartech].avgKDMA * 100) / 100) ? "" : Math.round(rowObject[soartech].avgKDMA * 100) / 100
+        };
 
-    let returnObj = {
-        "Participant": rowObject[0].pid,
-        "SimEnv": rowObject[0].env,
-        "SimOrder": rowObject[0].simOrder,
-        "AD_P1": rowObject[adept].data.data.length > 0 ? rowObject[adept].data.data[0].probe.kdma_association["MoralDesert"] : "",
-        "AD_P2": rowObject[adept].data.data.length > 1 ? rowObject[adept].data.data[1].probe.kdma_association["MoralDesert"] : "",
-        "AD_P3": rowObject[adept].data.data.length > 2 ? rowObject[adept].data.data[2].probe.kdma_association["MoralDesert"] : "",
-        "ST_1.1": "",
-        "ST_1.2": "",
-        "ST_1.3": "",
-        "ST_2.2": "",
-        "ST_2.3": "",
-        "ST_3.1": "",
-        "ST_3.2": "",
-        "ST_4.1": "",
-        "ST_4.2": "",
-        "ST_4.3": "",
-        "ST_5.1": "",
-        "ST_5.2": "",
-        "ST_5.3": "",
-        "ST_6.1": "",
-        "ST_6.2": "",
-        "ST_8.1": "",
-        "ST_8.2": "",
-        "AD_KDMA_Env": rowObject[adept]?.data?.alignment?.kdma_values?.length > 0 ? Math.round(rowObject[adept].data.alignment.kdma_values[0].value * 100) / 100 : "",
-        "ST_KDMA_Env": rowObject[soartech]?.data?.alignment?.kdma_values?.length > 0 ? Math.round(rowObject[soartech].data.alignment.kdma_values[0].value * 100) / 100 : "",
-        "AD_KDMA": isNaN(Math.round(rowObject[adept].avgKDMA * 100) / 100) ? "" : Math.round(rowObject[adept].avgKDMA * 100) / 100,
-        "ST_KDMA": isNaN(Math.round(rowObject[soartech].avgKDMA * 100) / 100) ? "" : Math.round(rowObject[soartech].avgKDMA * 100) / 100
-    };
+        const soartechProbeIds = ["1.1", "1.2", "1.3", "2.2", "2.3", "3.1", "3.2", "4.1", "4.2", "4.3", "5.1", "5.2", "5.3", "6.1", "6.2", "8.1", "8.2"]
 
-    const soartechProbeIds = ["1.1", "1.2", "1.3", "2.2", "2.3", "3.1", "3.2", "4.1", "4.2", "4.3", "5.1", "5.2", "5.3", "6.1", "6.2", "8.1", "8.2"]
-
-    for(let i=0; i < rowObject[soartech].data.data.length; i++) {
-        for(let j=0; j < soartechProbeIds.length; j++) {
-            if(rowObject[soartech].data.data[i].found_match !== false) { 
-                if (rowObject[soartech].data.data[i].probe_id.indexOf(soartechProbeIds[j]) > -1) {
-                    returnObj["ST_" + soartechProbeIds[j]] = rowObject[soartech].data.data[i].probe.kdma_association["maximization"];
-                } 
+        for (let i = 0; i < rowObject[soartech].data.data.length; i++) {
+            for (let j = 0; j < soartechProbeIds.length; j++) {
+                if (rowObject[soartech].data.data[i].found_match !== false) {
+                    if (rowObject[soartech].data.data[i].probe_id.indexOf(soartechProbeIds[j]) > -1) {
+                        returnObj["ST_" + soartechProbeIds[j]] = rowObject[soartech].data.data[i].probe.kdma_association["maximization"];
+                    } 
+                }
             }
         }
     }
@@ -530,7 +532,7 @@ function populateDataSet(data) {
             let tempGroupPidArray = [];
             Object.keys(tempGroupHumanSimData[key]).forEach (keyPid => {
                 if(keyPid.indexOf(" ") === -1) {
-                    tempGroupPidArray.push(populateHumanDataRow(tempGroupHumanSimData[key][keyPid]));
+                    tempGroupPidArray.push(populateHumanDataRow(tempGroupHumanSimData[key][keyPid], data.getAllSimAlignmentByEval[0].evalNumber));
                 }
             });
             tempGroupHumanSimData[key] = tempGroupPidArray;

--- a/dashboard-ui/src/components/AggregateResults/aggregateResults.jsx
+++ b/dashboard-ui/src/components/AggregateResults/aggregateResults.jsx
@@ -305,7 +305,7 @@ export default function AggregateResults({ type }) {
                             options={evalOptions}
                             placeholder="Select Evaluation"
                             defaultValue={evalOptions[0]}
-                            value={evalOptions[0]}
+                            value={evalOptions.find(option => option.value === selectedEval)}
                             styles={{
                                 // Fixes the overlapping problem of the component
                                 menu: provided => ({ ...provided, zIndex: 9999 })
@@ -359,6 +359,7 @@ export default function AggregateResults({ type }) {
                             options={evalOptions}
                             defaultValue={evalOptions[0]}
                             placeholder="Select Evaluation"
+                            value={evalOptions.find(option => option.value === selectedEval)}
                             styles={{
                                 // Fixes the overlapping problem of the component
                                 menu: provided => ({ ...provided, zIndex: 9999 })

--- a/dashboard-ui/src/components/DRE-Research/RQ1.jsx
+++ b/dashboard-ui/src/components/DRE-Research/RQ1.jsx
@@ -2,7 +2,7 @@ import { RQ13 } from "./tables/rq1-rq3";
 import './dre-rq.css';
 
 export function RQ1() {
-    return (<>
+    return (<div className="researchQuestion">
         <div className="section-container">
             <h2>RQ1: Does alignment score predict measures of trust?</h2>
             <p className='indented'>
@@ -55,5 +55,5 @@ export function RQ1() {
                 <button>View R Syntax</button>
             </div>
         </div>
-    </>);
+    </div>);
 }

--- a/dashboard-ui/src/components/DRE-Research/RQ2.jsx
+++ b/dashboard-ui/src/components/DRE-Research/RQ2.jsx
@@ -3,7 +3,7 @@ import './dre-rq.css';
 import { RQ21 } from "./tables/rq21";
 
 export function RQ2() {
-    return (<>
+    return (<div className="researchQuestion">
         <div className="section-container">
             <h2>RQ2: Do aligned ADMs have the ability to tune to a subset of the attribute space?</h2>
             <p className='indented'>
@@ -38,5 +38,5 @@ export function RQ2() {
             <RQ2223 />
 
         </div>
-    </>);
+    </div>);
 }

--- a/dashboard-ui/src/components/DRE-Research/RQ3.jsx
+++ b/dashboard-ui/src/components/DRE-Research/RQ3.jsx
@@ -2,7 +2,7 @@ import { RQ13 } from "./tables/rq1-rq3";
 import './dre-rq.css';
 
 export function RQ3() {
-    return (<>
+    return (<div className="researchQuestion">
         <div className="section-container">
             <h2>RQ3: Does alignment affect delegation preference for ADMs?</h2>
             <p className='indented'>
@@ -60,5 +60,5 @@ export function RQ3() {
                 <li>Trust_Rating</li>
             </ul>
         </div>
-    </>);
+    </div>);
 }

--- a/dashboard-ui/src/components/DRE-Research/dre-rq.css
+++ b/dashboard-ui/src/components/DRE-Research/dre-rq.css
@@ -45,7 +45,7 @@
     filter: brightness(80%);
 }
 
-h3 {
+.researchQuestion h3 {
     margin-left: 32px;
     margin-top: 24px;
 }

--- a/dashboard-ui/src/components/HumanResults/humanResults.jsx
+++ b/dashboard-ui/src/components/HumanResults/humanResults.jsx
@@ -305,7 +305,7 @@ export default function HumanResults() {
                     </table>
                 </div>
             </div>
-            : <h2 className="not-found">Please select an environment and participant to view results</h2>
+            : <h2 className="not-found">Please select {selectedEval == 4 ? "a scenario" : "an environment"} and participant to view results</h2>
         }
     </div >);
 }

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -192,7 +192,7 @@ const typeDefs = gql`
     getAllSimAlignmentByEval(evalNumber: Float): [JSON],
     getEvalIdsForSimAlignment: [JSON],
     getEvalNameNumbers: [JSON],
-    getEvalIdsForHumandResults: [JSON],
+    getEvalIdsForHumanResults: [JSON],
     getAllRawSimData: [JSON],
     getAllSurveyConfigs: [JSON],
     getAllTextBasedConfigs: [JSON],
@@ -415,7 +415,7 @@ const resolvers = {
       return await dashboardDB.db.collection('test').aggregate( 
         [{"$group": {"_id": {evalNumber: "$evalNumber", evalName: "$evalName"}}}]).toArray().then(result => {return result});
     },
-    getEvalIdsForHumandResults: async (obj, args, context, inflow) => {
+    getEvalIdsForHumanResults: async (obj, args, context, inflow) => {
       return await dashboardDB.db.collection('humanSimulatorRaw').aggregate( 
         [{"$group": {"_id": {evalNumber: "$evalNumber", evalName: "$evalName"}}}]).sort({'evalNumber': -1}).toArray().then(result => {return result});
     },


### PR DESCRIPTION
Updated http://localhost:3000/human-results for DRE.

Organizes DRE scenarios by scenario rather than environment, taking away the toggle between Adept/Soartech/Freeform, since that is no longer relevant. To see all probes, run the latest version of the probe_matcher, as the manually entered probes (dragging probes for QOL/VOL scenarios) have been put in the database in the latest commits [here](https://github.com/NextCenturyCorporation/itm-ingest/pull/40). 

Make sure switching between evaluations, scenarios, and participants works smoothly, and that the data looks appropriate. I fixed a typo in our graphql calls, so you will need to rerun the startup script. 

This also includes a minor fix so that entering http://localhost:3000/humanSimParticipant does not cause an error.

Note: built off of generalize-survey-results AND derek's branch to include all recent changes. That's why it shows extra changes that are not part of this branch.