### PR TITLE
ITM-565 - Updated SSL Certificate

### DIFF
--- a/docker_setup/docker-compose.yml
+++ b/docker_setup/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     volumes:
       - ./resources/nginx.conf:/etc/nginx/nginx.conf
       - ./certs:/certs
+      - ./nginxpwd:/nginxpwd
     ports:
       - "80:80"
       - "443:443"

--- a/docker_setup/resources/nginx.conf
+++ b/docker_setup/resources/nginx.conf
@@ -34,6 +34,8 @@ http {
     # SSL
     ssl_certificate /certs/ServerCertificate.crt;
     ssl_certificate_key /certs/darpaitm.key;
+    ssl_password_file /nginxpwd/sslpwd;
+
 
     # Recommendations from https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
     ssl_protocols TLSv1.1 TLSv1.2;


### PR DESCRIPTION
This is already running on Prod (it's the only way to test)

You wont see the certificates committed into the repo.
Certs were installed on our nginx **and** CISTAC needs to install the same certs on CACI's F5 load balancer.

If you go to the UI website, you should see the new SSL (on the address bar, to the left of the url, should be a lock icon, you should be able to navigate to the certificate).  You may need to do a hard refresh of the website (cntrl+shift+R on windows or Cmd+Opt+R on mac)

The new expiration date: Saturday, August 23, 2025 at 2:48:49 PM

I'll post a write-up on Confluence for the install.