### PR TITLE
VR page recording fix

### DIFF
--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -149,6 +149,7 @@ class SurveyPage extends Component {
             envsSeen: { "Del-1": "AD-1", "Del-2": "ST-3", "ADMOrder": 1 }
         };
         this.surveyConfigClone = null;
+        this.pageStartTimes = {};
 
         if (this.state.surveyConfig) {
             this.postConfigSetup();
@@ -174,7 +175,6 @@ class SurveyPage extends Component {
         this.survey = new Model(this.surveyConfigClone);
         this.survey.applyTheme(surveyTheme);
 
-        this.pageStartTimes = {};
         this.surveyData = {};
         this.survey.onAfterRenderPage.add(this.onAfterRenderPage);
         this.survey.onValueChanged.add(this.onValueChanged)


### PR DESCRIPTION
There was an issue with the 2nd page of the survey recording data. Confirm that once you enter a PID and complete the page that asks you about vr comfort level that both of these pages' data is properly stored in mongo

Run [kaitlyn's ingest pr first](https://github.com/NextCenturyCorporation/itm-ingest/pull/44)