### PR TITLE
started adding open world data to RQ8

### DIFF
--- a/dashboard-ui/src/components/DRE-Research/tables/rq6.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq6.jsx
@@ -10,7 +10,7 @@ import definitionPDFFile from '../variables/Variable Definitions RQ6.pdf';
 import { useQuery } from 'react-apollo'
 import gql from "graphql-tag";
 import { isDefined } from "../../AggregateResults/DataFunctions";
-import { admOrderMapping, delEnvMapping } from "../../Survey/survey";
+import { admOrderMapping } from "../../Survey/survey";
 
 const GET_PARTICIPANT_LOG = gql`
     query GetParticipantLog {


### PR DESCRIPTION
Adds the correct rows to the RQ8 table. SInce no analysis has been done on the open world data, most columns are still empty, but at least now the table has some data.

https://github.com/NextCenturyCorporation/itm-ingest/pull/52
Run this ingest script first!

Make sure that the other sim-related pages (play-by-play and probe values) are unaffected by the addition of open world data to the database