### PR TITLE
Itm 626

### DIFF
--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -179,7 +179,11 @@ class TextBasedScenariosPage extends Component {
         const { scenarios, currentScenarioIndex } = this.state;
         if (currentScenarioIndex < scenarios.length) {
             const currentScenario = scenarios[currentScenarioIndex];
-            this.loadSurveyConfig([currentScenario], currentScenario.title);
+            const newStartTime = new Date().toString();
+            
+            this.setState({ startTime: newStartTime }, () => {
+                this.loadSurveyConfig([currentScenario], currentScenario.title);
+            });
         } else {
             this.handleAllScenariosCompleted();
         }
@@ -569,13 +573,7 @@ class TextBasedScenariosPage extends Component {
     onAfterRenderPage = (sender, options) => {
         const pageName = options.page.name;
         const currentTime = new Date();
-
-        if (!this.state.startTime) {
-            this.setState({
-                startTime: currentTime.toString()
-            });
-        }
-
+    
         if (this.survey.currentPageNo > 0) {
             const previousPageName = this.survey.pages[this.survey.currentPageNo - 1].name;
             const startTime = this.pageStartTimes[previousPageName];
@@ -585,7 +583,7 @@ class TextBasedScenariosPage extends Component {
                 this.surveyData[previousPageName].timeSpentOnPage = timeSpentInSeconds;
             }
         }
-
+    
         this.pageStartTimes[pageName] = currentTime;
     }
 

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -379,7 +379,7 @@ class TextBasedScenariosPage extends Component {
             alignmentIDs.adeptAlignmentIDs.map(targetId => this.getAlignmentData(targetId, url, alignmentEndpoint, this.state.combinedSessionId, 'adept'))
         );
         const sortedAlignmentData = alignmentData.sort((a, b) => b.score - a.score);
-        const combinedMostLeastAligned = await this.mostLeastAligned(this.state.combinedSessionId, 'adept', url, null)
+        const combinedMostLeastAligned = await this.mostLeastAlgined(this.state.combinedSessionId, 'adept', url, null)
     
         for (let scenario of scenarios) {
             if (!this.state.uploadedScenarios.has(scenario.scenario_id)) {


### PR DESCRIPTION
[Ticket](https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?assignee=60ba425da547eb00686ee0ce&selectedIssue=ITM-626)

There was an issue with duplicate documents being uploaded for the text-based scenarios. The duplication would happen when one participant completed their text-based scenarios, followed by someone resetting the page by pressing 'M'. If another participant then completed their text-based scenarios, the previous participant's Adept documents would mistakenly be uploaded again (in addition to the current participant's documents). 

This is a little bit of a headache to test. The easiest way I'd suggest is to take a PID that isn't in your db already i.e `20249241` and click through the scenarios (sorry). 3 new adept documents should be added to `userScenarioResults`, 2 new soartech ones should be added. 

Then take another PID from the log (faster if you pick one with Adept as `text-1` i.e `20249243`). All you have to do this time is click until you are through the three adept scenarios. At which point, you can check your Mongo db to see that 3 new adept documents have been added. 

If you repeat these steps on dev, you should experience the bug. That is, the duplicate documents being uploaded.