### PR TITLE
Prevent x.0 in survey version recorded from survey results to prevent issues on data presentation pages

### DIFF
--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -11,7 +11,7 @@ import { OmnibusComparison } from "./omnibusComparison";
 import gql from "graphql-tag";
 import { Mutation } from '@apollo/react-components';
 import { useQuery } from 'react-apollo'
-import { getUID, shuffle, survey3_0_groups } from './util';
+import { getUID, shuffle, survey3_0_groups, surveyVersion_x_0 } from './util';
 import Bowser from "bowser";
 import { Prompt } from 'react-router-dom'
 import { useSelector } from "react-redux";
@@ -1101,7 +1101,7 @@ class SurveyPage extends Component {
         this.surveyData.user = this.props.currentUser;
         this.surveyData.timeComplete = new Date().toString();
         this.surveyData.startTime = this.state.startTime;
-        this.surveyData.surveyVersion = this.state.surveyVersion;
+        this.surveyData.surveyVersion = surveyVersion_x_0(this.state.surveyVersion);
         this.surveyData.browserInfo = this.state.browserInfo;
 
         // 7-16 data collect. Log info about order, agent, and DM 

--- a/dashboard-ui/src/components/Survey/util.js
+++ b/dashboard-ui/src/components/Survey/util.js
@@ -34,3 +34,10 @@ export const survey3_0_groups = [
         ['TAD', 'Adept Submarine'],
         ['kitware', 'Adept Submarine']
 ]
+
+export function surveyVersion_x_0(surveyVersion) {
+    if (surveyVersion.toString().endsWith('.0')) {
+      return parseInt(surveyVersion);
+    }
+    return surveyVersion;
+  }


### PR DESCRIPTION
After changing to survey version 3 on the admin page, future survey results were populating on the survey results page as `3.0` instead of `3`, creating two separate filters for what should be grouped together.

Test this out on dev, you will only need to click through a couple pages of the survey to see this behavior on the results page. Next, switch to the feature branch, delete the test document from the `surveyResults` collection in your database, and repeat the process. Verify that new results now show as version "3" (not "3.0") and that there's only one filter for version 3.