### PR TITLE
ITM-641: replace soartech/jenkins instance with new AWS 2023 os

### DIFF
--- a/docker_setup/docker-compose.yml
+++ b/docker_setup/docker-compose.yml
@@ -6,6 +6,7 @@ networks:
 services:
   nginx:
     image: nginx:latest
+    restart: always
     container_name: dashboard-nginx
     volumes:
       - ./resources/nginx.conf:/etc/nginx/nginx.conf
@@ -22,6 +23,7 @@ services:
   dashboard-ui:
     container_name: dashboard-ui
     image: dashboard-ui
+    restart: always
     volumes:
       - ../dashboard-ui/public/configs/prod/config.js:/usr/src/app/src/services/config.js
       - ../dashboard-ui/public:/usr/src//app/public
@@ -40,6 +42,7 @@ services:
   dashboard-server:
     container_name: dashboard-graphql
     image: dashboard-graphql
+    restart: always
     volumes:
       - ../dashboard-ui/public/configs/prod/graphql-config.js:/usr/src/app/config.js
       - $HOME/.aws/:/root/.aws/:ro
@@ -55,6 +58,7 @@ services:
       NODE_OPTIONS: "--max-old-space-size=16384"
   dashboard-mongo: 
     image: 'mongo'
+    restart: always
     container_name: dashboard-mongo
     command: --port 27030
     networks:

--- a/docker_setup/resources/nginx.conf
+++ b/docker_setup/resources/nginx.conf
@@ -142,7 +142,7 @@ http {
     }
 
     location /jenkins {
-      set $upstream http://10.216.38.67:8080;
+      set $upstream http://10.216.38.60:8080;
       proxy_pass $upstream;
 
       proxy_set_header  Host              $host;   # required for docker client's sake
@@ -156,7 +156,7 @@ http {
 
     location /soartech/ {
       # proxy_pass CANNOT contain variable for this to work
-      proxy_pass http://10.216.38.125:8084/;
+      proxy_pass http://10.216.38.25:8084/;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }


### PR DESCRIPTION
Jenkin and SoarTech instances were updated to AWS 2023 Linux, (Adept was updated a few weeks ago)
Jenkins, SoarTech and Adept new instances are currently live on prod. You won't be able to test nginx configs locally, since that's only setup for the prod env.
For Soartech, I moved the DB and Volume over to the new instance to retain session information.  All table counts from old/new systems were equal after migration was complete.
Also added a restart config to the docker-compose, the containers will restart after a reboot.


```
itm-ta1-server> db.info.count()
8
itm-ta1-server> db.probe_responses.count()
57937
itm-ta1-server> db.scenarios.count()
10
itm-ta1-server> db.sessions.count()
17949
```

You can test SoarTech using the Server Session ID (Delagator) and Target from:
https://darpaitm.caci.com/dre-results/rq1
(Or any other session dependent endpoint)

i.e.
```
curl --location 'https://darpaitm.caci.com/soartech/api/v1/alignment/session?session_id=82cd263e-177c-42bd-9026-98ff7fb022bb&target_id=qol-synth-LowCluster&population=false'

curl --location 'https://darpaitm.caci.com/soartech/api/v1/alignment/session?session_id=90603acb-7fdd-4133-a9ac-ad019176eed9&target_id=vol-human-7040555-SplitEvenBinary&population=false'

curl --location 'https://darpaitm.caci.com/soartech/api/v1/alignment/session?session_id=eccf6a61-ca32-4ea1-8e6c-1a49b80e86a1&target_id=vol-human-3043871-SplitLowMulti&population=false'
```

**New IP's (should only matter when you're inside AWS)**
Jenkins: 10.216.38.60:8080
SoarTech: 10.216.38.25:8084
Adept: 10.216.38.101:8080

