### PR TITLE
kdma data uploaded from dashboard instead of post data collect

### DIFF
--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -368,6 +368,8 @@ class TextBasedScenariosPage extends Component {
 
         } else {
             await this.calcScore(scenario, 'soartech')
+            const kdma_data = await this.attachKdmaValue(scenario.serverSessionId, process.env.REACT_APP_SOARTECH_URL)
+            scenario.kdmas = kdma_data
         }
     }
 
@@ -407,6 +409,7 @@ class TextBasedScenariosPage extends Component {
             scenario.combinedAlignmentData = sortedAlignmentData
             scenario.combinedSessionId = this.state.combinedSessionId
             scenario.mostLeastAligned = combinedMostLeastAligned
+            scenario.kdmas = await this.attachKdmaValue(this.state.combinedSessionId, url)
             const sanitizedData = this.sanitizeKeys(scenario)
             await new Promise(resolve => {
                 this.setState({
@@ -421,6 +424,13 @@ class TextBasedScenariosPage extends Component {
                 });
             });
         }
+    }
+
+    attachKdmaValue = async (sessionId, url) => {
+        const endpoint = '/api/v1/computed_kdma_profile?session_id='
+        const response = await axios.get(`${url}${endpoint}${sessionId}`)
+        console.log(response)
+        return response.data
     }
 
     mostLeastAligned = async (sessionId, ta1, url, scenario) => {

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -429,7 +429,6 @@ class TextBasedScenariosPage extends Component {
     attachKdmaValue = async (sessionId, url) => {
         const endpoint = '/api/v1/computed_kdma_profile?session_id='
         const response = await axios.get(`${url}${endpoint}${sessionId}`)
-        console.log(response)
         return response.data
     }
 


### PR DESCRIPTION
[ITM-654](https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?assignee=60ba425da547eb00686ee0ce&selectedIssue=ITM-654)

Click through text based scenarios and then view results in `userScenarioResults`. Should see a field labeled `kdmas` that for adept has their ingroup bias score and the moral judgment score. Soartech should have a kde dropdown. This was previously added post data collect with script _0_2_6_ in ingest

[ITM-654]: https://nextcentury.atlassian.net/browse/ITM-654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ