### PR TITLE
ITM-681: Persist TA1 DRE data

### DIFF
--- a/dashboard-ui/.env
+++ b/dashboard-ui/.env
@@ -1,13 +1,32 @@
 REACT_APP_SURVEY_VERSION=4.0
-# DEV
-#REACT_APP_SOARTECH_URL=http://127.0.0.1:8084
-#REACT_APP_ADEPT_URL=http://127.0.0.1:8080
 
-# PROD with prod servers
+# Running local Dashboard against local TA1 Servers
+#REACT_APP_ADEPT_URL=http://127.0.0.1:8080
+#REACT_APP_SOARTECH_URL=http://127.0.0.1:8084
+
+#REACT_APP_ADEPT_DRE_URL=http://127.0.0.1:8087
+#REACT_APP_SOARTECH_DRE_URL=http://127.0.0.1:8086
+
+
+# Running Dashboard on AWS against AWS TA1 Prod Servers
+
+## Current Phase
 #REACT_APP_ADEPT_URL=http://10.216.38.101:8080
 #REACT_APP_SOARTECH_URL=http://10.216.38.125:8084
 
-# Using prod servers locally 
+## DRE
+#REACT_APP_ADEPT_DRE_URL=http://10.216.38.101:8087
+#REACT_APP_SOARTECH_DRE_URL=http://10.216.38.125:8086
+
+# Running local dashboard against AWS TA1 Prod Servers
+
+## Current Phase
 REACT_APP_ADEPT_URL=https://darpaitm.caci.com/adept
 REACT_APP_SOARTECH_URL=https://darpaitm.caci.com/soartech
+
+## DRE
+REACT_APP_ADEPT_DRE_URL=https://darpaitm.caci.com/adept_dre
+REACT_APP_SOARTECH_DRE_URL=https://darpaitm.caci.com/soartech_dre
+
+
 REACT_APP_EMAIL_SALT=j0Bpq6e1b0556pu935uBdu

--- a/dashboard-ui/.env
+++ b/dashboard-ui/.env
@@ -1,9 +1,12 @@
 REACT_APP_SURVEY_VERSION=4.0
 
 # Running local Dashboard against local TA1 Servers
+
+## Current Phase
 #REACT_APP_ADEPT_URL=http://127.0.0.1:8080
 #REACT_APP_SOARTECH_URL=http://127.0.0.1:8084
 
+## DRE
 #REACT_APP_ADEPT_DRE_URL=http://127.0.0.1:8087
 #REACT_APP_SOARTECH_DRE_URL=http://127.0.0.1:8086
 

--- a/dashboard-ui/src/components/AggregateResults/DataFunctions.js
+++ b/dashboard-ui/src/components/AggregateResults/DataFunctions.js
@@ -834,10 +834,10 @@ function populateDataSet(data) {
                 tmpSet['IO_KDMA_Sim'] = adept_sim_kdmas?.find((x) => x.kdma == 'Ingroup Bias')?.value;
                 const qol_sim_sid = data.getAllSimAlignmentByEval.find((x) => x?._id?.split('_')[0] == pid && x?.scenario_id?.includes('qol'))?.data?.alignment?.sid;
                 const qol_sim_kdma = data.getAllSimAlignmentByEval.find((x) => x?._id?.split('_')[0] == pid && x?.scenario_id?.includes('qol'))?.data?.alignment?.kdmas?.computed_kdma_profile?.find((x) => x.kdma == 'QualityOfLife');
-                tmpSet['QOL_KDMA_Sim'] = ['202409112'].includes(pid) ? '-' : (qol_sim_kdma ? 'link:' + process.env.REACT_APP_SOARTECH_URL + `/api/v1/kdma_profile_graph?session_id=${qol_sim_sid}&kde_type=rawscores` : '-');
+                tmpSet['QOL_KDMA_Sim'] = ['202409112'].includes(pid) ? '-' : (qol_sim_kdma ? 'link:' + process.env.REACT_APP_SOARTECH_DRE_URL + `/api/v1/kdma_profile_graph?session_id=${qol_sim_sid}&kde_type=rawscores` : '-');
                 const vol_sim_sid = data.getAllSimAlignmentByEval.find((x) => x?._id?.split('_')[0] == pid && x?.scenario_id?.includes('vol'))?.data?.alignment?.sid;
                 const vol_sim_kdma = data.getAllSimAlignmentByEval.find((x) => x?._id?.split('_')[0] == pid && x?.scenario_id?.includes('vol'))?.data?.alignment?.kdmas?.computed_kdma_profile?.find((x) => x.kdma == 'PerceivedQuantityOfLivesSaved');
-                tmpSet['VOL_KDMA_Sim'] = ['202409111', '202409112'].includes(pid) ? '-' : (vol_sim_kdma ? 'link:' + process.env.REACT_APP_SOARTECH_URL + `/api/v1/kdma_profile_graph?session_id=${vol_sim_sid}&kde_type=rawscores` : '-');
+                tmpSet['VOL_KDMA_Sim'] = ['202409111', '202409112'].includes(pid) ? '-' : (vol_sim_kdma ? 'link:' + process.env.REACT_APP_SOARTECH_DRE_URL + `/api/v1/kdma_profile_graph?session_id=${vol_sim_sid}&kde_type=rawscores` : '-');
                 const adept_text_kdmas = text_scenarios.find((x) => x?.scenario_id?.includes('DryRun'))?.kdmas;
                 if (Array.isArray(adept_text_kdmas)) {
                     tmpSet['MJ_KDMA_Text'] = adept_text_kdmas?.find((x) => x.kdma == 'Moral judgement')?.value;
@@ -845,10 +845,10 @@ function populateDataSet(data) {
                 }
                 const qol_text_sid = text_scenarios.find((x) => x?.scenario_id?.includes('qol'))?.serverSessionId;
                 const qol_text_kdma = text_scenarios?.find((x) => x?.scenario_id?.includes('qol'))?.kdmas?.computed_kdma_profile?.find((x) => x.kdma == 'QualityOfLife');
-                tmpSet['QOL_KDMA_Text'] = qol_text_kdma ? 'link:' + process.env.REACT_APP_SOARTECH_URL + `/api/v1/kdma_profile_graph?session_id=${qol_text_sid}&kde_type=rawscores` : '-';
+                tmpSet['QOL_KDMA_Text'] = qol_text_kdma ? 'link:' + process.env.REACT_APP_SOARTECH_DRE_URL + `/api/v1/kdma_profile_graph?session_id=${qol_text_sid}&kde_type=rawscores` : '-';
                 const vol_text_sid = text_scenarios.find((x) => x?.scenario_id?.includes('vol'))?.serverSessionId;
                 const vol_text_kdma = text_scenarios?.find((x) => x?.scenario_id?.includes('vol'))?.kdmas?.computed_kdma_profile?.find((x) => x.kdma == 'PerceivedQuantityOfLivesSaved');
-                tmpSet['VOL_KDMA_Text'] = vol_text_kdma ? 'link:' + process.env.REACT_APP_SOARTECH_URL + `/api/v1/kdma_profile_graph?session_id=${vol_text_sid}&kde_type=rawscores` : '-';
+                tmpSet['VOL_KDMA_Text'] = vol_text_kdma ? 'link:' + process.env.REACT_APP_SOARTECH_DRE_URL + `/api/v1/kdma_profile_graph?session_id=${vol_text_sid}&kde_type=rawscores` : '-';
             }
 
 

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -385,13 +385,13 @@ class TextBasedScenariosPage extends Component {
 
         } else {
             await this.calcScore(scenario, 'soartech')
-            const kdma_data = await this.attachKdmaValue(scenario.serverSessionId, process.env.REACT_APP_SOARTECH_URL)
+            const kdma_data = await this.attachKdmaValue(scenario.serverSessionId, process.env.REACT_APP_SOARTECH_DRE_URL)
             scenario.kdmas = kdma_data
         }
     }
 
     beginRunningSession = async (scenario) => {
-        const url = process.env.REACT_APP_ADEPT_URL;
+        const url = process.env.REACT_APP_ADEPT_DRE_URL;
         const sessionEndpoint = '/api/v1/new_session';
 
         try {
@@ -407,13 +407,13 @@ class TextBasedScenariosPage extends Component {
     }
 
     continueRunningSession = async (scenario) => {
-        const url = process.env.REACT_APP_ADEPT_URL;
+        const url = process.env.REACT_APP_ADEPT_DRE_URL;
 
         await this.submitResponses(scenario, scenario.scenario_id, url, this.state.combinedSessionId)
     }
 
     uploadAdeptScenarios = async (scenarios) => {
-        const url = process.env.REACT_APP_ADEPT_URL;
+        const url = process.env.REACT_APP_ADEPT_DRE_URL;
         const alignmentEndpoint = '/api/v1/alignment/session'
 
         const alignmentData = await Promise.all(
@@ -533,11 +533,11 @@ class TextBasedScenariosPage extends Component {
         let url, sessionEndpoint, alignmentEndpoint;
 
         if (alignmentType === 'adept') {
-            url = process.env.REACT_APP_ADEPT_URL;
+            url = process.env.REACT_APP_ADEPT_DRE_URL;
             sessionEndpoint = '/api/v1/new_session';
             alignmentEndpoint = '/api/v1/alignment/session';
         } else if (alignmentType === 'soartech') {
-            url = process.env.REACT_APP_SOARTECH_URL;
+            url = process.env.REACT_APP_SOARTECH_DRE_URL;
             sessionEndpoint = '/api/v1/new_session?user_id=default_user';
             alignmentEndpoint = '/api/v1/alignment/session';
         } else {

--- a/docker_setup/resources/nginx.conf
+++ b/docker_setup/resources/nginx.conf
@@ -161,12 +161,27 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
+    location /soartech_dre/ {
+      # proxy_pass CANNOT contain variable for this to work
+      proxy_pass http://10.216.38.25:8086/;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
     location /adept/ {
      # proxy_pass CANNOT contain variable for this to work
       proxy_pass http://10.216.38.101:8080/;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
+
+    location /adept_dre/ {
+     # proxy_pass CANNOT contain variable for this to work
+      proxy_pass http://10.216.38.101:8087/;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
 
   }
 


### PR DESCRIPTION
SoarTech requires a wipe of the DB for the new scenarios and we need to persist SoarTech DRE data
There are now DRE and Current Eval end points for ADEPT/SoarTech.

These changes are live on PROD, you can review the changes there.  If all is right, should look exactly the same.

Please note the .env changes for future developemet:

```
## Current Phase
REACT_APP_ADEPT_URL=https://darpaitm.caci.com/adept
REACT_APP_SOARTECH_URL=https://darpaitm.caci.com/soartech

## DRE
REACT_APP_ADEPT_DRE_URL=https://darpaitm.caci.com/adept_dre
REACT_APP_SOARTECH_DRE_URL=https://darpaitm.caci.com/soartech_dre
```

End point examples:
SoarTech
[darpaitm.caci.com/soartech/api/v1/alignment_targets](https://darpaitm.caci.com/soartech/api/v1/alignment_targets)
[darpaitm.caci.com/soartech_dre/api/v1/alignment_targets](https://darpaitm.caci.com/soartech_dre/api/v1/alignment_targets)

Adept
[darpaitm.caci.com/adept/api/v1/alignment_target_ids](https://darpaitm.caci.com/adept/api/v1/alignment_target_ids)
[darpaitm.caci.com/adept_dre/api/v1/alignment_target_ids](https://darpaitm.caci.com/adept_dre/api/v1/alignment_target_ids)

Changes:
1. Added new URL's to .env
2. Updated the UI to reflect the URL/.env Updates
3. NGINX was updated to add new routes