### PR TITLE
add option to download filtered data only (rq pages)

### DIFF
--- a/dashboard-ui/src/components/DRE-Research/tables/download-buttons.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/download-buttons.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { exportToExcel } from "../utils";
+import '../../SurveyResults/resultsTable.css';
+
+export function DownloadButtons({ formattedData, filteredData, HEADERS, fileName, openModal }) {
+    return (
+        <div className={"option-section " + (filteredData.length < formattedData.length ? "adjusted-margin" : "")}>
+            {filteredData.length < formattedData.length ? <div className="downloadGroup">
+                <button className='downloadBtn' onClick={() => exportToExcel(fileName, formattedData, HEADERS)}>Download All Data</button>
+                <button className='downloadBtn' onClick={() => exportToExcel(fileName + ' (filtered)', filteredData, HEADERS)}>Download Filtered Data</button>
+            </div> :
+                <button className='downloadBtn' onClick={() => exportToExcel(fileName, formattedData, HEADERS)}>Download All Data</button>
+            }
+            <button className='downloadBtn' onClick={openModal}>View Variable Definitions</button>
+        </div>
+    );
+}

--- a/dashboard-ui/src/components/DRE-Research/tables/rq1-rq3.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq1-rq3.jsx
@@ -8,6 +8,7 @@ import { Autocomplete, Modal, TextField } from "@mui/material";
 import definitionXLFile from '../variables/Variable Definitions RQ1_RQ3.xlsx';
 import definitionPDFFile from '../variables/Variable Definitions RQ1_RQ3.pdf';
 import { exportToExcel, getRQ134Data } from "../utils";
+import { DownloadButtons } from "./download-buttons";
 
 
 const GET_PARTICIPANT_LOG = gql`
@@ -236,10 +237,7 @@ export function RQ13() {
                     onChange={(_, newVal) => setDelMilFilters(newVal)}
                 />
             </div>
-            <div className="option-section">
-                <button className='downloadBtn' onClick={() => exportToExcel('RQ-1_and_RQ-3 data', formattedData, HEADERS)}>Download All Data</button>
-                <button className='downloadBtn' onClick={openModal}>View Variable Definitions</button>
-            </div>
+            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-1_and_RQ-3 data'} openModal={openModal} />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/DRE-Research/tables/rq1-rq3.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq1-rq3.jsx
@@ -7,7 +7,7 @@ import CloseIcon from '@material-ui/icons/Close';
 import { Autocomplete, Modal, TextField } from "@mui/material";
 import definitionXLFile from '../variables/Variable Definitions RQ1_RQ3.xlsx';
 import definitionPDFFile from '../variables/Variable Definitions RQ1_RQ3.pdf';
-import { exportToExcel, getRQ134Data } from "../utils";
+import { getRQ134Data } from "../utils";
 import { DownloadButtons } from "./download-buttons";
 
 

--- a/dashboard-ui/src/components/DRE-Research/tables/rq21.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq21.jsx
@@ -7,7 +7,8 @@ import definitionXLFile from '../variables/Variable Definitions RQ2.1.xlsx';
 import definitionPDFFile from '../variables/Variable Definitions RQ2.1.pdf';
 import { useQuery } from 'react-apollo'
 import gql from "graphql-tag";
-import { ADM_NAME_MAP, exportToExcel, getAlignments } from "../utils";
+import { ADM_NAME_MAP, getAlignments } from "../utils";
+import { DownloadButtons } from "./download-buttons";
 
 const HEADERS = ['TA1_Name', 'Source', 'Attribute', 'Scenario', 'Group_Target', 'Decision_Maker', 'Alignment score (Individual|Group_target) or (ADM|group_target)']
 
@@ -275,10 +276,7 @@ export function RQ21() {
                     onChange={(_, newVal) => setDecisionMakerFilters(newVal)}
                 />
             </div>
-            <div className="option-section">
-                <button className='downloadBtn' onClick={() => exportToExcel('RQ-21 data', formattedData, HEADERS)}>Download All Data</button>
-                <button className='downloadBtn' onClick={openModal}>View Variable Definitions</button>
-            </div>
+            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-21 data'} openModal={openModal} />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/DRE-Research/tables/rq22-rq23.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq22-rq23.jsx
@@ -9,6 +9,7 @@ import definitionXLFile from '../variables/Variable Definitions RQ2.2_2.3.xlsx';
 import definitionPDFFile from '../variables/Variable Definitions RQ2.2_2.3.pdf';
 import { ADM_NAME_MAP, exportToExcel } from "../utils";
 import { isDefined } from "../../AggregateResults/DataFunctions";
+import { DownloadButtons } from "./download-buttons";
 
 const getAdmData = gql`
     query getAllHistoryByEvalNumber($evalNumber: Float!){
@@ -263,11 +264,7 @@ export function RQ2223() {
                     onChange={(_, newVal) => setTargetTypeFilters(newVal)}
                 />
             </div>
-
-            <div className="option-section">
-                <button className='downloadBtn' onClick={() => exportToExcel('RQ-22_and_RQ-23 data', formattedData, HEADERS)}>Download All Data</button>
-                <button className='downloadBtn' onClick={openModal}>View Variable Definitions</button>
-            </div>
+            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-22_and_RQ-23 data'} openModal={openModal} />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/DRE-Research/tables/rq22-rq23.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq22-rq23.jsx
@@ -7,7 +7,7 @@ import CloseIcon from '@material-ui/icons/Close';
 import { Autocomplete, TextField, Modal } from "@mui/material";
 import definitionXLFile from '../variables/Variable Definitions RQ2.2_2.3.xlsx';
 import definitionPDFFile from '../variables/Variable Definitions RQ2.2_2.3.pdf';
-import { ADM_NAME_MAP, exportToExcel } from "../utils";
+import { ADM_NAME_MAP } from "../utils";
 import { isDefined } from "../../AggregateResults/DataFunctions";
 import { DownloadButtons } from "./download-buttons";
 

--- a/dashboard-ui/src/components/DRE-Research/tables/rq5.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq5.jsx
@@ -9,6 +9,7 @@ import { useQuery } from 'react-apollo'
 import gql from "graphql-tag";
 import { isDefined } from "../../AggregateResults/DataFunctions";
 import { exportToExcel, getAlignments } from "../utils";
+import { DownloadButtons } from "./download-buttons";
 
 const GET_PARTICIPANT_LOG = gql`
     query GetParticipantLog {
@@ -325,10 +326,7 @@ export function RQ5() {
                     onChange={(_, newVal) => setGroupTargetFilters(newVal)}
                 />
             </div>
-            <div className="option-section">
-                <button className='downloadBtn' onClick={() => exportToExcel('RQ-5 data', formattedData, HEADERS)}>Download All Data</button>
-                <button className='downloadBtn' onClick={openModal}>View Variable Definitions</button>
-            </div>
+            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-5 data'} openModal={openModal} />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/DRE-Research/tables/rq5.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq5.jsx
@@ -8,7 +8,7 @@ import definitionPDFFile from '../variables/Variable Definitions RQ5.pdf';
 import { useQuery } from 'react-apollo'
 import gql from "graphql-tag";
 import { isDefined } from "../../AggregateResults/DataFunctions";
-import { exportToExcel, getAlignments } from "../utils";
+import { getAlignments } from "../utils";
 import { DownloadButtons } from "./download-buttons";
 
 const GET_PARTICIPANT_LOG = gql`

--- a/dashboard-ui/src/components/DRE-Research/tables/rq6.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq6.jsx
@@ -8,6 +8,7 @@ import definitionPDFFile from '../variables/Variable Definitions RQ6.pdf';
 import { useQuery } from 'react-apollo'
 import gql from "graphql-tag";
 import { exportToExcel, getAlignments } from "../utils";
+import { DownloadButtons } from "./download-buttons";
 
 const GET_PARTICIPANT_LOG = gql`
     query GetParticipantLog {
@@ -202,10 +203,7 @@ export function RQ6() {
                     onChange={(_, newVal) => setScenarioFilters(newVal)}
                 />
             </div>
-            <div className="option-section">
-                <button className='downloadBtn' onClick={() => exportToExcel('RQ-6 data', formattedData, HEADERS)}>Download All Data</button>
-                <button className='downloadBtn' onClick={openModal}>View Variable Definitions</button>
-            </div>
+            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-6 data'} openModal={openModal} />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/DRE-Research/tables/rq6.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq6.jsx
@@ -7,7 +7,7 @@ import definitionXLFile from '../variables/Variable Definitions RQ6.xlsx';
 import definitionPDFFile from '../variables/Variable Definitions RQ6.pdf';
 import { useQuery } from 'react-apollo'
 import gql from "graphql-tag";
-import { exportToExcel, getAlignments } from "../utils";
+import { getAlignments } from "../utils";
 import { DownloadButtons } from "./download-buttons";
 
 const GET_PARTICIPANT_LOG = gql`

--- a/dashboard-ui/src/components/DRE-Research/tables/rq8.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq8.jsx
@@ -8,6 +8,7 @@ import definitionPDFFile from '../variables/Variable Definitions RQ8.pdf';
 import { useQuery } from 'react-apollo'
 import gql from "graphql-tag";
 import { exportToExcel, getAlignments } from "../utils";
+import { DownloadButtons } from "./download-buttons";
 
 
 const GET_HUMAN_RESULTS = gql`
@@ -238,10 +239,7 @@ export function RQ8() {
                     onChange={(_, newVal) => setScenarioFilters(newVal)}
                 />
             </div>
-            <div className="option-section">
-                <button className='downloadBtn' onClick={() => exportToExcel('RQ-8 data', formattedData, HEADERS)}>Download All Data</button>
-                <button className='downloadBtn' onClick={openModal}>View Variable Definitions</button>
-            </div>
+            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-8 data'} openModal={openModal} />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/DRE-Research/tables/rq8.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq8.jsx
@@ -7,7 +7,7 @@ import definitionXLFile from '../variables/Variable Definitions RQ8.xlsx';
 import definitionPDFFile from '../variables/Variable Definitions RQ8.pdf';
 import { useQuery } from 'react-apollo'
 import gql from "graphql-tag";
-import { exportToExcel, getAlignments } from "../utils";
+import { getAlignments } from "../utils";
 import { DownloadButtons } from "./download-buttons";
 
 

--- a/dashboard-ui/src/components/SurveyResults/resultsTable.css
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.css
@@ -112,6 +112,11 @@
     gap: 8px;
 }
 
+.adjusted-margin {
+    margin-top: -32px;
+    height: 72px;
+}
+
 .checkboxes {
     display: flex;
     flex-direction: row;
@@ -146,4 +151,10 @@
 
 .filteredText {
     margin-left: 12px !important;
+}
+
+.downloadGroup {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
 }


### PR DESCRIPTION
Check out the RQ tables. The page should look the same until you turn on a filter. When a filter turns on, the "Download Filtered Data" button should show up. I've put it under the Download All button to help reduce the length-wise clutter in the filter section. When filters are off, the button should disappear again. 

Make sure all the table buttons work as expected.