### PR TITLE
IO4 Parallax Fix

### DIFF
--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -316,8 +316,8 @@ class SurveyPage extends Component {
                 const baselineAdm = allPages.find((x) => x.admAuthor == expectedAuthor && x.scenarioIndex == expectedScenario && x.admType == 'baseline' && x.admAlignment == baselineADMTarget);
                 // aligned
                 if (expectedScenario.includes('DryRun')) {
-                    alignedADMTarget = alignedADMTarget.slice(0, -1) + '.' + alignedADMTarget.slice(-1);
-                    misalignedADMTarget = misalignedADMTarget.slice(0, -1) + '.' + misalignedADMTarget.slice(-1);
+                    if (alignedADMTarget) alignedADMTarget = alignedADMTarget?.slice(0, -1) + '.' + alignedADMTarget?.slice(-1);
+                    if (misalignedADMTarget) misalignedADMTarget = misalignedADMTarget?.slice(0, -1) + '.' + misalignedADMTarget?.slice(-1);
                 }
                 const alignedAdm = allPages.find((x) => x.admAuthor == expectedAuthor && x.scenarioIndex == expectedScenario && x.admType == 'aligned' && x.admAlignment == alignedADMTarget);
                 // misaligned

--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -316,8 +316,8 @@ class SurveyPage extends Component {
                 const baselineAdm = allPages.find((x) => x.admAuthor == expectedAuthor && x.scenarioIndex == expectedScenario && x.admType == 'baseline' && x.admAlignment == baselineADMTarget);
                 // aligned
                 if (expectedScenario.includes('DryRun')) {
-                    if (alignedADMTarget) alignedADMTarget = alignedADMTarget?.slice(0, -1) + '.' + alignedADMTarget?.slice(-1);
-                    if (misalignedADMTarget) misalignedADMTarget = misalignedADMTarget?.slice(0, -1) + '.' + misalignedADMTarget?.slice(-1);
+                    if (alignedADMTarget && !alignedADMTarget.includes('.')) alignedADMTarget = alignedADMTarget?.slice(0, -1) + '.' + alignedADMTarget?.slice(-1);
+                    if (misalignedADMTarget && !misalignedADMTarget.includes('.')) misalignedADMTarget = misalignedADMTarget?.slice(0, -1) + '.' + misalignedADMTarget?.slice(-1);
                 }
                 const alignedAdm = allPages.find((x) => x.admAuthor == expectedAuthor && x.scenarioIndex == expectedScenario && x.admType == 'aligned' && x.admAlignment == alignedADMTarget);
                 // misaligned

--- a/dashboard-ui/src/components/Survey/surveyUtils.js
+++ b/dashboard-ui/src/components/Survey/surveyUtils.js
@@ -650,8 +650,9 @@ export function getParallaxAdms(surveyVersion, scenario, ioTargets, mjTargets, q
                     alignedTarget = null;
                 }
             } else {
-                target = ioTargets['response'].find((t) => t.target == 'ADEPT-DryRun-Ingroup Bias-08').target;
-                if (parseFloat(ioTargets[0].target.split('Bias-')[1]) > 6) {
+                target = 'ADEPT-DryRun-Ingroup Bias-08';
+                const mostAligned = Object.keys(ioTargets['response'][0])[0].split('Bias-')[1].slice(-1);
+                if (parseFloat(mostAligned) > 6) {
                     alignedTarget = target;
                     misalignedTarget = null;
                 }

--- a/dashboard-ui/src/components/Survey/surveyUtils.js
+++ b/dashboard-ui/src/components/Survey/surveyUtils.js
@@ -299,9 +299,9 @@ function getValidADM(allTargets, targets, cols1to3, set1, set2, set3) {
         let baselineOverlap = false;
         let alignedOverlap = false;
         while (cols1to3.includes(adeptSlice(misalignedTarget)) ||
-            (set1.includes(misalignedTarget) && set1.includes(alignedTarget)) ||
-            (set2.includes(misalignedTarget) && set2.includes(alignedTarget)) ||
-            (set3.includes(misalignedTarget) && set3.includes(alignedTarget))) {
+            (set1.includes(adeptSlice(misalignedTarget)) && set1.includes(adeptSlice(alignedTarget))) ||
+            (set2.includes(adeptSlice(misalignedTarget)) && set2.includes(adeptSlice(alignedTarget))) ||
+            (set3.includes(adeptSlice(misalignedTarget)) && set3.includes(adeptSlice(alignedTarget)))) {
             i += 1;
             if (targets.response) {
                 misalignedTarget = Object.keys(targets.response[targets.response.length - i])[0];

--- a/dashboard-ui/src/components/Survey/surveyUtils.js
+++ b/dashboard-ui/src/components/Survey/surveyUtils.js
@@ -639,6 +639,7 @@ export function getParallaxAdms(surveyVersion, scenario, ioTargets, mjTargets, q
         case 'DryRunEval-IO4-eval':
             if (surveyVersion == 4) {
                 // NOTE: Only 1 adm to be found here!! Special case!!
+                // load 1.0 as the second ADM. label it as "aligned" if most aligned is 0.5 to 1.0; otherwise label "misaligned"
                 target = ioTargets.find((t) => t.target == 'ADEPT-DryRun-Ingroup Bias-1.0').target;
                 if (parseFloat(ioTargets[0].target.split('Bias-')[1]) > 0.4) {
                     alignedTarget = target;
@@ -649,8 +650,8 @@ export function getParallaxAdms(surveyVersion, scenario, ioTargets, mjTargets, q
                     alignedTarget = null;
                 }
             } else {
-                target = ioTargets.find((t) => t.target == 'ADEPT-DryRun-Ingroup Bias-0.8').target;
-                if (parseFloat(ioTargets[0].target.split('Bias-')[1]) > 0.4) {
+                target = ioTargets['response'].find((t) => t.target == 'ADEPT-DryRun-Ingroup Bias-08').target;
+                if (parseFloat(ioTargets[0].target.split('Bias-')[1]) > 6) {
                     alignedTarget = target;
                     misalignedTarget = null;
                 }

--- a/dashboard-ui/src/components/Survey/surveyUtils.js
+++ b/dashboard-ui/src/components/Survey/surveyUtils.js
@@ -649,13 +649,15 @@ export function getParallaxAdms(surveyVersion, scenario, ioTargets, mjTargets, q
                     alignedTarget = null;
                 }
             } else {
-                cols1to3 = ['ADEPT-DryRun-Ingroup Bias-0.2', 'ADEPT-DryRun-Ingroup Bias-0.3', 'ADEPT-DryRun-Ingroup Bias-0.4', 'ADEPT-DryRun-Ingroup Bias-0.5', 'ADEPT-DryRun-Ingroup Bias-0.6'];
-                set1 = ['ADEPT-DryRun-Ingroup Bias-0.7', 'ADEPT-DryRun-Ingroup Bias-0.8'];
-                validAdms = getValidADM(getAllIoTargets(surveyVersion), ioTargets, cols1to3, set1, [], []);
-                alignedTarget = validAdms['aligned'];
-                misalignedTarget = validAdms['misaligned'];
-                alignedStatus = validAdms['alignedStatus'];
-                misalignedStatus = validAdms['misalignedStatus'];
+                target = ioTargets.find((t) => t.target == 'ADEPT-DryRun-Ingroup Bias-0.8').target;
+                if (parseFloat(ioTargets[0].target.split('Bias-')[1]) > 0.4) {
+                    alignedTarget = target;
+                    misalignedTarget = null;
+                }
+                else {
+                    misalignedTarget = target;
+                    alignedTarget = null;
+                }
             }
             break;
         case 'DryRunEval-IO5-eval':


### PR DESCRIPTION
Important fix that does two things:
1. Makes sure IO4 parallax shows only 2 ADMs (baseline and either aligned/misaligned, just like DRE). Check the comparison page as well.
2. Fixes a bug in survey.jsx that does not allow for only 2 ADMs and will crash the page when that occurs. 

To test, you'll need a participant with AD-2 in the plog and adm order 1 or 4. You can edit a participant you already tested with (in the participant log) to get this combination. Make sure the text scenarios have been filled out. Run through until you find IO4. Make sure only 2 adms show up, make sure you can get through it, make sure the results look good.