### PR TITLE
query string edit so that phase 1 adms load in without have to reclick

### DIFF
--- a/dashboard-ui/src/components/Results/resultsTable.jsx
+++ b/dashboard-ui/src/components/Results/resultsTable.jsx
@@ -57,7 +57,7 @@ class ResultsTable extends React.Component {
             adm: "",
             scenario: "",
             evalNumber: 5,
-            ADMQueryString: "history.parameters.ADM Name",
+            ADMQueryString: "history.parameters.adm_name",
             showScrollButton: false,
             alignmentTarget: null
         }


### PR DESCRIPTION
https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?selectedIssue=ITM-728

http://localhost:3000/results

Before you had to click on 'Phase 1' again for the adms to load in. Now you should be able to select a scenario and have the adms popup without any additional clicking.