### PR TITLE
Duplicate pid issue

### DIFF
--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -297,7 +297,7 @@ export class App extends React.Component {
                 }
                 else {
                     // still want to record distinction between civ and mil but it should no longer effect the actual pid
-                    const newPid = Math.max(...pLog.filter((x) => 
+                    const newPid = Math.max(...pLog.filter((x) =>
                         !["202409113A", "202409113B"].includes(x['ParticipantID'])
                     ).map((x) => Number(x['ParticipantID']))) + 1;
                     const setNum = (newPid - (classification == 'Civ' ? 5 : 1)) % 12;
@@ -370,12 +370,15 @@ export class App extends React.Component {
                                                             </div>
                                                         )}
                                                     </Mutation>
-                                                    <Mutation mutation={ADD_PARTICIPANT} onCompleted={() => {
-                                                        this.setState({ pid: this.state.newParticipantData['ParticipantID'] }, () => {
-                                                            history.push("/text-based?pid=" + this.state.pid + "&class=" + this.state.newParticipantData['Type']);
+                                                    <Mutation mutation={ADD_PARTICIPANT} onCompleted={(data) => {
+                                                        console.log('Server response:', data);
+                                                        const finalPid = data?.addNewParticipantToLog?.ops?.[0]?.ParticipantID;
+                                                        console.log('Using final PID from server:', finalPid);
+
+                                                        this.setState({ pid: finalPid }, () => {
+                                                            history.push("/text-based?pid=" + finalPid + "&class=" + this.state.newParticipantData['Type']);
                                                         });
-                                                    }
-                                                    }>
+                                                    }}>
                                                         {(addNewParticipantToLog) => (
                                                             <div>
                                                                 <button ref={this.addPButtonRef} hidden onClick={(e) => {

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -4,6 +4,22 @@ const { dashboardDB } = require('./server.mongo');
 // const { MONGO_DB } = require('./config');
 const { GraphQLScalarType, Kind } = require("graphql");
 
+async function createUniqueIndex() {
+  try {
+      await dashboardDB.db.collection('participantLog').createIndex(
+          { "ParticipantID": 1 }, 
+          { unique: true }
+      );
+      console.log("Unique index on ParticipantID created successfully");
+  } catch (error) {
+      if (error.code !== 85) { // Index already exists
+          console.error("Error creating unique index:", error);
+      }
+  }
+}
+
+createUniqueIndex().catch(console.error);
+
 const typeDefs = gql`
   scalar JSON
 
@@ -537,8 +553,74 @@ const resolvers = {
       }
     },
     addNewParticipantToLog: async (obj, args, context, inflow) => {
-      return await dashboardDB.db.collection('participantLog').insertOne(args.participantData);
-    },
+      try {
+          const timestamp = new Date().toISOString();
+          console.log(`[${timestamp}] ====== Starting new participant addition ======`);
+          console.log(`[${timestamp}] Initial participant data:`, {
+              email: args.participantData.hashedEmail.substring(0, 10) + '...',
+              type: args.participantData.Type,
+              proposedPID: args.participantData.ParticipantID
+          });
+
+          if (!Number.isFinite(args.participantData.ParticipantID)) {
+              console.log(`[${timestamp}] Invalid PID detected, querying for highest PID`);
+              
+              const highestPidDoc = await dashboardDB.db.collection('participantLog')
+                  .find({
+                      ParticipantID: { $type: "number" }
+                  })
+                  .sort({ ParticipantID: -1 })
+                  .limit(1)
+                  .toArray();
+  
+              console.log(`[${timestamp}] Current highest PID record:`, highestPidDoc[0]?.ParticipantID || 'none found');
+  
+              const nextPid = highestPidDoc.length > 0 ? Number(highestPidDoc[0].ParticipantID) + 1 : 202411301;
+              console.log(`[${timestamp}] Generated new PID: ${nextPid}`);
+              
+              args.participantData.ParticipantID = nextPid;
+          }
+  
+          // try to insert with our validated PID
+          try {
+              console.log(`[${timestamp}] Attempting insert for PID: ${args.participantData.ParticipantID}`);
+              const result = await dashboardDB.db.collection('participantLog').insertOne(args.participantData);
+              console.log(`[${timestamp}] Insert SUCCESS for PID: ${args.participantData.ParticipantID}`);
+              return result;
+          } catch (error) {
+              if (error.code === 11000) { // ff we hit a duplicate
+                  console.log(`[${timestamp}] DUPLICATE KEY ERROR for PID: ${args.participantData.ParticipantID}`);
+                  console.log(`[${timestamp}] Retrying with new PID generation`);
+                  
+                  // get absolute latest highest PID
+                  const highestPidDoc = await dashboardDB.db.collection('participantLog')
+                      .find({
+                          ParticipantID: { $type: "number" }
+                      })
+                      .sort({ ParticipantID: -1 })
+                      .limit(1)
+                      .toArray();
+  
+                  const retryPid = Number(highestPidDoc[0].ParticipantID) + 1;
+                  console.log(`[${timestamp}] New retry PID generated: ${retryPid}`);
+                  
+                  args.participantData.ParticipantID = retryPid;
+                  
+                  console.log(`[${timestamp}] Attempting final insert with PID: ${retryPid}`);
+                  const retryResult = await dashboardDB.db.collection('participantLog')
+                      .insertOne(args.participantData);
+                  console.log(`[${timestamp}] Retry insert SUCCESS for PID: ${retryPid}`);
+                  return retryResult;
+              }
+              console.error(`[${timestamp}] NON-DUPLICATE ERROR:`, error);
+              throw error;
+          }
+      } catch (error) {
+          const timestamp = new Date().toISOString();
+          console.error(`[${timestamp}] CRITICAL ERROR in addNewParticipantToLog:`, error);
+          throw error;
+      }
+  },
     updateEvalIdsByPage: async (obj, args, context, inflow) => {
       // hmm can't do this with graphql?      
       // var field = args["field"];


### PR DESCRIPTION
We had an issue with two of the same participant ids being generated. `participantLog` will now be indexed by `ParticipantID` field. GQL should catch an error if two with the same pid try to get added to the log and then retry with the same PID + 1. 

To test:
First try to recreate the bug. On dev I was able to recreate by going to the text scenario email login in two different chrome tabs and hitting start in rapid succession. 

Rebuild your gql container, if you look at the docker logs you should see this message 
`Unique index on ParticipantID created successfully`

Then refresh your two tabs and give it another go. If it is working correctly you should see logs like these in the gql container:
<img width="1039" alt="Screenshot 2024-11-25 at 6 09 34 PM" src="https://github.com/user-attachments/assets/dace5458-9d20-43f9-96e0-7d3aea23e8a8">

And then the newly generated participant ids in the participant log:
<img width="606" alt="Screenshot 2024-11-25 at 6 10 01 PM" src="https://github.com/user-attachments/assets/dafafe7c-662e-49f7-838f-9783eb879070">

_**Be sure that these proper PIDs are also reflected in the URL of your tabs**_
