### PR TITLE
Itm 730 no class

### DIFF
--- a/dashboard-ui/src/components/Account/login.jsx
+++ b/dashboard-ui/src/components/Account/login.jsx
@@ -16,13 +16,11 @@ class LoginApp extends React.Component {
         this.state = {
             userName: "",
             password: "",
-            classification: "",
             error: null,
             createUserName: "",
             createPassword: "",
             createEmail: "",
             textEmail: "",
-            textClassification: "",
             forgotEmail: "",
             loginFailed: false,
             createAccountFailed: false,
@@ -35,12 +33,12 @@ class LoginApp extends React.Component {
 
     setupPID = async (e) => {
         e.preventDefault();  // Prevent the default form submission
-        const { textEmail, textClassification } = this.state;
+        const { textEmail } = this.state;
 
         // removing leading and trailing white space 
         const trimmedEmail = textEmail.trim().toLowerCase();
 
-        if (!textEmail || !textClassification) {
+        if (!textEmail) {
             $("#text-entry-feedback").addClass("feedback-display").text("All fields are required.");
             return; // Stop the function if any field is empty
         }
@@ -53,7 +51,7 @@ class LoginApp extends React.Component {
 
         $("#text-entry-feedback").removeClass("feedback-display");
         try {
-            this.props.participantLoginHandler(hashedEmail, textClassification, this.props.updatePLog);
+            this.props.participantLoginHandler(hashedEmail, this.props.updatePLog);
         } catch (err) {
             $("#text-entry-feedback").addClass("feedback-display");
             this.setState({ error: err.message, pidCreationFailed: true });
@@ -162,10 +160,6 @@ class LoginApp extends React.Component {
 
     onChangeTextEmail = ({ target }) => {
         this.setState({ textEmail: target.value });
-    };
-
-    onChangeClassification = ({ target }) => {
-        this.setState({ textClassification: target.value });
     };
 
     showSignIn = (evt) => {
@@ -321,19 +315,6 @@ class LoginApp extends React.Component {
                                                 <div className="input-with-btn">
                                                     <input className="form-control form-control-lg" required placeholder="Email" type={this.state.viewHiddenEmail ? "text" : "password"} id="emailOnly" value={this.state.textEmail} onChange={this.onChangeTextEmail} />
                                                     <button className="blank-btn" type='button' onClick={this.toggleVisibility}>{this.state.viewHiddenEmail ? <VisibilityIcon /> : <VisibilityOffIcon />}</button>
-                                                </div>
-                                            </div>
-                                            <div className="form-group">
-                                                <div className="input-login-header">Classification</div>
-                                                <div className='radios'>
-                                                    <div>
-                                                        <input type="radio" id="Mil" name="classification" value="Mil" onChange={this.onChangeClassification} required />
-                                                        <label htmlFor="Mil">Military</label>
-                                                    </div>
-                                                    <div>
-                                                        <input type="radio" id="Civ" name="classification" value="Civ" onChange={this.onChangeClassification} />
-                                                        <label htmlFor="Civ">Civilian</label>
-                                                    </div>
                                                 </div>
                                             </div>
                                             <div className="form-group">

--- a/dashboard-ui/src/components/Account/pidLookup.jsx
+++ b/dashboard-ui/src/components/Account/pidLookup.jsx
@@ -15,7 +15,6 @@ const GET_PARTICIPANT_LOG = gql`
 export function PidLookup() {
 
     const [viewHiddenEmail, setViewHiddenEmail] = React.useState(false);
-    const [classification, setClassification] = React.useState("");
     const [email, setEmail] = React.useState("");
     const [pid, setPid] = React.useState("");
     const [sim1, setSim1] = React.useState("")
@@ -29,7 +28,7 @@ export function PidLookup() {
             const trimmedEmail = email.trim().toLowerCase();
             const hashedEmail = bcrypt.hashSync(trimmedEmail, "$2a$10$" + process.env.REACT_APP_EMAIL_SALT);
             const matchingParticipant = dataParticipantLog.getParticipantLog.find(
-                (x) => x.hashedEmail == hashedEmail && classification == x.Type
+                (x) => x.hashedEmail == hashedEmail
             );
 
             if (matchingParticipant) {
@@ -55,10 +54,6 @@ export function PidLookup() {
         setViewHiddenEmail(!viewHiddenEmail);
     };
 
-    const onChangeClassification = ({ target }) => {
-        setClassification(target.value);
-    };
-
     const onChangeEmail = ({ target }) => {
         setEmail(target.value);
     };
@@ -82,19 +77,6 @@ export function PidLookup() {
                         <div className="input-with-btn">
                             <input className="form-control form-control-lg" required placeholder="Email" type={viewHiddenEmail ? "text" : "password"} id="emailOnly" value={email} onChange={onChangeEmail} />
                             <button className="blank-btn" type='button' onClick={toggleVisibility}>{viewHiddenEmail ? <VisibilityIcon /> : <VisibilityOffIcon />}</button>
-                        </div>
-                    </div>
-                    <div className="form-group">
-                        <div className="input-login-header">Classification</div>
-                        <div className='radios'>
-                            <div>
-                                <input type="radio" id="Mil" name="classification" value="Mil" onChange={onChangeClassification} required />
-                                <label htmlFor="Mil">Military</label>
-                            </div>
-                            <div>
-                                <input type="radio" id="Civ" name="classification" value="Civ" onChange={onChangeClassification} />
-                                <label htmlFor="Civ">Civilian</label>
-                            </div>
                         </div>
                     </div>
 

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -77,8 +77,7 @@ const ADD_PARTICIPANT = gql`
         addNewParticipantToLog(participantData: $participantData) 
     }`;
 
-const SURVEY_SETS = {
-    "Mil": [
+const SURVEY_SETS = [
         { "Text-1": "AD-1", "Text-2": "ST-1", "Sim-1": "AD-2", "Sim-2": "ST-2", "Del-1": "AD-3", "Del-2": "ST-3", "ADMOrder": 1 },
         { "Text-1": "ST-1", "Text-2": "AD-2", "Sim-1": "ST-2", "Sim-2": "AD-3", "Del-1": "ST-3", "Del-2": "AD-1", "ADMOrder": 2 },
         { "Text-1": "AD-2", "Text-2": "ST-2", "Sim-1": "AD-3", "Sim-2": "ST-3", "Del-1": "AD-1", "Del-2": "ST-1", "ADMOrder": 3 },
@@ -90,9 +89,7 @@ const SURVEY_SETS = {
         { "Text-1": "AD-2", "Text-2": "ST-2", "Sim-1": "AD-3", "Sim-2": "ST-3", "Del-1": "AD-1", "Del-2": "ST-1", "ADMOrder": 1 },
         { "Text-1": "ST-2", "Text-2": "AD-3", "Sim-1": "ST-3", "Sim-2": "AD-1", "Del-1": "ST-1", "Del-2": "AD-2", "ADMOrder": 2 },
         { "Text-1": "AD-3", "Text-2": "ST-3", "Sim-1": "AD-1", "Sim-2": "ST-1", "Del-1": "AD-2", "Del-2": "ST-2", "ADMOrder": 3 },
-        { "Text-1": "ST-3", "Text-2": "AD-1", "Sim-1": "ST-1", "Sim-2": "AD-2", "Del-1": "ST-2", "Del-2": "AD-3", "ADMOrder": 4 },
-    ],
-    "Civ": [
+    { "Text-1": "ST-3", "Text-2": "AD-1", "Sim-1": "ST-1", "Sim-2": "AD-2", "Del-1": "ST-2", "Del-2": "AD-3", "ADMOrder": 4 },
         { "Text-1": "AD-1", "Text-2": "ST-1", "Sim-1": "AD-2", "Sim-2": "ST-2", "Del-1": "AD-3", "Del-2": "ST-3", "ADMOrder": 3 },
         { "Text-1": "ST-1", "Text-2": "AD-2", "Sim-1": "ST-2", "Sim-2": "AD-3", "Del-1": "ST-3", "Del-2": "AD-1", "ADMOrder": 4 },
         { "Text-1": "AD-2", "Text-2": "ST-2", "Sim-1": "AD-3", "Sim-2": "ST-3", "Del-1": "AD-1", "Del-2": "ST-1", "ADMOrder": 1 },
@@ -104,9 +101,8 @@ const SURVEY_SETS = {
         { "Text-1": "AD-2", "Text-2": "ST-2", "Sim-1": "AD-3", "Sim-2": "ST-3", "Del-1": "AD-1", "Del-2": "ST-1", "ADMOrder": 3 },
         { "Text-1": "ST-2", "Text-2": "AD-3", "Sim-1": "ST-3", "Sim-2": "AD-1", "Del-1": "ST-1", "Del-2": "AD-2", "ADMOrder": 4 },
         { "Text-1": "AD-3", "Text-2": "ST-3", "Sim-1": "AD-1", "Sim-2": "ST-1", "Del-1": "AD-2", "Del-2": "ST-2", "ADMOrder": 1 },
-        { "Text-1": "ST-3", "Text-2": "AD-1", "Sim-1": "ST-1", "Sim-2": "AD-2", "Del-1": "ST-2", "Del-2": "AD-3", "ADMOrder": 2 },
-    ]
-}
+    { "Text-1": "ST-3", "Text-2": "AD-1", "Sim-1": "ST-1", "Sim-2": "AD-2", "Del-1": "ST-2", "Del-2": "AD-3", "ADMOrder": 2 }
+]
 
 
 function Home({ newState }) {
@@ -263,7 +259,7 @@ export class App extends React.Component {
         this.setState({ currentUser: userObject });
     }
 
-    participantLoginHandler(hashedEmail, classification) {
+    participantLoginHandler(hashedEmail) {
         // get fresh participant log from database to minimize race conditions
         setParticipantLogInStore(null);
         const sleep = (ms) => {
@@ -275,34 +271,33 @@ export class App extends React.Component {
             }
             this.setState({ loadPLog: false });
             const pLog = store.getState().participants.participantLog;
-            const foundParticipant = pLog.find((x) => x.hashedEmail == hashedEmail && classification == x.Type);
+            const foundParticipant = pLog.find((x) => x.hashedEmail == hashedEmail);
             if (foundParticipant) {
                 const pid = foundParticipant['ParticipantID'];
                 this.setState({ pid: pid }, () => {
-                    history.push("/text-based?pid=" + this.state.pid + "&class=" + classification);
+                    history.push("/text-based?pid=" + this.state.pid);
                 });
             }
             else {
                 // create a user account and get a pid for this user
-                const nextAvailablePid = pLog.find((x) => x.Type == classification && !x.claimed)?.['ParticipantID'];
+                const nextAvailablePid = pLog.find((x) => !x.claimed)?.['ParticipantID'];
                 if (isDefined(nextAvailablePid)) {
                     this.setState({ updatePLog: true, pLogUpdate: { updates: { hashedEmail: hashedEmail, claimed: true }, pid: nextAvailablePid } }, () => {
                         if (this.uploadButtonRef.current) {
                             this.uploadButtonRef.current.click();
                         }
                         this.setState({ pid: nextAvailablePid }, () => {
-                            history.push("/text-based?pid=" + this.state.pid + "&class=" + classification);
+                            history.push("/text-based?pid=" + this.state.pid);
                         });
                     });
                 }
                 else {
-                    // still want to record distinction between civ and mil but it should no longer effect the actual pid
                     const newPid = Math.max(...pLog.filter((x) =>
                         !["202409113A", "202409113B"].includes(x['ParticipantID'])
                     ).map((x) => Number(x['ParticipantID']))) + 1;
-                    const setNum = (newPid - (classification == 'Civ' ? 5 : 1)) % 12;
+                    const setNum = newPid % 24;
                     const participantData = {
-                        ...SURVEY_SETS[classification][setNum], "ParticipantID": newPid, "Type": classification,
+                        ...SURVEY_SETS[setNum], "ParticipantID": newPid, "Type": "emailParticipant",
                         "claimed": true, "simEntryCount": 0, "surveyEntryCount": 0, "textEntryCount": 0, "hashedEmail": hashedEmail
                     };
                     this.setState({ updatePLog: true, newParticipantData: participantData }, () => {
@@ -372,12 +367,17 @@ export class App extends React.Component {
                                                     </Mutation>
                                                     <Mutation mutation={ADD_PARTICIPANT} onCompleted={(data) => {
                                                         console.log('Server response:', data);
-                                                        const finalPid = data?.addNewParticipantToLog?.ops?.[0]?.ParticipantID;
-                                                        console.log('Using final PID from server:', finalPid);
+                                                        if (data?.addNewParticipantToLog == -1) {
+                                                            alert("This email address is taken. Please enter a different email.");
+                                                        }
+                                                        else {
+                                                            const finalPid = data?.addNewParticipantToLog?.ops?.[0]?.ParticipantID;
+                                                            console.log('Using final PID from server:', finalPid);
 
-                                                        this.setState({ pid: finalPid }, () => {
-                                                            history.push("/text-based?pid=" + finalPid + "&class=" + this.state.newParticipantData['Type']);
-                                                        });
+                                                            this.setState({ pid: finalPid }, () => {
+                                                                history.push("/text-based?pid=" + finalPid);
+                                                            });
+                                                        }
                                                     }}>
                                                         {(addNewParticipantToLog) => (
                                                             <div>

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -297,7 +297,7 @@ export class App extends React.Component {
                 }
                 else {
                     // still want to record distinction between civ and mil but it should no longer effect the actual pid
-                    const newPid = Math.max(...pLog.filter((x) => 
+                    const newPid = Math.max(...pLog.filter((x) =>
                         !["202409113A", "202409113B"].includes(x['ParticipantID'])
                     ).map((x) => Number(x['ParticipantID']))) + 1;
                     const setNum = (newPid - (classification == 'Civ' ? 5 : 1)) % 12;
@@ -370,12 +370,15 @@ export class App extends React.Component {
                                                             </div>
                                                         )}
                                                     </Mutation>
-                                                    <Mutation mutation={ADD_PARTICIPANT} onCompleted={() => {
-                                                        this.setState({ pid: this.state.newParticipantData['ParticipantID'] }, () => {
-                                                            history.push("/text-based?pid=" + this.state.pid + "&class=" + this.state.newParticipantData['Type']);
+                                                    <Mutation mutation={ADD_PARTICIPANT} onCompleted={(data) => {
+                                                        console.log('Server response:', data);
+                                                        const finalPid = data?.addNewParticipantToLog?.ops?.[0]?.ParticipantID;
+                                                        console.log('Using final PID from server:', finalPid);
+
+                                                        this.setState({ pid: finalPid }, () => {
+                                                            history.push("/text-based?pid=" + finalPid + "&class=" + this.state.newParticipantData['Type']);
                                                         });
-                                                    }
-                                                    }>
+                                                    }}>
                                                         {(addNewParticipantToLog) => (
                                                             <div>
                                                                 <button ref={this.addPButtonRef} hidden onClick={(e) => {

--- a/dashboard-ui/src/components/DRE-Research/utils.js
+++ b/dashboard-ui/src/components/DRE-Research/utils.js
@@ -154,7 +154,7 @@ export function getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dat
                 const entryObj = {};
                 entryObj['ADM Order'] = logData['ADMOrder'];
                 entryObj['Delegator_ID'] = pid;
-                entryObj['Delegator_grp'] = logData['Type'] == 'Civ' ? 'Civilian' : 'Military';
+                entryObj['Delegator_grp'] = logData['Type'] == 'Civ' ? 'Civilian' : logData['Type'] == 'Mil' ? 'Military' : logData['Type'];
                 const roles = res.results?.['Post-Scenario Measures']?.questions?.['What is your current role (choose all that apply):']?.['response'];
                 // override 102, who is military
                 entryObj['Delegator_mil'] = roles?.includes('Military Background') || pid == '202409102' ? 'yes' : 'no';

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -234,11 +234,10 @@ class TextBasedScenariosPage extends Component {
         document.addEventListener('keydown', this.handleKeyPress);
         const queryParams = new URLSearchParams(window.location.search);
         const pid = queryParams.get('pid');
-        const classification = queryParams.get('class');
-        if (isDefined(pid) && isDefined(classification)) {
+        if (isDefined(pid)) {
             this.introSurvey.data = {
                 "Participant ID": pid,
-                "Military or Civilian background": classification == 'Civ' ? "Civilian Background" : "Military Background",
+                "Military or Civilian background": null,
                 "vrEnvironmentsCompleted": ['none']
             };
             this.setState({ moderated: false, startSurvey: false }, () => {

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -4,6 +4,22 @@ const { dashboardDB } = require('./server.mongo');
 // const { MONGO_DB } = require('./config');
 const { GraphQLScalarType, Kind } = require("graphql");
 
+async function createUniqueIndex() {
+  try {
+      await dashboardDB.db.collection('participantLog').createIndex(
+          { "ParticipantID": 1 }, 
+          { unique: true }
+      );
+      console.log("Unique index on ParticipantID created successfully");
+  } catch (error) {
+      if (error.code !== 85) { // Index already exists
+          console.error("Error creating unique index:", error);
+      }
+  }
+}
+
+createUniqueIndex().catch(console.error);
+
 const typeDefs = gql`
   scalar JSON
 
@@ -537,8 +553,74 @@ const resolvers = {
       }
     },
     addNewParticipantToLog: async (obj, args, context, inflow) => {
-      return await dashboardDB.db.collection('participantLog').insertOne(args.participantData);
-    },
+      try {
+          const timestamp = new Date().toISOString();
+          console.log(`[${timestamp}] ====== Starting new participant addition ======`);
+          console.log(`[${timestamp}] Initial participant data:`, {
+              email: args.participantData.hashedEmail.substring(0, 10) + '...',
+              type: args.participantData.Type,
+              proposedPID: args.participantData.ParticipantID
+          });
+
+          if (!Number.isFinite(args.participantData.ParticipantID)) {
+              console.log(`[${timestamp}] Invalid PID detected, querying for highest PID`);
+              
+              const highestPidDoc = await dashboardDB.db.collection('participantLog')
+                  .find({
+                      ParticipantID: { $type: "number" }
+                  })
+                  .sort({ ParticipantID: -1 })
+                  .limit(1)
+                  .toArray();
+  
+              console.log(`[${timestamp}] Current highest PID record:`, highestPidDoc[0]?.ParticipantID || 'none found');
+  
+              const nextPid = highestPidDoc.length > 0 ? Number(highestPidDoc[0].ParticipantID) + 1 : 202411301;
+              console.log(`[${timestamp}] Generated new PID: ${nextPid}`);
+              
+              args.participantData.ParticipantID = nextPid;
+          }
+  
+          // try to insert with our validated PID
+          try {
+              console.log(`[${timestamp}] Attempting insert for PID: ${args.participantData.ParticipantID}`);
+              const result = await dashboardDB.db.collection('participantLog').insertOne(args.participantData);
+              console.log(`[${timestamp}] Insert SUCCESS for PID: ${args.participantData.ParticipantID}`);
+              return result;
+          } catch (error) {
+              if (error.code === 11000) { // ff we hit a duplicate
+                  console.log(`[${timestamp}] DUPLICATE KEY ERROR for PID: ${args.participantData.ParticipantID}`);
+                  console.log(`[${timestamp}] Retrying with new PID generation`);
+                  
+                  // get absolute latest highest PID
+                  const highestPidDoc = await dashboardDB.db.collection('participantLog')
+                      .find({
+                          ParticipantID: { $type: "number" }
+                      })
+                      .sort({ ParticipantID: -1 })
+                      .limit(1)
+                      .toArray();
+  
+                  const retryPid = Number(highestPidDoc[0].ParticipantID) + 1;
+                  console.log(`[${timestamp}] New retry PID generated: ${retryPid}`);
+                  
+                  args.participantData.ParticipantID = retryPid;
+                  
+                  console.log(`[${timestamp}] Attempting final insert with PID: ${retryPid}`);
+                  const retryResult = await dashboardDB.db.collection('participantLog')
+                      .insertOne(args.participantData);
+                  console.log(`[${timestamp}] Retry insert SUCCESS for PID: ${retryPid}`);
+                  return retryResult;
+              }
+              console.error(`[${timestamp}] NON-DUPLICATE ERROR:`, error);
+              throw error;
+          }
+      } catch (error) {
+          const timestamp = new Date().toISOString();
+          console.error(`[${timestamp}] CRITICAL ERROR in addNewParticipantToLog:`, error);
+          throw error;
+      }
+  },
     updateEvalIdsByPage: async (obj, args, context, inflow) => {
       // hmm can't do this with graphql?      
       // var field = args["field"];

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -10,11 +10,22 @@ async function createUniqueIndex() {
           { "ParticipantID": 1 }, 
           { unique: true }
       );
-      console.log("Unique index on ParticipantID created successfully");
+    console.log("Unique index on ParticipantID created successfully.");
   } catch (error) {
       if (error.code !== 85) { // Index already exists
-          console.error("Error creating unique index:", error);
-      }
+      console.error("Error creating unique index (ParticipantID):", error);
+    }
+  }
+  try {
+    await dashboardDB.db.collection('participantLog').createIndex(
+      { "hashedEmail": 1 },
+      { unique: true }
+    );
+    console.log("Unique index on hashedEmail created successfully.");
+  } catch (error) {
+    if (error.code !== 85) { // Index already exists
+      console.error("Error creating unique index (hashedEmail):", error);
+    }
   }
 }
 
@@ -618,7 +629,13 @@ const resolvers = {
       } catch (error) {
           const timestamp = new Date().toISOString();
           console.error(`[${timestamp}] CRITICAL ERROR in addNewParticipantToLog:`, error);
+        if (error.code === 11000) {
+          return -1;
+        }
+        else {
           throw error;
+        }
+
       }
   },
     updateEvalIdsByPage: async (obj, args, context, inflow) => {


### PR DESCRIPTION
Removed classification from email participants. Everything should work the same as before, except now participants will be classified as "emailParticipant". 

Additionally, before there was a race condition with email addresses, where if the same email address was used in quick succession, it would get assigned to two different pids. Emails are now unique in mongo. In order to see this behavior, please: 1. run the latest ingest PR (same branch name as this) and 2. delete participant 315 from the log. Then reset your graphql container and ensure you can not enter the same email twice and get different pids. 

If you enter the same email more than once, you should always get the same pid. 