### PR TITLE
Itm 731 progress table

### DIFF
--- a/dashboard-ui/package.json
+++ b/dashboard-ui/package.json
@@ -62,7 +62,8 @@
         "survey-analytics": "^1.9.137",
         "survey-core": "^1.9.137",
         "survey-react-ui": "^1.9.137",
-        "typescript": "5.4.3"
+        "typescript": "5.4.3",
+        "xlsx-js-style": "1.2.0"
     },
     "scripts": {
         "start": "react-scripts start",

--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -1,0 +1,112 @@
+import React from "react";
+import '../SurveyResults/resultsTable.css';
+import { Autocomplete, TextField } from "@mui/material";
+import { useQuery } from 'react-apollo'
+import gql from "graphql-tag";
+import { DownloadButtons } from "../DRE-Research/tables/download-buttons";
+
+const GET_PARTICIPANT_LOG = gql`
+    query GetParticipantLog {
+        getParticipantLog
+    }`;
+
+const HEADERS = ['Participant ID', 'Participant Type', 'Text Responses', 'Survey Responses', 'Sim Entries'];
+// const HEADERS = ['Participant ID', 'Participant Type', 'Sim Date', 'Sim-1', 'Sim-2', 'Sim-3', 'Sim-4', 'Text Date', 'Text', 'Del Date', 'Delegation', 'IO1', 'MJ1', 'MJ2', 'MJ4', 'MJ5', 'QOL1', 'QOL2', 'QOL3', 'QOL4', 'VOL1', 'VOL2', 'VOL3', 'VOL4'];
+
+
+export function ParticipantProgressTable() {
+    const { loading: loadingParticipantLog, error: errorParticipantLog, data: dataParticipantLog } = useQuery(GET_PARTICIPANT_LOG);
+    const [formattedData, setFormattedData] = React.useState([]);
+    const [types, setTypes] = React.useState([]);
+    const [typeFilters, setTypeFilters] = React.useState([]);
+    const [filteredData, setFilteredData] = React.useState([]);
+
+    React.useEffect(() => {
+        if (dataParticipantLog?.getParticipantLog) {
+            const participantLog = dataParticipantLog.getParticipantLog;
+            const allObjs = [];
+            const allTypes = [];
+
+            for (const res of participantLog) {
+                console.log(res);
+                const obj = {};
+                const pid = res['ParticipantID'];
+                obj['Participant ID'] = pid;
+                obj['Participant Type'] = res['Type'];
+                allTypes.push(res['Type']);
+                obj['Text Responses'] = res['textEntryCount'];
+                obj['Survey Responses'] = res['surveyEntryCount'];
+                obj['Sim Entries'] = res['simEntryCount'];
+                allObjs.push(obj);
+            }
+            // // sort
+            allObjs.sort((a, b) => {
+                // Compare PID
+                if (Number(a['Participant_ID']) < Number(b['Participant_ID'])) return -1;
+                if (Number(a['Participant_ID']) > Number(b['Participant_ID'])) return 1;
+            });
+            setFormattedData(allObjs);
+            setFilteredData(allObjs);
+            setTypes(Array.from(new Set(allTypes)));
+        }
+    }, [dataParticipantLog]);
+
+    React.useEffect(() => {
+        if (formattedData.length > 0) {
+            setFilteredData(formattedData.filter((x) =>
+                (typeFilters.length == 0 || typeFilters.includes(x['Participant Type']))
+            ));
+        }
+    }, [formattedData, typeFilters]);
+
+    if (loadingParticipantLog) return <p>Loading...</p>;
+    if (errorParticipantLog) return <p>Error :</p>;
+
+    return (<>
+        <h2 className='progress-header'>Participant Progress</h2>
+        {filteredData.length < formattedData.length && <p className='filteredText'>Showing {filteredData.length} of {formattedData.length} rows based on filters</p>}
+        <section className='tableHeader'>
+            <div className="filters">
+                <Autocomplete
+                    multiple
+                    options={types}
+                    filterSelectedOptions
+                    size="small"
+                    renderInput={(params) => (
+                        <TextField
+                            {...params}
+                            label="Type"
+                            placeholder=""
+                        />
+                    )}
+                    onChange={(_, newVal) => setTypeFilters(newVal)}
+                />
+            </div>
+            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'Participant_Progress'} openModal={null} />
+        </section>
+        <div className='resultTableSection'>
+            <table className='itm-table'>
+                <thead>
+                    <tr>
+                        {HEADERS.map((val, index) => {
+                            return (<th key={'header-' + index}>
+                                {val}
+                            </th>);
+                        })}
+                    </tr>
+                </thead>
+                <tbody>
+                    {filteredData.map((dataSet, index) => {
+                        return (<tr key={dataSet['Participant_ID'] + '-' + index}>
+                            {HEADERS.map((val) => {
+                                return (<td key={dataSet['Participant_ID'] + '-' + val}>
+                                    {dataSet[val]}
+                                </td>);
+                            })}
+                        </tr>);
+                    })}
+                </tbody>
+            </table>
+        </div>
+    </>);
+}

--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -4,40 +4,104 @@ import { Autocomplete, TextField } from "@mui/material";
 import { useQuery } from 'react-apollo'
 import gql from "graphql-tag";
 import { DownloadButtons } from "../DRE-Research/tables/download-buttons";
+import { isDefined } from "../AggregateResults/DataFunctions";
 
 const GET_PARTICIPANT_LOG = gql`
     query GetParticipantLog {
         getParticipantLog
     }`;
 
-const HEADERS = ['Participant ID', 'Participant Type', 'Text Responses', 'Survey Responses', 'Sim Entries'];
-// const HEADERS = ['Participant ID', 'Participant Type', 'Sim Date', 'Sim-1', 'Sim-2', 'Sim-3', 'Sim-4', 'Text Date', 'Text', 'Del Date', 'Delegation', 'IO1', 'MJ1', 'MJ2', 'MJ4', 'MJ5', 'QOL1', 'QOL2', 'QOL3', 'QOL4', 'VOL1', 'VOL2', 'VOL3', 'VOL4'];
+const GET_SURVEY_RESULTS = gql`
+    query GetAllResults {
+        getAllSurveyResults
+    }`;
+
+const GET_TEXT_RESULTS = gql`
+    query GetAllResults {
+        getAllScenarioResults
+    }`;
+
+const GET_SIM_DATA = gql`
+    query GetAllSimAlignment {
+        getAllSimAlignment
+    }`;
+
+const HEADERS = ['Participant ID', 'Participant Type', 'Evaluation', 'Sim Date', 'Sim Count', 'Sim-1', 'Sim-2', 'Sim-3', 'Sim-4', 'Del Date', 'Delegation', 'Text Date', 'Text', 'IO1', 'MJ1', 'MJ2', 'MJ4', 'MJ5', 'QOL1', 'QOL2', 'QOL3', 'QOL4', 'VOL1', 'VOL2', 'VOL3', 'VOL4'];
 
 
 export function ParticipantProgressTable() {
-    const { loading: loadingParticipantLog, error: errorParticipantLog, data: dataParticipantLog } = useQuery(GET_PARTICIPANT_LOG);
+    const { loading: loadingParticipantLog, error: errorParticipantLog, data: dataParticipantLog } = useQuery(GET_PARTICIPANT_LOG, { fetchPolicy: 'no-cache' });
+    const { loading: loadingSurveyResults, error: errorSurveyResults, data: dataSurveyResults } = useQuery(GET_SURVEY_RESULTS, { fetchPolicy: 'no-cache' });
+    const { loading: loadingTextResults, error: errorTextResults, data: dataTextResults } = useQuery(GET_TEXT_RESULTS, { fetchPolicy: 'no-cache' });
+    const { loading: loadingSim, error: errorSim, data: dataSim } = useQuery(GET_SIM_DATA);
     const [formattedData, setFormattedData] = React.useState([]);
     const [types, setTypes] = React.useState([]);
+    const [evals, setEvals] = React.useState([]);
+    const [completion] = React.useState(['All Text (5)', 'Missing Text', 'Delegation (1)', 'No Delegation', 'All Sim (4)', 'Any Sim', 'Adept + OW Sim', 'No Sim']);
     const [typeFilters, setTypeFilters] = React.useState([]);
+    const [evalFilters, setEvalFilters] = React.useState([]);
+    const [completionFilters, setCompletionFilters] = React.useState([]);
     const [filteredData, setFilteredData] = React.useState([]);
 
     React.useEffect(() => {
-        if (dataParticipantLog?.getParticipantLog) {
+        if (dataParticipantLog?.getParticipantLog && dataSurveyResults?.getAllSurveyResults && dataTextResults?.getAllScenarioResults && dataSim?.getAllSimAlignment) {
             const participantLog = dataParticipantLog.getParticipantLog;
+            const surveyResults = dataSurveyResults.getAllSurveyResults;
+            const textResults = dataTextResults.getAllScenarioResults;
+            const simResults = dataSim.getAllSimAlignment;
             const allObjs = [];
             const allTypes = [];
+            const allEvals = [];
 
             for (const res of participantLog) {
-                console.log(res);
                 const obj = {};
-                const pid = res['ParticipantID'];
+                const pid = res['ParticipantID']?.toString();
                 obj['Participant ID'] = pid;
                 obj['Participant Type'] = res['Type'];
                 allTypes.push(res['Type']);
-                obj['Text Responses'] = res['textEntryCount'];
-                obj['Survey Responses'] = res['surveyEntryCount'];
-                obj['Sim Entries'] = res['simEntryCount'];
+
+                const sims = simResults.filter((x) => x.pid == pid).sort((a, b) => a.timestamp - b.timestamp);
+                obj['Evaluation'] = sims[0]?.evalName;
+                const sim_date = new Date(sims[0]?.timestamp);
+                obj['Sim Date'] = sim_date != 'Invalid Date' ? `${sim_date?.getMonth()}/${sim_date?.getDate() + 1}/${sim_date?.getFullYear()}` : undefined;
+                obj['Sim Count'] = sims.length;
+                obj['Sim-1'] = sims[0]?.scenario_id;
+                obj['Sim-2'] = sims[1]?.scenario_id;
+                obj['Sim-3'] = sims[2]?.scenario_id;
+                obj['Sim-4'] = sims[3]?.scenario_id;
+
+
+                const surveys = surveyResults.filter((x) => ((x.results?.pid && (x.results.pid == pid)) || x.results?.['Participant ID Page']?.questions?.['Participant ID']?.response == pid)
+                    && x.results?.['Post-Scenario Measures']);
+                const lastSurvey = surveys?.slice(-1)?.[0];
+                const survey_date = new Date(lastSurvey?.results?.timeComplete);
+                obj['Del Date'] = survey_date != 'Invalid Date' ? `${survey_date?.getMonth()}/${survey_date?.getDate() + 1}/${survey_date?.getFullYear()}` : undefined;
+                obj['Delegation'] = surveys.length;
+                obj['Evaluation'] = obj['Evaluation'] ?? lastSurvey?.evalName;
+
+                const scenarios = textResults.filter((x) => x.participantID == pid);
+                const lastScenario = scenarios?.slice(-1)?.[0];
+                const text_date = new Date(lastScenario?.timeComplete);
+                obj['Text Date'] = text_date != 'Invalid Date' ? `${text_date?.getMonth()}/${text_date?.getDate() + 1}/${text_date?.getFullYear()}` : undefined;
+                obj['Text'] = scenarios.length;
+                obj['Evaluation'] = obj['Evaluation'] ?? lastScenario?.evalName;
+                const completedScenarios = scenarios.map((x) => x.scenario_id);
+                obj['IO1'] = completedScenarios.includes('DryRunEval.IO1') || completedScenarios.includes('phase1-adept-train-IO1') ? 'y' : null;
+                obj['MJ1'] = completedScenarios.includes('DryRunEval.MJ1') || completedScenarios.includes('phase1-adept-train-MJ1') ? 'y' : null;
+                obj['MJ2'] = completedScenarios.includes('DryRunEval-MJ2-eval') || completedScenarios.includes('phase1-adept-eval-MJ2') ? 'y' : null;
+                obj['MJ4'] = completedScenarios.includes('DryRunEval-MJ4-eval') || completedScenarios.includes('phase1-adept-eval-MJ4') ? 'y' : null;
+                obj['MJ5'] = completedScenarios.includes('DryRunEval-MJ5-eval') || completedScenarios.includes('phase1-adept-eval-MJ5') ? 'y' : null;
+                obj['QOL1'] = completedScenarios.includes('qol-dre-1-eval') ? 'y' : null;
+                obj['QOL2'] = completedScenarios.includes('qol-dre-2-eval') || completedScenarios.includes('qol-ph1-eval-2') ? 'y' : null;
+                obj['QOL3'] = completedScenarios.includes('qol-dre-3-eval') || completedScenarios.includes('qol-ph1-eval-3') ? 'y' : null;
+                obj['QOL4'] = completedScenarios.includes('qol-ph1-eval-4') ? 'y' : null;
+                obj['VOL1'] = completedScenarios.includes('vol-dre-1-eval') ? 'y' : null;
+                obj['VOL2'] = completedScenarios.includes('vol-dre-2-eval') || completedScenarios.includes('vol-ph1-eval-2') ? 'y' : null;
+                obj['VOL3'] = completedScenarios.includes('vol-dre-3-eval') || completedScenarios.includes('vol-ph1-eval-3') ? 'y' : null;
+                obj['VOL4'] = completedScenarios.includes('vol-ph1-eval-4') ? 'y' : null;
+
                 allObjs.push(obj);
+                obj['Evaluation'] && allEvals.push(obj['Evaluation']);
             }
             // // sort
             allObjs.sort((a, b) => {
@@ -48,19 +112,49 @@ export function ParticipantProgressTable() {
             setFormattedData(allObjs);
             setFilteredData(allObjs);
             setTypes(Array.from(new Set(allTypes)));
+            setEvals(Array.from(new Set(allEvals)));
         }
-    }, [dataParticipantLog]);
+    }, [dataParticipantLog, dataSim, dataSurveyResults, dataTextResults]);
+
+    const formatCell = (header, dataSet) => {
+        const val = dataSet[header];
+        const getClassName = (header, val) => {
+            const lightGreenIfNotNull = ['Sim-1', 'Sim-2', 'Sim-3', 'Sim-4', 'IO1', 'MJ1', 'MJ2', 'MJ4', 'MJ5', 'QOL1', 'QOL2', 'QOL3', 'QOL4', 'VOL1', 'VOL2', 'VOL3', 'VOL4'];
+            if (lightGreenIfNotNull.includes(header) && isDefined(val)) {
+                return 'li-green-cell';
+            }
+            if ((header == 'Delegation' && val == 1) || (header == 'Text' && val == 5) || (header == 'Sim Count' && val == 4)) {
+                return 'dk-green-cell';
+            }
+            return 'white-cell';
+        };
+        return (<td key={dataSet['Participant_ID'] + '-' + header} className={getClassName(header, val) + ' ' + (header.length < 5 ? 'small-column' : '')}>
+            {val ?? '-'}
+        </td>);
+    };
 
     React.useEffect(() => {
         if (formattedData.length > 0) {
-            setFilteredData(formattedData.filter((x) =>
-                (typeFilters.length == 0 || typeFilters.includes(x['Participant Type']))
-            ));
+            setFilteredData(formattedData.filter((x) => {
+                const sims = [x['Sim-1'], x['Sim-2'], x['Sim-3'], x['Sim-4']];
+                const didAdept = sims.filter((s) => s?.includes('MJ')).length > 0;
+                const didOW = sims.filter((s) => s?.includes('open_world')).length > 0;
+                return (typeFilters.length == 0 || typeFilters.includes(x['Participant Type'])) &&
+                    (evalFilters.length == 0 || evalFilters.includes(x['Evaluation'])) &&
+                    (!completionFilters.includes('All Text (5)') || x['Text'] >= 5) &&
+                    (!completionFilters.includes('Missing Text') || x['Text'] < 5) &&
+                    (!completionFilters.includes('Delegation (1)') || x['Delegation'] >= 1) &&
+                    (!completionFilters.includes('No Delegation') || x['Delegation'] == 0) &&
+                    (!completionFilters.includes('All Sim (4)') || x['Sim Count'] >= 4) &&
+                    (!completionFilters.includes('Any Sim') || x['Sim Count'] >= 1) &&
+                    (!completionFilters.includes('Adept + OW Sim') || (didAdept && didOW)) &&
+                    (!completionFilters.includes('No Sim') || x['Sim Count'] == 0)
+            }));
         }
-    }, [formattedData, typeFilters]);
+    }, [formattedData, typeFilters, evalFilters, completionFilters]);
 
-    if (loadingParticipantLog) return <p>Loading...</p>;
-    if (errorParticipantLog) return <p>Error :</p>;
+    if (loadingParticipantLog || loadingSurveyResults || loadingTextResults || loadingSim) return <p>Loading...</p>;
+    if (errorParticipantLog || errorSurveyResults || errorTextResults || errorSim) return <p>Error :</p>;
 
     return (<>
         <h2 className='progress-header'>Participant Progress</h2>
@@ -81,15 +175,45 @@ export function ParticipantProgressTable() {
                     )}
                     onChange={(_, newVal) => setTypeFilters(newVal)}
                 />
+                <Autocomplete
+                    multiple
+                    options={evals}
+                    filterSelectedOptions
+                    size="small"
+                    style={{ width: '400px' }}
+                    renderInput={(params) => (
+                        <TextField
+                            {...params}
+                            label="Eval"
+                            placeholder=""
+                        />
+                    )}
+                    onChange={(_, newVal) => setEvalFilters(newVal)}
+                />
+                <Autocomplete
+                    multiple
+                    options={completion}
+                    filterSelectedOptions
+                    size="small"
+                    style={{ width: '600px' }}
+                    renderInput={(params) => (
+                        <TextField
+                            {...params}
+                            label="Progress"
+                            placeholder=""
+                        />
+                    )}
+                    onChange={(_, newVal) => setCompletionFilters(newVal)}
+                />
             </div>
-            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'Participant_Progress'} openModal={null} />
+            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'Participant_Progress'} openModal={null} isParticipantData={true} />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>
                 <thead>
                     <tr>
                         {HEADERS.map((val, index) => {
-                            return (<th key={'header-' + index}>
+                            return (<th key={'header-' + index} className={val.length < 5 ? 'small-column' : ''}>
                                 {val}
                             </th>);
                         })}
@@ -99,9 +223,7 @@ export function ParticipantProgressTable() {
                     {filteredData.map((dataSet, index) => {
                         return (<tr key={dataSet['Participant_ID'] + '-' + index}>
                             {HEADERS.map((val) => {
-                                return (<td key={dataSet['Participant_ID'] + '-' + val}>
-                                    {dataSet[val]}
-                                </td>);
+                                return formatCell(val, dataSet);
                             })}
                         </tr>);
                     })}

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -44,6 +44,7 @@ import store from '../../store/store';
 import { isDefined } from '../AggregateResults/DataFunctions';
 import { PidLookup } from '../Account/pidLookup';
 import StartOnline from '../OnlineOnly/OnlineOnly';
+import { ParticipantProgressTable } from '../Account/participantProgress';
 
 
 const history = createBrowserHistory();
@@ -485,6 +486,11 @@ export class App extends React.Component {
                                                                             Administrator
                                                                         </Link>
                                                                     )}
+                                                                    {(this.state.currentUser.experimenter === true || this.state.currentUser.admin === true || this.state.currentUser.evaluator === true) && (
+                                                                        <Link className="dropdown-item" to="/participant-progress-table" onClick={this.handleToggle}>
+                                                                            Progress Table
+                                                                        </Link>
+                                                                    )}
                                                                     {(this.state.currentUser.experimenter === true || this.state.currentUser.admin === true) && (
                                                                         <Link className="dropdown-item" to="/pid-lookup" onClick={this.handleToggle}>
                                                                             PID Lookup
@@ -528,6 +534,9 @@ export class App extends React.Component {
                                                     </Route>
                                                     <Route path="/admin">
                                                         <Admin newState={this.state} userLoginHandler={this.userLoginHandler} />
+                                                    </Route>
+                                                    <Route path="/participant-progress-table">
+                                                        <ParticipantProgressTable newState={this.state} />
                                                     </Route>
                                                     <Route path="/pid-lookup">
                                                         <PidLookupPage newState={this.state} />

--- a/dashboard-ui/src/components/DRE-Research/tables/download-buttons.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/download-buttons.jsx
@@ -11,7 +11,7 @@ export function DownloadButtons({ formattedData, filteredData, HEADERS, fileName
             </div> :
                 <button className='downloadBtn' onClick={() => exportToExcel(fileName, formattedData, HEADERS)}>Download All Data</button>
             }
-            <button className='downloadBtn' onClick={openModal}>View Variable Definitions</button>
+            {openModal && <button className='downloadBtn' onClick={openModal}>View Variable Definitions</button>}
         </div>
     );
 }

--- a/dashboard-ui/src/components/DRE-Research/tables/download-buttons.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/download-buttons.jsx
@@ -2,14 +2,14 @@ import React from "react";
 import { exportToExcel } from "../utils";
 import '../../SurveyResults/resultsTable.css';
 
-export function DownloadButtons({ formattedData, filteredData, HEADERS, fileName, openModal }) {
+export function DownloadButtons({ formattedData, filteredData, HEADERS, fileName, openModal, isParticipantData = false }) {
     return (
         <div className={"option-section " + (filteredData.length < formattedData.length ? "adjusted-margin" : "")}>
             {filteredData.length < formattedData.length ? <div className="downloadGroup">
-                <button className='downloadBtn' onClick={() => exportToExcel(fileName, formattedData, HEADERS)}>Download All Data</button>
-                <button className='downloadBtn' onClick={() => exportToExcel(fileName + ' (filtered)', filteredData, HEADERS)}>Download Filtered Data</button>
+                <button className='downloadBtn' onClick={() => exportToExcel(fileName, formattedData, HEADERS, isParticipantData)}>Download All Data</button>
+                <button className='downloadBtn' onClick={() => exportToExcel(fileName + ' (filtered)', filteredData, HEADERS, isParticipantData)}>Download Filtered Data</button>
             </div> :
-                <button className='downloadBtn' onClick={() => exportToExcel(fileName, formattedData, HEADERS)}>Download All Data</button>
+                <button className='downloadBtn' onClick={() => exportToExcel(fileName, formattedData, HEADERS, isParticipantData)}>Download All Data</button>
             }
             {openModal && <button className='downloadBtn' onClick={openModal}>View Variable Definitions</button>}
         </div>

--- a/dashboard-ui/src/components/DRE-Research/utils.js
+++ b/dashboard-ui/src/components/DRE-Research/utils.js
@@ -1,5 +1,5 @@
 import * as FileSaver from 'file-saver';
-import XLSX from 'sheetjs-style';
+import XLSX from 'xlsx-js-style';
 import { isDefined } from "../AggregateResults/DataFunctions";
 import { admOrderMapping, getDelEnvMapping } from '../Survey/delegationMappings';
 
@@ -24,7 +24,7 @@ const RATING_MAP = {
 const fileType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=UTF-8';
 const fileExtension = '.xlsx';
 
-export const exportToExcel = async (filename, formattedData, headers) => {
+export const exportToExcel = async (filename, formattedData, headers, participantData = false) => {
     // Create a new workbook and worksheet
     const wb = XLSX.utils.book_new();
     const dataCopy = structuredClone(formattedData);
@@ -41,8 +41,39 @@ export const exportToExcel = async (filename, formattedData, headers) => {
     const colWidths = headers.map(header => ({ wch: Math.max(header.length, 20) }));
     ws['!cols'] = colWidths;
 
+    if (participantData) {
+        // apply conditional formatting to participant data
+        const keys = Object.keys(dataCopy[Object.keys(dataCopy)[0]]);
+        const lightGreenIfNotNull = ['Sim-1', 'Sim-2', 'Sim-3', 'Sim-4', 'IO1', 'MJ1', 'MJ2', 'MJ4', 'MJ5', 'QOL1', 'QOL2', 'QOL3', 'QOL4', 'VOL1', 'VOL2', 'VOL3', 'VOL4'];
+
+        for (let row = 1; row <= dataCopy.length; row++) {
+            for (let col = 0; col < keys.length; col++) {
+                const cellRef = XLSX.utils.encode_cell({ r: row, c: col });
+                const cell = ws[cellRef];
+
+                if (cell) {
+                    const val = cell.v;
+                    if (lightGreenIfNotNull.includes(keys[col]) && isDefined(val)) {
+                        cell.s = {
+                            fill: {
+                                fgColor: { rgb: 'c2ecc2' }  // Light green color
+                            }
+                        };
+                    }
+                    if ((keys[col] == 'Delegation' && val == 1) || (keys[col] == 'Text' && val == 5) || (keys[col] == 'Sim Count' && val == 4)) {
+                        cell.s = {
+                            fill: {
+                                fgColor: { rgb: '7bbc7b' }  // Dark green color
+                            }
+                        };
+                    }
+                }
+            }
+        }
+    }
+
     // Add the worksheet to the workbook
-    XLSX.utils.book_append_sheet(wb, ws, 'RQ Data');
+    XLSX.utils.book_append_sheet(wb, ws, participantData ? 'Participants' : 'RQ Data');
 
     // Generate Excel file
     const excelBuffer = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });

--- a/dashboard-ui/src/components/SurveyResults/resultsTable.css
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.css
@@ -163,3 +163,19 @@
     margin-left: 12px;
     margin-top: 18px;
 }
+
+.li-green-cell {
+    background-color: rgb(194, 236, 194) !important;
+}
+
+.dk-green-cell {
+    background-color: rgb(123, 188, 123) !important;
+}
+
+.white-cell {
+    background-color: white !important;
+}
+
+.small-column {
+    min-width: 100px !important;
+}

--- a/dashboard-ui/src/components/SurveyResults/resultsTable.css
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.css
@@ -158,3 +158,8 @@
     flex-direction: column;
     gap: 4px;
 }
+
+.progress-header {
+    margin-left: 12px;
+    margin-top: 18px;
+}


### PR DESCRIPTION
LOWER PRIORITY REVIEW:

This adds a new option for experimenters, evaluators, and admin to quickly see participant progress. It shows all the PIDs in the participant log (remember that there are no longer "extra" PIDs, in order for a PID to appear, it has been assigned to somebody somehow) along with how many sim responses, survey responses, and scenario responses they have completed. The dates are included. A column is dark green if it is a wrapped count, for example, are there 4 sim responses (all of them), 1 survey response, or 5 text responses. A column is light green if we have data for it. 

The cell coloring should transfer to the download. You will need to rerun the startup script for this because a new library was needed to get the styling. 

To find this new table, look in your user dropdown when logged in. Play around with the filters and make sure they work properly. 