### PR TITLE
fixed adm charts by evalNum

### DIFF
--- a/dashboard-ui/src/components/AdmCharts/scoreChart.jsx
+++ b/dashboard-ui/src/components/AdmCharts/scoreChart.jsx
@@ -67,7 +67,7 @@ class ScoreChart extends React.Component {
                     if (loading) return <div>No stats yet</div> 
                     if (error) return <div>Error</div>
 
-                    const chartData = data[GET_HISTORIES_BY_ID];
+                    const chartData = data[GET_HISTORIES_BY_ID]?.filter((x) => x.evalNumber == this.props.evalNumber);
 
                     let admNameParamter = "ADM Name";
                     if(this.props.evalNumber > 2) {

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -309,7 +309,7 @@ const resolvers = {
         [{ "$group": { "_id": { evalNumber: "$evalNumber", evalName: "$evalName" } } }]).sort({ 'evalNumber': -1 }).toArray().then(result => { return result });
     },
     getAllHistoryByID: async (obj, args, context, inflow) => {
-      return await dashboardDB.db.collection('test').find({ "history.response.id": args.historyId }, { projection: { "history.parameters.adm_name": 1, "history.response.score": 1 } }).toArray().then(result => { return result; });
+      return await dashboardDB.db.collection('test').find({ "history.response.id": args.historyId }, { projection: { "history.parameters.adm_name": 1, "history.response.score": 1, "evalNumber": 1 } }).toArray().then(result => { return result; });
     },
     getScenario: async (obj, args, context, inflow) => {
       return await dashboardDB.db.collection('scenarios').findOne({ "id": args["scenarioId"] }).then(result => { return result; });


### PR DESCRIPTION
Before, the Adept ADM charts for eval 4 and 5 were the same because the code was not filtering by eval number (but the scenario names are the same for ph1 and dre). i added in the eval number filter (you'll have to rerun the startup script) and now all charts should work and be unique