### PR TITLE
ITM-744: added new ST instance for scalar kdma endpoint

### DIFF
--- a/docker_setup/resources/nginx.conf
+++ b/docker_setup/resources/nginx.conf
@@ -168,7 +168,7 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
-    location /soartech_dre/ {
+    location /soartech_scalar_kdma/ {
       # proxy_pass CANNOT contain variable for this to work
       proxy_pass http://10.216.38.25:8088/;
       proxy_set_header X-Real-IP $remote_addr;

--- a/docker_setup/resources/nginx.conf
+++ b/docker_setup/resources/nginx.conf
@@ -168,6 +168,13 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
+    location /soartech_dre/ {
+      # proxy_pass CANNOT contain variable for this to work
+      proxy_pass http://10.216.38.25:8088/;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
     location /adept/ {
      # proxy_pass CANNOT contain variable for this to work
       proxy_pass http://10.216.38.101:8080/;


### PR DESCRIPTION
A new instance of the SoarTech API was setup with:
https://github.com/ITM-Soartech/ta1-server-mvp/tree/exp/scalar-kdma
(app is setup on 8088 and mongo on 27021)

I updated prod to test this.  It's working now on prod (but will be removed if a dashboard push is made before this is merged):

Targets should be the same as DRE:
https://[darpaitm.caci.com/soartech_scalar_kdma/api/v1/alignment_targets](https://darpaitm.caci.com/soartech_scalar_kdma/api/v1/alignment_targets)
https://[darpaitm.caci.com/soartech_dre/api/v1/alignment_targets](https://darpaitm.caci.com/soartech_dre/api/v1/alignment_targets)

Scenarios should be the same:
https://[darpaitm.caci.com/soartech_scalar_kdma/api/v1/scenarios](https://darpaitm.caci.com/soartech_scalar_kdma/api/v1/scenarios)
https://[darpaitm.caci.com/soartech_dre/api/v1/scenarios](https://darpaitm.caci.com/soartech_dre/api/v1/scenarios)


