### PR TITLE
add error handling text surveys; update survey intro qualtrix

### DIFF
--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -146,7 +146,7 @@ class SurveyPage extends Component {
                 else {
                     this.survey.currentPage = this.state.onlineOnly ? 3 : 2;
                     if (this.state.onlineOnly) {
-                        this.survey.pages[3].elements[0].html = this.survey.pages[3].elements[0].html.split('<br/><br/>').slice(0, -1).join('<br/><br/>');
+                        this.survey.pages[3].elements[0].html = this.survey.pages[3].elements[0].html.split('<br/><br/>').slice(0, -1).join('<br/><br/>').replace('Welcome to the <strong>Military Triage Delegation Experiment</strong>. Here', 'In the final part of the study,');
                         this.survey.pages[0].visibleIf = 'false';
                         this.survey.pages[2].visibleIf = 'false';
                     }

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -448,8 +448,13 @@ class TextBasedScenariosPage extends Component {
 
     attachKdmaValue = async (sessionId, url) => {
         const endpoint = '/api/v1/computed_kdma_profile?session_id='
+        try {
         const response = await axios.get(`${url}${endpoint}${sessionId}`)
         return response.data
+        } catch (e) {
+            console.error('Error getting kdmas: ' + e);
+            return null;
+        }
     }
 
     mostLeastAligned = async (sessionId, ta1, url, scenario) => {


### PR DESCRIPTION
This allows you to at least get through the text scenarios if there are cors errors (or other network issues). It also changes the intro on the adept qualtrix online-only survey