### PR TITLE
Updates to Participant Progress Table

### DIFF
--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -63,7 +63,7 @@ export function ParticipantProgressTable() {
                 const sims = simResults.filter((x) => x.pid == pid).sort((a, b) => a.timestamp - b.timestamp);
                 obj['Evaluation'] = sims[0]?.evalName;
                 const sim_date = new Date(sims[0]?.timestamp);
-                obj['Sim Date'] = sim_date != 'Invalid Date' ? `${sim_date?.getMonth()}/${sim_date?.getDate() + 1}/${sim_date?.getFullYear()}` : undefined;
+                obj['Sim Date'] = sim_date != 'Invalid Date' ? `${sim_date?.getMonth() + 1}/${sim_date?.getDate()}/${sim_date?.getFullYear()}` : undefined;
                 obj['Sim Count'] = sims.length;
                 obj['Sim-1'] = sims[0]?.scenario_id;
                 obj['Sim-2'] = sims[1]?.scenario_id;
@@ -75,14 +75,14 @@ export function ParticipantProgressTable() {
                     && x.results?.['Post-Scenario Measures']);
                 const lastSurvey = surveys?.slice(-1)?.[0];
                 const survey_date = new Date(lastSurvey?.results?.timeComplete);
-                obj['Del Date'] = survey_date != 'Invalid Date' ? `${survey_date?.getMonth()}/${survey_date?.getDate() + 1}/${survey_date?.getFullYear()}` : undefined;
+                obj['Del Date'] = survey_date != 'Invalid Date' ? `${survey_date?.getMonth() + 1}/${survey_date?.getDate()}/${survey_date?.getFullYear()}` : undefined;
                 obj['Delegation'] = surveys.length;
                 obj['Evaluation'] = obj['Evaluation'] ?? lastSurvey?.evalName;
 
                 const scenarios = textResults.filter((x) => x.participantID == pid);
                 const lastScenario = scenarios?.slice(-1)?.[0];
                 const text_date = new Date(lastScenario?.timeComplete);
-                obj['Text Date'] = text_date != 'Invalid Date' ? `${text_date?.getMonth()}/${text_date?.getDate() + 1}/${text_date?.getFullYear()}` : undefined;
+                obj['Text Date'] = text_date != 'Invalid Date' ? `${text_date?.getMonth() + 1}/${text_date?.getDate()}/${text_date?.getFullYear()}` : undefined;
                 obj['Text'] = scenarios.length;
                 obj['Evaluation'] = obj['Evaluation'] ?? lastScenario?.evalName;
                 const completedScenarios = scenarios.map((x) => x.scenario_id);

--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -30,10 +30,10 @@ const HEADERS = ['Participant ID', 'Participant Type', 'Evaluation', 'Sim Date',
 
 
 export function ParticipantProgressTable() {
-    const { loading: loadingParticipantLog, error: errorParticipantLog, data: dataParticipantLog } = useQuery(GET_PARTICIPANT_LOG, { fetchPolicy: 'no-cache' });
-    const { loading: loadingSurveyResults, error: errorSurveyResults, data: dataSurveyResults } = useQuery(GET_SURVEY_RESULTS, { fetchPolicy: 'no-cache' });
-    const { loading: loadingTextResults, error: errorTextResults, data: dataTextResults } = useQuery(GET_TEXT_RESULTS, { fetchPolicy: 'no-cache' });
-    const { loading: loadingSim, error: errorSim, data: dataSim } = useQuery(GET_SIM_DATA);
+    const { loading: loadingParticipantLog, error: errorParticipantLog, data: dataParticipantLog, refetch: refetchPLog } = useQuery(GET_PARTICIPANT_LOG, { fetchPolicy: 'no-cache' });
+    const { loading: loadingSurveyResults, error: errorSurveyResults, data: dataSurveyResults, refetch: refetchSurveyResults } = useQuery(GET_SURVEY_RESULTS, { fetchPolicy: 'no-cache' });
+    const { loading: loadingTextResults, error: errorTextResults, data: dataTextResults, refetch: refetchTextResults } = useQuery(GET_TEXT_RESULTS, { fetchPolicy: 'no-cache' });
+    const { loading: loadingSim, error: errorSim, data: dataSim, refetch: refetchSimData } = useQuery(GET_SIM_DATA);
     const [formattedData, setFormattedData] = React.useState([]);
     const [types, setTypes] = React.useState([]);
     const [evals, setEvals] = React.useState([]);
@@ -153,6 +153,13 @@ export function ParticipantProgressTable() {
         }
     }, [formattedData, typeFilters, evalFilters, completionFilters]);
 
+    const refreshData = async () => {
+        await refetchPLog();
+        await refetchSimData();
+        await refetchSurveyResults();
+        await refetchTextResults();
+    };
+
     if (loadingParticipantLog || loadingSurveyResults || loadingTextResults || loadingSim) return <p>Loading...</p>;
     if (errorParticipantLog || errorSurveyResults || errorTextResults || errorSim) return <p>Error :</p>;
 
@@ -206,7 +213,7 @@ export function ParticipantProgressTable() {
                     onChange={(_, newVal) => setCompletionFilters(newVal)}
                 />
             </div>
-            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'Participant_Progress'} openModal={null} isParticipantData={true} />
+            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'Participant_Progress'} extraAction={refreshData} extraActionText={'Refresh Data'} isParticipantData={true} />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -193,6 +193,18 @@ function PidLookupPage({ newState }) {
     }
 }
 
+function ProgressTable({ newState }) {
+    if (newState.currentUser === null) {
+        history.push("/login");
+    } else {
+        if (newState.currentUser.experimenter || newState.currentUser.admin || newState.evaluator) {
+            return <ParticipantProgressTable />
+        } else {
+            return <Home newState={newState} />;
+        }
+    }
+}
+
 function ReviewTextBased({ newState, userLoginHandler }) {
     if (newState.currentUser === null) {
         history.push("/login");
@@ -555,7 +567,7 @@ export class App extends React.Component {
                                                         <Admin newState={this.state} userLoginHandler={this.userLoginHandler} />
                                                     </Route>
                                                     <Route path="/participant-progress-table">
-                                                        <ParticipantProgressTable newState={this.state} />
+                                                        <ProgressTable newState={this.state} />
                                                     </Route>
                                                     <Route path="/pid-lookup">
                                                         <PidLookupPage newState={this.state} />

--- a/dashboard-ui/src/components/DRE-Research/tables/download-buttons.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/download-buttons.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { exportToExcel } from "../utils";
 import '../../SurveyResults/resultsTable.css';
 
-export function DownloadButtons({ formattedData, filteredData, HEADERS, fileName, openModal, isParticipantData = false }) {
+export function DownloadButtons({ formattedData, filteredData, HEADERS, fileName, extraAction, isParticipantData = false, extraActionText = 'View Variable Definitions' }) {
     return (
         <div className={"option-section " + (filteredData.length < formattedData.length ? "adjusted-margin" : "")}>
             {filteredData.length < formattedData.length ? <div className="downloadGroup">
@@ -11,7 +11,7 @@ export function DownloadButtons({ formattedData, filteredData, HEADERS, fileName
             </div> :
                 <button className='downloadBtn' onClick={() => exportToExcel(fileName, formattedData, HEADERS, isParticipantData)}>Download All Data</button>
             }
-            {openModal && <button className='downloadBtn' onClick={openModal}>View Variable Definitions</button>}
+            {extraAction && <button className='downloadBtn' onClick={extraAction}>{extraActionText}</button>}
         </div>
     );
 }

--- a/dashboard-ui/src/components/DRE-Research/tables/rq1-rq3.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq1-rq3.jsx
@@ -245,7 +245,7 @@ export function RQ13({ evalNum }) {
                     onChange={(_, newVal) => setDelMilFilters(newVal)}
                 />
             </div>
-            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-1_and_RQ-3 data'} openModal={openModal} />
+            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-1_and_RQ-3 data'} extraAction={openModal} />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/DRE-Research/tables/rq21.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq21.jsx
@@ -286,7 +286,7 @@ export function RQ21({ evalNum }) {
                     onChange={(_, newVal) => setDecisionMakerFilters(newVal)}
                 />
             </div>
-            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-21 data'} openModal={openModal} />
+            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-21 data'} extraAction={openModal} />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/DRE-Research/tables/rq22-rq23.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq22-rq23.jsx
@@ -270,7 +270,7 @@ export function RQ2223({ evalNum }) {
                     onChange={(_, newVal) => setTargetTypeFilters(newVal)}
                 />
             </div>
-            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-22_and_RQ-23 data'} openModal={openModal} />
+            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-22_and_RQ-23 data'} extraAction={openModal} />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/DRE-Research/tables/rq5.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq5.jsx
@@ -326,7 +326,7 @@ export function RQ5({ evalNum }) {
                     onChange={(_, newVal) => setGroupTargetFilters(newVal)}
                 />
             </div>
-            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-5 data'} openModal={openModal} />
+            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-5 data'} extraAction={openModal} />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/DRE-Research/tables/rq6.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq6.jsx
@@ -203,7 +203,7 @@ export function RQ6({ evalNum }) {
                     onChange={(_, newVal) => setScenarioFilters(newVal)}
                 />
             </div>
-            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-6 data'} openModal={openModal} />
+            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-6 data'} extraAction={openModal} />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/DRE-Research/tables/rq8.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq8.jsx
@@ -246,7 +246,7 @@ export function RQ8({ evalNum }) {
                     onChange={(_, newVal) => setScenarioFilters(newVal)}
                 />
             </div>
-            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-8 data'} openModal={openModal} />
+            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-8 data'} extraAction={openModal} />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -79,6 +79,7 @@ class SurveyPage extends Component {
             pid: this.queryParams.get('pid') ?? null,
             onlineOnly: isDefined(this.queryParams.get('adeptQualtrix')),
             prolificPid: this.queryParams.get('PROLIFIC_PID'),
+            contactId: this.queryParams.get('ContactID'),
             validPid: false,
             lastTimeCalled: 0,
             envsSeen: { "Del-1": "AD-1", "Del-2": "ST-3", "ADMOrder": 1 },
@@ -800,7 +801,7 @@ class SurveyPage extends Component {
                             </div>
                         </div>
                     )}
-                    <a ref={this.redirectLinkRef} hidden href={`https://singuser67d7ec86.sjc1.qualtrics.com/jfe/form/SV_0pUd3RTN39qu9qS/?participant_id=${this.state.pid}&PROLIFIC_PID=${this.state.prolificPid}`} />
+                    <a ref={this.redirectLinkRef} hidden href={`https://singuser67d7ec86.sjc1.qualtrics.com/jfe/form/SV_0pUd3RTN39qu9qS/?participant_id=${this.state.pid}&PROLIFIC_PID=${this.state.prolificPid}&ContactID=${this.state.contactId}`} />
                 </>
                 }
             </>


### PR DESCRIPTION
1. **Fixed dates.** Months are 0 based, apparently. Moved the +1 from day-of-month (which was unnecessary) to month (where it was needed). Check the participant progress table to make sure Phase 1 results are showing at the end of november, beginning of december
2. **Added a refresh button.** If you look at prod, you'll see that you have to hit the browser refresh for new data to come in. This loses your filters and takes forever. Here, I've added a refresh button to the page that will just refetch all the data and fill up the table. To test, open the progress table in one tab (with a filter chosen, like Phase 1). In another tab taking an online scenario or text scenario through email. As soon as you are assigned a pid, hit the refresh button on the progress table you kept open in the other tab. See the table populate more. As you go through your tests, keep hitting the refresh button and see your progress populate!!
3. **Fixed permissions** While the progress button is only visible for evaluators, admin, and experimenters, if someone who does not have one of those roles knows the url, they may be able to access the page. I added some extra security here so that does not happen
4. Added one more url parameter to pass to adept at the end (ContactID)
