### PR TITLE
removes old moderator reset

### DIFF
--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -116,8 +116,6 @@ class TextBasedScenariosPage extends Component {
         this.uploadButtonRef = React.createRef();
         this.uploadButtonRefPLog = React.createRef();
         this.shouldBlockNavigation = true
-        this.handleKeyPress = this.handleKeyPress.bind(this);
-        this.handleKeyPress = this.handleKeyPress.bind(this);
     }
 
     duplicatePid = (pid) => {
@@ -233,7 +231,6 @@ class TextBasedScenariosPage extends Component {
     }
 
     componentDidMount() {
-        document.addEventListener('keydown', this.handleKeyPress);
         const queryParams = new URLSearchParams(window.location.search);
         const pid = queryParams.get('pid');
         const classification = queryParams.get('class');
@@ -255,18 +252,6 @@ class TextBasedScenariosPage extends Component {
                 });
             }
 
-        }
-    }
-
-    componentWillUnmount() {
-        document.removeEventListener('keydown', this.handleKeyPress);
-    }
-
-    handleKeyPress(event) {
-        if (event.key === 'M' || event.key === 'm') {
-            if (this.state.allScenariosCompleted) {
-                this.resetState();
-            }
         }
     }
 


### PR DESCRIPTION
http://localhost:3000/remote-text-survey?adeptQualtrix=true

Removes bug where you can reset yourself accidentally by pressing 'm' or 'M' in delegation survey. Click through text scenarios and once you get to the survey, try to kick yourself out.