### PR TITLE
Itm 753 store prolificid

### DIFF
--- a/dashboard-ui/src/components/Account/adminPage.jsx
+++ b/dashboard-ui/src/components/Account/adminPage.jsx
@@ -45,6 +45,13 @@ const UPDATE_EXPERIMENTER_USER = gql`
     }
 `;
 
+const UPDATE_ADEPT_USER = gql`
+    mutation updateAdeptUser($username: String!, $isAdeptUser: Boolean!) {
+        updateAdeptUser(username: $username, isAdeptUser: $isAdeptUser) 
+    }
+`;
+
+
 const GET_CURRENT_SURVEY_VERSION = gql`
     query getCurrentSurveyVersion {
         getCurrentSurveyVersion
@@ -182,6 +189,49 @@ function ExperimenterInputBox({ options, selectedOptions }) {
             lang={{
                 availableHeader: "All Users",
                 selectedHeader: "Experimenters"
+            }} />
+    );
+}
+
+function AdeptInputBox({ options, selectedOptions }) {
+    const [selected, setSelected] = useState(selectedOptions.sort());
+    const [updateAdeptUserCall] = useMutation(UPDATE_ADEPT_USER);
+
+    const setAdeptUser = (newSelect) => {
+        for (let i = 0; i < newSelect.length; i++) {
+            if (!selected.includes(newSelect[i])) {
+                updateAdeptUserCall({
+                    variables: {
+                        username: newSelect[i],
+                        isAdeptUser: true
+                    }
+                });
+            }
+        }
+        for (let i = 0; i < selected.length; i++) {
+            if (!newSelect.includes(selected[i])) {
+                updateAdeptUserCall({
+                    variables: {
+                        username: selected[i],
+                        isAdeptUser: false
+                    }
+                });
+            }
+        }
+        setSelected(newSelect);
+    }
+
+    options.sort((a, b) => (a.value > b.value) ? 1 : -1);
+
+    return (
+        <DualListBox
+            options={options}
+            selected={selected}
+            onChange={setAdeptUser}
+            showHeaderLabels={true}
+            lang={{
+                availableHeader: "All Users",
+                selectedHeader: "ADEPT Users"
             }} />
     );
 }
@@ -426,12 +476,15 @@ function AdminPage({ currentUser }) {
                     let evaluatorSelectedOptions = [];
                     let experimenterOptions = [];
                     let experimenterSelectedOptions = [];
+                    let adeptOptions = [];
+                    let adeptSelectedOptions = [];
 
                     const users = data[getUsersQueryName]
                     for (let i = 0; i < users.length; i++) {
                         options.push({ value: users[i].username, label: users[i].username + " (" + (users[i].emails !== undefined ? users[i].emails[0].address : "") + ")" });
                         evaluatorOptions.push({ value: users[i].username, label: users[i].username + " (" + (users[i].emails !== undefined ? users[i].emails[0].address : "") + ")" });
                         experimenterOptions.push({ value: users[i].username, label: users[i].username + " (" + (users[i].emails !== undefined ? users[i].emails[0].address : "") + ")" });
+                        adeptOptions.push({ value: users[i].username, label: users[i].username + " (" + (users[i].emails !== undefined ? users[i].emails[0].address : "") + ")" });
 
                         if (users[i].admin) {
                             selectedOptions.push(users[i].username);
@@ -443,6 +496,10 @@ function AdminPage({ currentUser }) {
 
                         if (users[i].experimenter) {
                             experimenterSelectedOptions.push(users[i].username);
+                        }
+
+                        if (users[i].adeptUser) {
+                            adeptSelectedOptions.push(users[i].username);
                         }
                     }
 
@@ -488,6 +545,21 @@ function AdminPage({ currentUser }) {
                                             </Card.Text>
                                             <h6>Modify Current Experimenters</h6>
                                             <ExperimenterInputBox options={experimenterOptions} selectedOptions={experimenterSelectedOptions} />
+                                        </Card.Body>
+                                    </Card>
+                                </Col>
+                            </Row>
+
+                            <Row className="mb-4">
+                                <Col>
+                                    <Card>
+                                        <Card.Header as="h5">ADEPT Users</Card.Header>
+                                        <Card.Body>
+                                            <Card.Text>
+                                                Manage ADEPT user settings.
+                                            </Card.Text>
+                                            <h6>Modify Current ADEPT Users</h6>
+                                            <AdeptInputBox options={adeptOptions} selectedOptions={adeptSelectedOptions} />
                                         </Card.Body>
                                     </Card>
                                 </Col>

--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -26,10 +26,10 @@ const GET_SIM_DATA = gql`
         getAllSimAlignment
     }`;
 
-const HEADERS = ['Participant ID', 'Participant Type', 'Evaluation', 'Sim Date', 'Sim Count', 'Sim-1', 'Sim-2', 'Sim-3', 'Sim-4', 'Del Date', 'Delegation', 'Text Date', 'Text', 'IO1', 'MJ1', 'MJ2', 'MJ4', 'MJ5', 'QOL1', 'QOL2', 'QOL3', 'QOL4', 'VOL1', 'VOL2', 'VOL3', 'VOL4'];
+const HEADERS_NO_PROLIFIC = ['Participant ID', 'Participant Type', 'Evaluation', 'Sim Date', 'Sim Count', 'Sim-1', 'Sim-2', 'Sim-3', 'Sim-4', 'Del Date', 'Delegation', 'Text Date', 'Text', 'IO1', 'MJ1', 'MJ2', 'MJ4', 'MJ5', 'QOL1', 'QOL2', 'QOL3', 'QOL4', 'VOL1', 'VOL2', 'VOL3', 'VOL4'];
+const HEADERS_WITH_PROLIFIC = ['Participant ID', 'Participant Type', 'Evaluation', 'Prolific ID', 'Contact ID', 'Sim Date', 'Sim Count', 'Sim-1', 'Sim-2', 'Sim-3', 'Sim-4', 'Del Date', 'Delegation', 'Text Date', 'Text', 'IO1', 'MJ1', 'MJ2', 'MJ4', 'MJ5', 'QOL1', 'QOL2', 'QOL3', 'QOL4', 'VOL1', 'VOL2', 'VOL3', 'VOL4'];
 
-
-export function ParticipantProgressTable() {
+export function ParticipantProgressTable({ canViewProlific = false }) {
     const { loading: loadingParticipantLog, error: errorParticipantLog, data: dataParticipantLog, refetch: refetchPLog } = useQuery(GET_PARTICIPANT_LOG, { fetchPolicy: 'no-cache' });
     const { loading: loadingSurveyResults, error: errorSurveyResults, data: dataSurveyResults, refetch: refetchSurveyResults } = useQuery(GET_SURVEY_RESULTS, { fetchPolicy: 'no-cache' });
     const { loading: loadingTextResults, error: errorTextResults, data: dataTextResults, refetch: refetchTextResults } = useQuery(GET_TEXT_RESULTS, { fetchPolicy: 'no-cache' });
@@ -42,6 +42,7 @@ export function ParticipantProgressTable() {
     const [evalFilters, setEvalFilters] = React.useState([]);
     const [completionFilters, setCompletionFilters] = React.useState([]);
     const [filteredData, setFilteredData] = React.useState([]);
+    const HEADERS = canViewProlific ? HEADERS_WITH_PROLIFIC : HEADERS_NO_PROLIFIC;
 
     React.useEffect(() => {
         if (dataParticipantLog?.getParticipantLog && dataSurveyResults?.getAllSurveyResults && dataTextResults?.getAllScenarioResults && dataSim?.getAllSimAlignment) {
@@ -78,6 +79,10 @@ export function ParticipantProgressTable() {
                 obj['Del Date'] = survey_date != 'Invalid Date' ? `${survey_date?.getMonth() + 1}/${survey_date?.getDate()}/${survey_date?.getFullYear()}` : undefined;
                 obj['Delegation'] = surveys.length;
                 obj['Evaluation'] = obj['Evaluation'] ?? lastSurvey?.evalName;
+                if (canViewProlific) {
+                    obj['Prolific ID'] = res['prolificId'];
+                    obj['Contact ID'] = res['contactId'];
+                }
 
                 const scenarios = textResults.filter((x) => x.participantID == pid);
                 const lastScenario = scenarios?.slice(-1)?.[0];

--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -63,6 +63,10 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
 
                 const sims = simResults.filter((x) => x.pid == pid).sort((a, b) => a.timestamp - b.timestamp);
                 obj['Evaluation'] = sims[0]?.evalName;
+                if (canViewProlific) {
+                    obj['Prolific ID'] = res['prolificId'];
+                    obj['Contact ID'] = res['contactId'];
+                }
                 const sim_date = new Date(sims[0]?.timestamp);
                 obj['Sim Date'] = sim_date != 'Invalid Date' ? `${sim_date?.getMonth() + 1}/${sim_date?.getDate()}/${sim_date?.getFullYear()}` : undefined;
                 obj['Sim Count'] = sims.length;
@@ -79,10 +83,7 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
                 obj['Del Date'] = survey_date != 'Invalid Date' ? `${survey_date?.getMonth() + 1}/${survey_date?.getDate()}/${survey_date?.getFullYear()}` : undefined;
                 obj['Delegation'] = surveys.length;
                 obj['Evaluation'] = obj['Evaluation'] ?? lastSurvey?.evalName;
-                if (canViewProlific) {
-                    obj['Prolific ID'] = res['prolificId'];
-                    obj['Contact ID'] = res['contactId'];
-                }
+
 
                 const scenarios = textResults.filter((x) => x.participantID == pid);
                 const lastScenario = scenarios?.slice(-1)?.[0];

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -197,8 +197,8 @@ function ProgressTable({ newState }) {
     if (newState.currentUser === null) {
         history.push("/login");
     } else {
-        if (newState.currentUser.experimenter || newState.currentUser.admin || newState.evaluator) {
-            return <ParticipantProgressTable />
+        if (newState.currentUser.experimenter || newState.currentUser.admin || newState.currentUser.evaluator || newState.currentUser.adeptUser) {
+            return <ParticipantProgressTable canViewProlific={newState.currentUser.adeptUser || newState.currentUser.admin} />
         } else {
             return <Home newState={newState} />;
         }

--- a/dashboard-ui/src/components/OnlineOnly/OnlineOnly.jsx
+++ b/dashboard-ui/src/components/OnlineOnly/OnlineOnly.jsx
@@ -73,8 +73,9 @@ export default function StartOnline() {
         ).map((x) => Number(x['ParticipantID'])), lowPid - 1) + 1;
         // get correct plog data
         const setNum = newPid % 24;
+        const currentSearchParams = new URLSearchParams(location.search);
         const participantData = {
-            ...LOG_VARIATIONS[setNum], "ParticipantID": newPid, "Type": "Online",
+            ...LOG_VARIATIONS[setNum], "ParticipantID": newPid, "Type": "Online", "prolificId": currentSearchParams.get('PROLIFIC_PID'), "contactId": currentSearchParams.get('ContactID'),
             "claimed": true, "simEntryCount": 0, "surveyEntryCount": 0, "textEntryCount": 0, "hashedEmail": bcrypt.hashSync(newPid.toString(), "$2a$10$" + process.env.REACT_APP_EMAIL_SALT)
         };
         // update database
@@ -83,7 +84,7 @@ export default function StartOnline() {
         newPid = addRes?.data?.addNewParticipantToLog?.ops?.[0]?.ParticipantID;
 
 
-        const currentSearchParams = new URLSearchParams(location.search);
+
         currentSearchParams.set('pid', newPid);
         currentSearchParams.set('class', 'Online');
         history.push({

--- a/dashboard-ui/src/services/accountsService.js
+++ b/dashboard-ui/src/services/accountsService.js
@@ -29,6 +29,7 @@ const accountsGraphQL = new GraphQLClient({
       admin
       evaluator
       experimenter
+      adeptUser
     }
   `,
 });

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -46,6 +46,7 @@ const typeDefs = gql`
     admin: Boolean
     evaluator: Boolean
     experimenter: Boolean
+    adeptUser: Boolean
   }
 
   type Player {
@@ -240,6 +241,7 @@ const typeDefs = gql`
     updateAdminUser(username: String, isAdmin: Boolean): JSON,
     updateEvaluatorUser(username: String, isEvaluator: Boolean): JSON,
     updateExperimenterUser(username: String, isExperimenter: Boolean): JSON,
+    updateAdeptUser(username: String, isAdeptUser: Boolean): JSON,
     uploadSurveyResults(surveyId: String, results: JSON): JSON,
     uploadScenarioResults(results: [JSON]): JSON,
     addNewParticipantToLog(participantData: JSON, lowPid: Int, highPid: Int): JSON,
@@ -600,6 +602,12 @@ const resolvers = {
       return await dashboardDB.db.collection('users').update(
         { "username": args["username"] },
         { $set: { "experimenter": args["isExperimenter"] } }
+      );
+    },
+    updateAdeptUser: async (obj, args, context, inflow) => {
+      return await dashboardDB.db.collection('users').update(
+        { "username": args["username"] },
+        { $set: { "adeptUser": args["isAdeptUser"] } }
       );
     },
     uploadSurveyResults: async (obj, args, context, inflow) => {


### PR DESCRIPTION
Created a new role: adeptUser
Added two new columns to progress table: prolific id and contact id
Stored two new parameters in the participant log: prolific id and contact id (will only appear for online users)

Only adeptUsers and admins can view prolific id and contact id in the progress table. 

Test to make sure the adeptUser box on the admin page works properly, and that being an adeptUser and not an admin, or an admin and not an adeptUser, or both, works for populating ProlificId and contactID in the progress table.

Make sure if you are not an adept user or admin, you cannot view those two columns. Make sure the download does not include those two columns