### PR TITLE
Itm 755 skip text

### DIFF
--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -66,7 +66,7 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
                 if (canViewProlific) {
                     obj['Prolific ID'] = res['prolificId'];
                     obj['Contact ID'] = res['contactId'];
-                    if (res['prolificId']) obj['Survey Link'] = `https://darpaitm.caci.com/remote-text-survey?adeptQualtrix=true&PROLIFIC_PID=${res['prolificId']}&ContactID=${res['contactId']}&pid=${pid}&class=Online&startSurvey=true`
+                    if (res['prolificId']) obj['Survey Link'] = `https://darpaitm.caci.com/remote-text-survey?adeptQualtrix=true&PROLIFIC_PID=${res['prolificId']}&ContactID=${res['contactId']}&pid=${pid}&class=Online&startSurvey=true`;
                 }
                 const sim_date = new Date(sims[0]?.timestamp);
                 obj['Sim Date'] = sim_date != 'Invalid Date' ? `${sim_date?.getMonth() + 1}/${sim_date?.getDate()}/${sim_date?.getFullYear()}` : undefined;
@@ -91,6 +91,7 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
                 const text_date = new Date(lastScenario?.timeComplete);
                 obj['Text Date'] = text_date != 'Invalid Date' ? `${text_date?.getMonth() + 1}/${text_date?.getDate()}/${text_date?.getFullYear()}` : undefined;
                 obj['Text'] = scenarios.length;
+                if (obj['Text'] < 5) obj['Survey Link'] = null;
                 obj['Evaluation'] = obj['Evaluation'] ?? lastScenario?.evalName;
                 const completedScenarios = scenarios.map((x) => x.scenario_id);
                 obj['IO1'] = completedScenarios.includes('DryRunEval.IO1') || completedScenarios.includes('phase1-adept-train-IO1') ? 'y' : null;

--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -27,7 +27,7 @@ const GET_SIM_DATA = gql`
     }`;
 
 const HEADERS_NO_PROLIFIC = ['Participant ID', 'Participant Type', 'Evaluation', 'Sim Date', 'Sim Count', 'Sim-1', 'Sim-2', 'Sim-3', 'Sim-4', 'Del Date', 'Delegation', 'Text Date', 'Text', 'IO1', 'MJ1', 'MJ2', 'MJ4', 'MJ5', 'QOL1', 'QOL2', 'QOL3', 'QOL4', 'VOL1', 'VOL2', 'VOL3', 'VOL4'];
-const HEADERS_WITH_PROLIFIC = ['Participant ID', 'Participant Type', 'Evaluation', 'Prolific ID', 'Contact ID', 'Sim Date', 'Sim Count', 'Sim-1', 'Sim-2', 'Sim-3', 'Sim-4', 'Del Date', 'Delegation', 'Text Date', 'Text', 'IO1', 'MJ1', 'MJ2', 'MJ4', 'MJ5', 'QOL1', 'QOL2', 'QOL3', 'QOL4', 'VOL1', 'VOL2', 'VOL3', 'VOL4'];
+const HEADERS_WITH_PROLIFIC = ['Participant ID', 'Participant Type', 'Evaluation', 'Prolific ID', 'Contact ID', 'Survey Link', 'Sim Date', 'Sim Count', 'Sim-1', 'Sim-2', 'Sim-3', 'Sim-4', 'Del Date', 'Delegation', 'Text Date', 'Text', 'IO1', 'MJ1', 'MJ2', 'MJ4', 'MJ5', 'QOL1', 'QOL2', 'QOL3', 'QOL4', 'VOL1', 'VOL2', 'VOL3', 'VOL4'];
 
 export function ParticipantProgressTable({ canViewProlific = false }) {
     const { loading: loadingParticipantLog, error: errorParticipantLog, data: dataParticipantLog, refetch: refetchPLog } = useQuery(GET_PARTICIPANT_LOG, { fetchPolicy: 'no-cache' });
@@ -66,6 +66,7 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
                 if (canViewProlific) {
                     obj['Prolific ID'] = res['prolificId'];
                     obj['Contact ID'] = res['contactId'];
+                    if (res['prolificId']) obj['Survey Link'] = `https://darpaitm.caci.com/remote-text-survey?adeptQualtrix=true&PROLIFIC_PID=${res['prolificId']}&ContactID=${res['contactId']}&pid=${pid}&class=Online&startSurvey=true`
                 }
                 const sim_date = new Date(sims[0]?.timestamp);
                 obj['Sim Date'] = sim_date != 'Invalid Date' ? `${sim_date?.getMonth() + 1}/${sim_date?.getDate()}/${sim_date?.getFullYear()}` : undefined;
@@ -135,8 +136,12 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
             return 'white-cell';
         };
         return (<td key={dataSet['Participant_ID'] + '-' + header} className={getClassName(header, val) + ' ' + (header.length < 5 ? 'small-column' : '')}>
-            {val ?? '-'}
+            {header == 'Survey Link' && val ? <button onClick={() => copyLink(val)} className='downloadBtn'>Copy Link</button> : <span>{val ?? '-'}</span>}
         </td>);
+    };
+
+    const copyLink = (linkToCopy) => {
+        navigator.clipboard.writeText(linkToCopy);
     };
 
     React.useEffect(() => {
@@ -192,7 +197,7 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
                     multiple
                     options={evals}
                     filterSelectedOptions
-                    size="small"
+                    size="small" 
                     style={{ width: '400px' }}
                     renderInput={(params) => (
                         <TextField

--- a/dashboard-ui/src/components/OnlineOnly/OnlineOnly.jsx
+++ b/dashboard-ui/src/components/OnlineOnly/OnlineOnly.jsx
@@ -58,6 +58,9 @@ export default function StartOnline() {
         if (adeptQualtrix != 'true') {
             history.push('/login');
         }
+        if (queryParams.get('startSurvey') == 'true') {
+            setTextTime(true);
+        }
     }, []);
 
     const startSurvey = async () => {

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -103,7 +103,8 @@ class TextBasedScenariosPage extends Component {
             startSurvey: true,
             updatePLog: false,
             startCount: 0,
-            onlineOnly: false
+            onlineOnly: false,
+            skipText: false
         };
 
         this.surveyData = {};
@@ -238,6 +239,7 @@ class TextBasedScenariosPage extends Component {
         const pid = queryParams.get('pid');
         const classification = queryParams.get('class');
         const adeptQualtrix = queryParams.get('adeptQualtrix');
+        const startSurvey = queryParams.get('startSurvey');
         if (isDefined(pid)) {
             this.introSurvey.data = {
                 "Participant ID": pid,
@@ -245,9 +247,14 @@ class TextBasedScenariosPage extends Component {
                 "vrEnvironmentsCompleted": ['none']
             };
             if (isDefined(adeptQualtrix)) {
-                this.setState({ moderated: false, startSurvey: true, onlineOnly: true }, () => {
-                    this.introSurveyComplete(this.introSurvey);
-                });
+                if (startSurvey == 'true') {
+                    this.setState({ moderated: false, onlineOnly: true, skipText: true });
+                }
+                else {
+                    this.setState({ moderated: false, startSurvey: true, onlineOnly: true }, () => {
+                        this.introSurveyComplete(this.introSurvey);
+                    });
+                }
             }
             else {
                 this.setState({ moderated: false, startSurvey: false }, () => {
@@ -650,10 +657,10 @@ class TextBasedScenariosPage extends Component {
     render() {
         return (
             <>
-                {!this.state.currentConfig && (
+                {!this.state.skipText && !this.state.currentConfig && (
                     <Survey model={this.introSurvey} />
                 )}
-                {!this.state.moderated && !this.state.startSurvey && (
+                {!this.state.skipText && !this.state.moderated && !this.state.startSurvey && (
                     <div className="text-instructions">
                         <h2>Instructions</h2>
                         <p><b>Welcome to the ITM Text Scenario experiment. Thank you for your participation.</b>
@@ -675,7 +682,7 @@ class TextBasedScenariosPage extends Component {
                 )
 
                 }
-                {this.state.currentConfig && !this.state.allScenariosCompleted && this.state.startSurvey && (
+                {!this.state.skipText && this.state.currentConfig && !this.state.allScenariosCompleted && this.state.startSurvey && (
                     <>
                         <Survey model={this.survey} />
                         {this.shouldBlockNavigation && (
@@ -686,7 +693,7 @@ class TextBasedScenariosPage extends Component {
                         )}
                     </>
                 )}
-                {this.state.uploadData && (
+                {!this.state.skipText && this.state.uploadData && (
                     <Mutation
                         mutation={UPLOAD_SCENARIO_RESULTS}
                         onCompleted={() => {
@@ -715,7 +722,7 @@ class TextBasedScenariosPage extends Component {
                         )}
                     </Mutation>
                 )}
-                {this.state.updatePLog && (
+                {!this.state.skipText && this.state.updatePLog && (
                     <Mutation mutation={UPDATE_PARTICIPANT_LOG}>
                         {(updateParticipantLog) => (
                             <div>
@@ -730,7 +737,7 @@ class TextBasedScenariosPage extends Component {
                         )}
                     </Mutation>
                 )}
-                {this.state.allScenariosCompleted && (this.state.uploadedScenarios != this.state.scenarios.length) && (
+                {!this.state.skipText && this.state.allScenariosCompleted && (this.state.uploadedScenarios != this.state.scenarios.length) && (
                     <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.5)', display: 'flex', justifyContent: 'center', alignItems: 'center', zIndex: 9999 }}>
                         <div style={{ backgroundColor: 'white', padding: '20px', borderRadius: '10px', textAlign: 'center' }}>
                             <Spinner animation="border" role="status">
@@ -740,7 +747,7 @@ class TextBasedScenariosPage extends Component {
                         </div>
                     </div>
                 )}
-                {this.state.allScenariosCompleted && this.state.uploadedScenarios === this.state.scenarios.length && (
+                {(this.state.skipText || (this.state.allScenariosCompleted && this.state.uploadedScenarios === this.state.scenarios.length)) && (
                     <ScenarioCompletionScreen
                         sim1={this.state.sim1}
                         sim2={this.state.sim2}


### PR DESCRIPTION
Added new column to participant progress table (only for adept users and admin!). Shows "Copy Link" button when prolific id is available. Copies a link straight to your clipboard with the prolific id, contact id, pid, and other online parameters AND a new parameter called startSurvey. 

If startSurvey is true (which it will be when you copy the link), the participant will be brought directly to the survey (skipping the intro page and text). The pid should stay the same and data will not be overridden in the database.

The link should only be copiable if all 5 text scenarios have been completed!