### PR TITLE
Adept online survey block navigation from page

### DIFF
--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -726,7 +726,7 @@ class SurveyPage extends Component {
         window.addEventListener('popstate', this.handlePopState);
 
         // push initial state to prevent back navigation
-        window.history.pushState(null, '', window.location.pathname);
+        window.history.pushState(null, '', window.location.href);
     }
 
     handleBeforeUnload = (e) => {
@@ -748,7 +748,7 @@ class SurveyPage extends Component {
             } else {
                 // prevent navigation
                 e.preventDefault();
-                window.history.pushState(null, '', window.location.pathname);
+                window.history.pushState(null, '', window.location.href);
             }
         }
     };

--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -14,7 +14,6 @@ import { Mutation } from '@apollo/react-components';
 import { useQuery } from 'react-apollo'
 import { generateComparisonPagev4_5, getKitwareAdms, getOrderedAdeptTargets, getParallaxAdms, getUID, shuffle, survey3_0_groups, surveyVersion_x_0 } from './surveyUtils';
 import Bowser from "bowser";
-import { Prompt } from 'react-router-dom'
 import { useSelector } from "react-redux";
 import { isDefined } from "../AggregateResults/DataFunctions";
 import { Spinner } from 'react-bootstrap';
@@ -574,7 +573,7 @@ class SurveyPage extends Component {
 
 
     uploadSurveyData = (survey, finalUpload) => {
-        if (finalUpload) {
+        if (finalUpload && survey.PageCount > 1) {
             this.setState({ surveyComplete: true });
         }
         this.timerHelper()
@@ -722,6 +721,41 @@ class SurveyPage extends Component {
 
     componentDidMount() {
         this.detectUserInfo();
+
+        window.addEventListener('beforeunload', this.handleBeforeUnload);
+        window.addEventListener('popstate', this.handlePopState);
+
+        // push initial state to prevent back navigation
+        window.history.pushState(null, '', window.location.pathname);
+    }
+
+    handleBeforeUnload = (e) => {
+        if (!this.state.surveyComplete) {
+            if (!window.confirm('Please finish the survey before leaving the page. If you leave now, you will need to start the survey over from the beginning.')) {
+                e.preventDefault();
+                e.returnValue = '';
+                return '';
+            }
+        }
+    };
+
+
+    handlePopState = (e) => {
+        if (!this.state.surveyComplete) {
+            if (window.confirm('Please finish the survey before leaving the page. By hitting "OK", you will be leaving the survey before completion and will be required to start the survey over from the beginning.')) {
+                // allow navigation
+                return;
+            } else {
+                // prevent navigation
+                e.preventDefault();
+                window.history.pushState(null, '', window.location.pathname);
+            }
+        }
+    };
+
+    componentWillUnmount() {
+        window.removeEventListener('beforeunload', this.handleBeforeUnload);
+        window.removeEventListener('popstate', this.handlePopState);
     }
 
     detectUserInfo = () => {
@@ -740,18 +774,12 @@ class SurveyPage extends Component {
                 <this.ConfigGetter />
                 {this.state.isSurveyLoaded &&
                     <>
-                        {this.shouldBlockNavigation && (
-                            <Prompt
-                                when={this.shouldBlockNavigation}
-                                message='Please finish the survey before leaving the page. By hitting "OK", you will be leaving the survey before completion and will be required to start the survey over from the beginning.'
-                            />
-                        )}
                         <Survey model={this.survey} />
                         {this.state.uploadData && (
                             <Mutation mutation={UPLOAD_SURVEY_RESULTS}>
                                 {(uploadSurveyResults, { data }) => (
                                     <div>
-                                    <button ref={this.uploadButtonRef} hidden onClick={(e) => {
+                                        <button ref={this.uploadButtonRef} hidden onClick={(e) => {
                                             e.preventDefault();
                                             uploadSurveyResults({
                                                 variables: { surveyId: this.state.surveyId, results: this.surveyData }
@@ -761,22 +789,22 @@ class SurveyPage extends Component {
                                     </div>
                                 )}
                             </Mutation>
-                    )}
-                    {this.state.updatePLog && (
-                        <Mutation mutation={UPDATE_PARTICIPANT_LOG} onCompleted={() => { this.state.onlineOnly && this.redirectLinkRef?.current?.click() }}>
-                            {(updateParticipantLog) => (
-                                <div>
-                                    <button ref={this.uploadButtonRefPLog} hidden onClick={(e) => {
-                                        e.preventDefault();
-                                        updateParticipantLog({
-                                            variables: { pid: this.state.pid, updates: { claimed: true, surveyEntryCount: this.state.initialUploadedCount + (this.state.hasUploaded ? 1 : 0) } }
-                                        });
-                                        this.setState({ updatePLog: false });
-                                    }}></button>
-                                </div>
-                            )}
-                        </Mutation>
-                    )}
+                        )}
+                        {this.state.updatePLog && (
+                            <Mutation mutation={UPDATE_PARTICIPANT_LOG} onCompleted={() => { this.state.onlineOnly && this.redirectLinkRef?.current?.click() }}>
+                                {(updateParticipantLog) => (
+                                    <div>
+                                        <button ref={this.uploadButtonRefPLog} hidden onClick={(e) => {
+                                            e.preventDefault();
+                                            updateParticipantLog({
+                                                variables: { pid: this.state.pid, updates: { claimed: true, surveyEntryCount: this.state.initialUploadedCount + (this.state.hasUploaded ? 1 : 0) } }
+                                            });
+                                            this.setState({ updatePLog: false });
+                                        }}></button>
+                                    </div>
+                                )}
+                            </Mutation>
+                        )}
                         <div style={{
                             position: 'fixed',
                             bottom: '1rem',
@@ -791,18 +819,18 @@ class SurveyPage extends Component {
                         }}>
                             Survey v{this.state.surveyVersion}
                         </div>
-                    {this.surveyComplete && (this.state.updatePLog || this.state.uploadData) && (
-                        <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.5)', display: 'flex', justifyContent: 'center', alignItems: 'center', zIndex: 9999 }}>
-                            <div style={{ backgroundColor: 'white', padding: '20px', borderRadius: '10px', textAlign: 'center' }}>
-                                <Spinner animation="border" role="status">
-                                    <span className="sr-only">Loading...</span>
-                                </Spinner>
-                                <p style={{ marginTop: '10px' }}>Uploading documents, please wait...</p>
+                        {this.surveyComplete && (this.state.updatePLog || this.state.uploadData) && (
+                            <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.5)', display: 'flex', justifyContent: 'center', alignItems: 'center', zIndex: 9999 }}>
+                                <div style={{ backgroundColor: 'white', padding: '20px', borderRadius: '10px', textAlign: 'center' }}>
+                                    <Spinner animation="border" role="status">
+                                        <span className="sr-only">Loading...</span>
+                                    </Spinner>
+                                    <p style={{ marginTop: '10px' }}>Uploading documents, please wait...</p>
+                                </div>
                             </div>
-                        </div>
-                    )}
-                    <a ref={this.redirectLinkRef} hidden href={`https://singuser67d7ec86.sjc1.qualtrics.com/jfe/form/SV_0pUd3RTN39qu9qS/?participant_id=${this.state.pid}&PROLIFIC_PID=${this.state.prolificPid}&ContactID=${this.state.contactId}`} />
-                </>
+                        )}
+                        <a ref={this.redirectLinkRef} hidden href={`https://singuser67d7ec86.sjc1.qualtrics.com/jfe/form/SV_0pUd3RTN39qu9qS/?participant_id=${this.state.pid}&PROLIFIC_PID=${this.state.prolificPid}&ContactID=${this.state.contactId}`} />
+                    </>
                 }
             </>
         )


### PR DESCRIPTION
For some mysterious reason, the Prompt component was not firing during the survey portion of the Adept online only experiment despite it working during the text-based scenarios. After trying to debug with Kaitlyn with no luck, I just decided to scrap that and do it a different way. 

Attempting to navigate away from the delegation survey with either the browser back button or the browser refresh button should give the user a warning instead of allowing them to navigate away immediately. The easiest way to test is to grab a link from the progress table to take you to an adept experiment delegation survey. Also make sure that it is working for the route OSU takes, which is using http://localhost:3000/survey.

<img width="459" alt="Screenshot 2024-12-12 at 1 38 09 PM" src="https://github.com/user-attachments/assets/252619fd-1356-43c7-a991-4543aabbc4bb" />

The message should look like this for the back arrow. I couldn't edit the warning for reloading but it will still ask for confirmation with the user being able to hit cancel. 

