### PR TITLE
Itm 757 legacy results

### DIFF
--- a/dashboard-ui/src/components/SurveyResults/resultsTable.css
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.css
@@ -179,3 +179,13 @@
 .small-column {
     min-width: 100px !important;
 }
+
+.simple-radios {
+    display: flex;
+    flex-direction: row;
+    min-width: 240px !important;
+    border: 1px solid rgb(175, 175, 175);
+    padding-left: 12px;
+    border-radius: 4px;
+    max-height: 40px !important;
+}

--- a/dashboard-ui/src/components/SurveyResults/resultsTable.jsx
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.jsx
@@ -11,6 +11,7 @@ import { useSelector } from "react-redux";
 import { Autocomplete, TextField } from "@mui/material";
 import { isDefined } from "../AggregateResults/DataFunctions";
 import { DownloadButtons } from "../DRE-Research/tables/download-buttons";
+import { FormControlLabel, Radio, RadioGroup } from "@mui/material";
 
 const EVAL_MAP = {
     3: 'MRE',
@@ -88,12 +89,13 @@ export function ResultsTable({ data, pLog }) {
     const [roles, setRoles] = React.useState([]);
     const [roleFilters, setRoleFilters] = React.useState([]);
     const [surveyStatus] = React.useState(['Complete', 'Incomplete']);
-    const [statusFilters, setStatusFilters] = React.useState([]);
+    const [statusFilters, setStatusFilters] = React.useState(null);
     const [militaryStatus] = React.useState(['Yes', 'No']);
-    const [milFilters, setMilFilters] = React.useState([]);
+    const [milFilters, setMilFilters] = React.useState(null);
     const [versions, setVersions] = React.useState([]);
     const [versionFilters, setVersionFilters] = React.useState([]);
     const [origHeaderSet, setOrigHeaderSet] = React.useState([]);
+    const [showLegacy, setShowLegacy] = React.useState(false);
 
 
     React.useEffect(() => {
@@ -281,6 +283,7 @@ export function ResultsTable({ data, pLog }) {
         }
     }, [versionFilters, evalFilters, formattedData, statusFilters, roleFilters, milFilters]);
 
+
     const refineData = (origData) => {
         // remove unwanted headers from download
         const updatedData = structuredClone(origData);
@@ -289,6 +292,16 @@ export function ResultsTable({ data, pLog }) {
             return x;
         });
         return updatedData;
+    };
+
+    const toggleDataType = (event) => {
+        setShowLegacy(event.target.value == 'Legacy');
+        setFilteredData(formattedData);
+        setEvalFilters([]);
+        setMilFilters(null);
+        setRoleFilters([]);
+        setStatusFilters(null);
+        setVersionFilters([]);
     };
 
     return (<>
@@ -300,7 +313,8 @@ export function ResultsTable({ data, pLog }) {
                     options={evals}
                     filterSelectedOptions
                     size="small"
-                    defaultValue={evals.filter((x) => x.value == '5')}
+                    value={evalFilters}
+                    isOptionEqualToValue={(x, y) => x.value == y.value & x.label == y.label}
                     renderInput={(params) => (
                         <TextField
                             {...params}
@@ -315,6 +329,7 @@ export function ResultsTable({ data, pLog }) {
                     options={versions}
                     filterSelectedOptions
                     size="small"
+                    value={versionFilters}
                     renderInput={(params) => (
                         <TextField
                             {...params}
@@ -329,6 +344,7 @@ export function ResultsTable({ data, pLog }) {
                     options={roles}
                     filterSelectedOptions
                     size="small"
+                    value={roleFilters}
                     renderInput={(params) => (
                         <TextField
                             {...params}
@@ -342,6 +358,7 @@ export function ResultsTable({ data, pLog }) {
                     options={militaryStatus}
                     filterSelectedOptions
                     size="small"
+                    value={milFilters}
                     renderInput={(params) => (
                         <TextField
                             {...params}
@@ -355,6 +372,7 @@ export function ResultsTable({ data, pLog }) {
                     options={surveyStatus}
                     filterSelectedOptions
                     size="small"
+                    value={statusFilters}
                     renderInput={(params) => (
                         <TextField
                             {...params}
@@ -364,7 +382,12 @@ export function ResultsTable({ data, pLog }) {
                     )}
                     onChange={(_, newVal) => setStatusFilters(newVal)}
                 />
+                <RadioGroup className='simple-radios' row defaultValue="DRE/PH1" onChange={toggleDataType}>
+                    <FormControlLabel value="Legacy" control={<Radio />} label="Legacy" />
+                    <FormControlLabel value="DRE/PH1" control={<Radio />} label="DRE/PH1" />
+                </RadioGroup>
             </div>
+
             <DownloadButtons formattedData={refineData(formattedData)} filteredData={refineData(filteredData)} HEADERS={headers} fileName={'Survey Results'} />
         </section>
         <div className='resultTableSection'>

--- a/dashboard-ui/src/components/SurveyResults/resultsTable.jsx
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.jsx
@@ -1,13 +1,5 @@
 import React from "react";
-import * as FileSaver from 'file-saver';
-import XLSX from 'sheetjs-style';
 import './resultsTable.css';
-import InputLabel from '@mui/material/InputLabel';
-import MenuItem from '@mui/material/MenuItem';
-import FormControl from '@mui/material/FormControl';
-import ListItemText from '@mui/material/ListItemText';
-import Checkbox from '@mui/material/Checkbox';
-import { useSelector } from "react-redux";
 import { Autocomplete, TextField } from "@mui/material";
 import { isDefined } from "../AggregateResults/DataFunctions";
 import { DownloadButtons } from "../DRE-Research/tables/download-buttons";
@@ -81,7 +73,7 @@ function formatTime(seconds) {
 }
 
 export function ResultsTable({ data, pLog }) {
-    const [headers, setHeaders] = React.useState(STARTING_HEADERS);
+    const [headers, setHeaders] = React.useState([...STARTING_HEADERS]);
     const [formattedData, setFormattedData] = React.useState([]);
     const [filteredData, setFilteredData] = React.useState([]);
     const [evals, setEvals] = React.useState([]);
@@ -100,162 +92,344 @@ export function ResultsTable({ data, pLog }) {
 
     React.useEffect(() => {
         if (data) {
-            const allObjs = [];
-            const allVersions = [];
-            const allEvals = [];
-            let allRoles = [];
-            const updatedHeaders = STARTING_HEADERS;
-            // set up block headers
-            for (let block = 1; block < 5; block++) {
-                for (let dm = 1; dm < 4; dm++) {
-                    const subheaders = ['TA1', 'TA2', 'Type', 'Target', 'Name', 'Time', 'Scenario', 'Agreement', 'SRAlign', 'Trustworthy', 'Trust'];
-                    for (let subhead of subheaders) {
-                        updatedHeaders.push(`B${block}_DM${dm}_${subhead}`);
-                    }
-                }
-                const comparisons = ['Compare_DM1', 'Compare_DM2', 'Compare_DM3', 'Compare_Time', 'Compare_FC1', 'Compare_FC1_Conf', 'Compare_FC1_Explain', 'Compare_FC2', 'Compare_FC2_Conf', 'Compare_FC2_Explain'];
-                for (let subhead of comparisons) {
-                    updatedHeaders.push(`B${block}_${subhead}`);
+            if (showLegacy) {
+                setLegacyData(data);
+            }
+            else {
+                setDrePh1Data(data);
+            }
+        }
+    }, [data, pLog, showLegacy]);
+
+
+    const setDrePh1Data = (data) => {
+        const allObjs = [];
+        const allEvals = [];
+        let allRoles = [];
+        const updatedHeaders = [...STARTING_HEADERS];
+        // set up block headers
+        for (let block = 1; block < 5; block++) {
+            for (let dm = 1; dm < 4; dm++) {
+                const subheaders = ['TA1', 'TA2', 'Type', 'Target', 'Name', 'Time', 'Scenario', 'Agreement', 'SRAlign', 'Trustworthy', 'Trust'];
+                for (let subhead of subheaders) {
+                    updatedHeaders.push(`B${block}_DM${dm}_${subhead}`);
                 }
             }
-            for (let entry of data) {
-                const obj = {};
-                // not shown in table, just for filters
-                obj['eval'] = entry.evalNumber ?? entry.results?.evalNumber;
+            const comparisons = ['Compare_DM1', 'Compare_DM2', 'Compare_DM3', 'Compare_Time', 'Compare_FC1', 'Compare_FC1_Conf', 'Compare_FC1_Explain', 'Compare_FC2', 'Compare_FC2_Conf', 'Compare_FC2_Explain'];
+            for (let subhead of comparisons) {
+                updatedHeaders.push(`B${block}_${subhead}`);
+            }
+        }
+        for (let entry of data) {
+            const obj = {};
+            // not shown in table, just for filters
+            obj['eval'] = entry.evalNumber ?? entry.results?.evalNumber;
 
-                // clean up data, only showing relevant entries
-                entry = entry.results ?? entry;
-                if (!entry) {
-                    continue;
-                }
+            // clean up data, only showing relevant entries
+            entry = entry.results ?? entry;
+            if (!entry) {
+                continue;
+            }
 
-                // ignore invalid versions
-                const version = entry.surveyVersion;
-                if (!version || version < 4) {
-                    // TODO: show this somewhere else
-                    continue;
-                }
+            // ignore invalid versions
+            const version = entry.surveyVersion;
+            if (!version || version < 4) {
+                continue;
+            }
 
-                // ignore invalid pids
-                let pid = entry['Participant ID']?.questions['Participant ID']?.response ?? entry['Participant ID Page']?.questions['Participant ID']?.response ?? entry['pid'];
-                if (!pid) {
-                    continue;
-                }
-                const logData = pLog.find(
-                    log => log['ParticipantID'] == pid && log['Type'] != 'Test'
-                );
-                if ((version == 4 || version == 5) && !logData) {
-                    continue;
-                }
-                if (obj['eval'] == 3 && pid.slice(0, 4) != '2024') {
-                    continue;
-                }
+            // ignore invalid pids
+            let pid = entry['Participant ID']?.questions['Participant ID']?.response ?? entry['Participant ID Page']?.questions['Participant ID']?.response ?? entry['pid'];
+            if (!pid) {
+                continue;
+            }
+            const logData = pLog.find(
+                log => log['ParticipantID'] == pid && log['Type'] != 'Test'
+            );
+            if ((version == 4 || version == 5) && !logData) {
+                continue;
+            }
 
-                const lastPage = entry['Post-Scenario Measures'];
+            const lastPage = entry['Post-Scenario Measures'];
 
-                // add data to filter options
-                allEvals.push(obj['eval']);
-                allVersions.push(version);
+            // add data to filter options
+            allEvals.push(obj['eval']);
 
-                // add data to table
-                obj['Participant ID'] = pid;
-                obj['Survey Version'] = version;
-                obj['Start Time'] = entry.startTime ? new Date(entry.startTime)?.toLocaleString() : null;
-                obj['End Time'] = new Date(entry.timeComplete)?.toLocaleString();
-                const timeDifSeconds = (new Date(entry.timeComplete).getTime() - new Date(entry.startTime).getTime()) / 1000;
-                obj['Total Time'] = entry.startTime ? formatTime(timeDifSeconds) : null;
-                if (lastPage) {
-                    obj['Post-Scenario Measures - Time Taken (mm:ss)'] = formatTime(lastPage.timeSpentOnPage);
-                    for (const q of Object.keys(lastPage.questions)) {
-                        if (q != 'What is your current role (choose all that apply):') {
-                            obj[q] = lastPage.questions[q].response?.toString();
-                        }
-                        else {
-                            const roles = lastPage.questions[q].response?.toString();
-                            allRoles = [...allRoles, ...roles.split(',')];
-                            obj[q] = roles.replaceAll(',', '; ');
-                        }
+            // add data to table
+            obj['Participant ID'] = pid;
+            obj['Survey Version'] = version;
+            obj['Start Time'] = entry.startTime ? new Date(entry.startTime)?.toLocaleString() : null;
+            obj['End Time'] = new Date(entry.timeComplete)?.toLocaleString();
+            const timeDifSeconds = (new Date(entry.timeComplete).getTime() - new Date(entry.startTime).getTime()) / 1000;
+            obj['Total Time'] = entry.startTime ? formatTime(timeDifSeconds) : null;
+            if (lastPage) {
+                obj['Post-Scenario Measures - Time Taken (mm:ss)'] = formatTime(lastPage.timeSpentOnPage);
+                for (const q of Object.keys(lastPage.questions)) {
+                    if (q != 'What is your current role (choose all that apply):') {
+                        obj[q] = lastPage.questions[q].response?.toString();
+                    }
+                    else {
+                        const roles = lastPage.questions[q].response?.toString();
+                        allRoles = [...allRoles, ...roles.split(',')];
+                        obj[q] = roles.replaceAll(',', '; ');
                     }
                 }
+            }
 
-                if (!entry['Note page']) {
+            if (!entry['Note page']) {
+                continue;
+            }
+            if (entry['VR Page']) {
+                obj["VR Experience Level"] = entry['VR Page']?.questions?.['VR Experience Level']?.response?.slice(0, 1);
+                obj["VR Comfort Level"] = entry['VR Page']?.questions?.['VR Comfort Level']?.response;
+                obj["Additional Information About Discomfort"] = entry['VR Page']?.questions?.['Additional Information About Discomfort']?.response;
+            }
+            else {
+                obj["VR Comfort Level"] = entry['Participant ID Page']?.questions?.['VR Comfort Level']?.response;
+                obj["Additional Information About Discomfort"] = entry['Participant ID Page']?.questions?.['Additional Information About Discomfort']?.response;
+                obj["Have you completed the text-based scenarios"] = entry['Participant ID Page']?.questions?.['Have you completed the text-based scenarios']?.response;
+                obj["VR Scenarios Completed"] = entry['Participant ID Page']?.questions?.['VR Scenarios Completed']?.response;
+            }
+            obj["Note Page - Time Taken (mm:ss)"] = formatTime(entry['Note page'].timeSpentOnPage);
+
+
+            // get blocks of dms
+            let block = 1;
+            let dm = 1;
+            for (const pageName of (entry['orderLog'] ?? Object.keys(entry)).filter((x) => x.includes('Medic'))) {
+                const page = entry[pageName];
+                if (!page) {
+                    // should never occur
+                    if (lastPage) {
+                        console.error('Page not found! ', pageName);
+                    }
                     continue;
                 }
-                if (entry['VR Page']) {
-                    obj["VR Experience Level"] = entry['VR Page']?.questions?.['VR Experience Level']?.response?.slice(0, 1);
-                    obj["VR Comfort Level"] = entry['VR Page']?.questions?.['VR Comfort Level']?.response;
-                    obj["Additional Information About Discomfort"] = entry['VR Page']?.questions?.['Additional Information About Discomfort']?.response;
+                if (page.pageType == 'singleMedic') {
+                    obj[`B${block}_DM${dm}_TA1`] = page.scenarioIndex?.includes('vol') || page.scenarioIndex?.includes('qol') ? 'ST' : 'AD';
+                    obj[`B${block}_DM${dm}_TA2`] = page.admAuthor.replace('kitware', 'Kitware').replace('TAD', 'Parallax');
+                    obj[`B${block}_DM${dm}_Type`] = page.admAlignment;
+                    obj[`B${block}_DM${dm}_Target`] = page.admTarget;
+                    obj[`B${block}_DM${dm}_Name`] = pageName;
+                    obj[`B${block}_DM${dm}_Time`] = formatTime(page.timeSpentOnPage);
+                    obj[`B${block}_DM${dm}_Scenario`] = page.scenarioIndex;
+                    obj[`B${block}_DM${dm}_Agreement`] = TRUST_MAP[page.questions?.[pageName + ': Do you agree with the decisions that this medic made?']?.response];
+                    obj[`B${block}_DM${dm}_SRAlign`] = TRUST_MAP[page.questions?.[pageName + ': The way this medic makes medical decisions is how I make decisions']?.response];
+                    obj[`B${block}_DM${dm}_Trustworthy`] = TRUST_MAP[page.questions?.[pageName + ': This medic is trustworthy']?.response];
+                    obj[`B${block}_DM${dm}_Trust`] = TRUST_MAP[page.questions?.[pageName + ': I would be comfortable allowing this medic to execute medical triage, even if I could not monitor it']?.response];
+                    dm += 1;
                 }
-                else {
-                    obj["VR Comfort Level"] = entry['Participant ID Page']?.questions?.['VR Comfort Level']?.response;
-                    obj["Additional Information About Discomfort"] = entry['Participant ID Page']?.questions?.['Additional Information About Discomfort']?.response;
-                    obj["Have you completed the text-based scenarios"] = entry['Participant ID Page']?.questions?.['Have you completed the text-based scenarios']?.response;
-                    obj["VR Scenarios Completed"] = entry['Participant ID Page']?.questions?.['VR Scenarios Completed']?.response;
+                else if (page.pageType == 'comparison') {
+                    const alignment = page.admAlignment?.split(' vs ');
+                    const order = pageName.replace(' vs  vs ', ' vs ').split(' vs ');
+                    const alignedVsBaseline = order[alignment.indexOf('aligned')] + ' vs ' + order[alignment.indexOf('baseline')];
+                    const alignedVsMisaligned = order[alignment.indexOf('aligned')] + ' vs ' + order[alignment.indexOf('misaligned')];
+                    obj[`B${block}_Compare_DM1`] = order[0] + ' - ' + alignment[0];
+                    obj[`B${block}_Compare_DM2`] = order[1] + ' - ' + alignment[1];
+                    obj[`B${block}_Compare_DM3`] = order[2] + ' - ' + alignment[2];
+                    obj[`B${block}_Compare_Time`] = formatTime(page.timeSpentOnPage);
+                    const fc1 = page.questions?.[alignedVsBaseline + ': Forced Choice']?.response
+                    obj[`B${block}_Compare_FC1`] = fc1 + ' - ' + alignment[order.indexOf(fc1)];
+                    obj[`B${block}_Compare_FC1_Conf`] = CONFIDENCE_MAP[page.questions?.[alignedVsBaseline + ': Rate your confidence about the delegation decision indicated in the previous question']?.response];
+                    obj[`B${block}_Compare_FC1_Explain`] = page.questions?.[alignedVsBaseline + ': Explain your response to the delegation preference question']?.response;
+                    const fc2 = page.questions?.[alignedVsMisaligned + ': Forced Choice']?.response
+                    obj[`B${block}_Compare_FC2`] = fc2 + ' - ' + alignment[order.indexOf(fc2)];
+                    obj[`B${block}_Compare_FC2_Conf`] = CONFIDENCE_MAP[page.questions?.[alignedVsMisaligned + ': Rate your confidence about the delegation decision indicated in the previous question']?.response];
+                    obj[`B${block}_Compare_FC2_Explain`] = page.questions?.[alignedVsMisaligned + ': Explain your response to the delegation preference question']?.response;
+                    block += 1;
+                    dm = 1;
                 }
-                obj["Note Page - Time Taken (mm:ss)"] = formatTime(entry['Note page'].timeSpentOnPage);
+            }
+
+            allObjs.push(obj);
+        }
+        // prep filters and data (sort by pid)
+        allObjs.sort((a, b) => a['Participant ID'] - b['Participant ID']);
+        setEvals(Array.from(new Set(allEvals)).filter((x) => isDefined(x)).map((x) => { return { 'value': x.toString(), 'label': x + ' - ' + EVAL_MAP[x] } }));
+        setFormattedData(allObjs);
+        setFilteredData(allObjs);
+        setHeaders(updatedHeaders);
+        setRoles(Array.from(new Set(allRoles)));
+        setOrigHeaderSet(updatedHeaders);
+    };
 
 
-                // get blocks of dms
-                let block = 1;
-                let dm = 1;
-                for (const pageName of (entry['orderLog'] ?? Object.keys(entry)).filter((x) => x.includes('Medic'))) {
-                    const page = entry[pageName];
-                    if (!page) {
-                        // should never occur
-                        if (lastPage) {
-                            console.error('Page not found! ', pageName);
-                        }
-                        continue;
+    const setLegacyData = (data) => {
+        const allObjs = [];
+        const allVersions = [];
+        let allRoles = [];
+        const updatedHeaders = [...STARTING_HEADERS];
+        // set up block headers
+        const subheaders = ['Name', 'Time', 'Scenario', 'Agreement', 'SRAlign', 'Trustworthy', 'Trust'];
+        for (let block = 1; block < 5; block++) {
+            for (let dm = 1; dm < 3; dm++) {
+
+                for (let subhead of subheaders) {
+                    updatedHeaders.push(`B${block}_DM${dm}_${subhead}`);
+                }
+            }
+            const comparisons = ['Compare_DM1', 'Compare_DM2', 'Compare_Time', 'Compare_FC1', 'Compare_FC1_Conf', 'Compare_FC1_Explain', 'Compare_FC1_Differences'];
+            for (let subhead of comparisons) {
+                updatedHeaders.push(`B${block}_${subhead}`);
+            }
+        }
+        for (let block = 5; block < 7; block++) {
+            for (let omni = 1; omni < 3; omni++) {
+                for (let subhead of subheaders) {
+                    updatedHeaders.push(`B${block}_Omni${omni}_${subhead}`);
+                }
+            }
+            const comparisons = ['Compare_Omni1', 'Compare_Omni2', 'Omni_Compare_Time', 'Omni_Compare_FC1', 'Omni_Compare_FC1_Conf', 'Omni_Compare_FC1_Explain'];
+            for (let subhead of comparisons) {
+                updatedHeaders.push(`B${block}_${subhead}`);
+            }
+        }
+        for (let entry of data) {
+            const obj = {};
+            // not shown in table, just for filters
+            obj['eval'] = entry.evalNumber ?? entry.results?.evalNumber;
+
+            // clean up data, only showing relevant entries
+            entry = entry.results ?? entry;
+            if (!entry) {
+                continue;
+            }
+
+            // ignore invalid versions
+            const version = entry.surveyVersion;
+            if (!version || version >= 4) {
+                continue;
+            }
+
+            // ignore invalid pids
+            let pid = entry['Participant ID']?.questions['Participant ID']?.response ?? entry['Participant ID Page']?.questions['Participant ID']?.response ?? entry['pid'];
+            if (!pid) {
+                continue;
+            }
+            if (obj['eval'] == 3 && pid.slice(0, 4) != '2024') {
+                continue;
+            }
+
+            const lastPage = entry['Post-Scenario Measures'];
+            if (!lastPage) {
+                continue;
+            }
+
+            // add data to filter options
+            allVersions.push(version);
+
+            // add data to table
+            obj['Participant ID'] = pid;
+            obj['Survey Version'] = version;
+            obj['Start Time'] = entry.startTime ? new Date(entry.startTime)?.toLocaleString() : null;
+            obj['End Time'] = new Date(entry.timeComplete)?.toLocaleString();
+            const timeDifSeconds = (new Date(entry.timeComplete).getTime() - new Date(entry.startTime).getTime()) / 1000;
+            obj['Total Time'] = entry.startTime ? formatTime(timeDifSeconds) : null;
+            if (lastPage) {
+                obj['Post-Scenario Measures - Time Taken (mm:ss)'] = formatTime(lastPage.timeSpentOnPage);
+                for (const q of Object.keys(lastPage.questions)) {
+                    if (q != 'What is your current role (choose all that apply):') {
+                        obj[q] = lastPage.questions[q].response?.toString();
                     }
+                    else {
+                        const roles = lastPage.questions[q].response?.toString();
+                        allRoles = [...allRoles, ...roles.split(',')];
+                        obj[q] = roles.replaceAll(',', '; ');
+                    }
+                }
+            }
+
+            if (!entry['Note page']) {
+                // ignore no note page, because that means they never started the survey
+                continue;
+            }
+            if (entry['VR Page']) {
+                obj["VR Experience Level"] = entry['VR Page']?.questions?.['VR Experience Level']?.response?.slice(0, 1);
+                obj["VR Comfort Level"] = entry['VR Page']?.questions?.['VR Comfort Level']?.response;
+                obj["Additional Information About Discomfort"] = entry['VR Page']?.questions?.['Additional Information About Discomfort']?.response;
+            }
+            else {
+                obj["VR Comfort Level"] = entry['Participant ID Page']?.questions?.['VR Comfort Level']?.response;
+                obj["Additional Information About Discomfort"] = entry['Participant ID Page']?.questions?.['Additional Information About Discomfort']?.response;
+                obj["Have you completed the text-based scenarios"] = entry['Participant ID Page']?.questions?.['Have you completed the text-based scenarios']?.response;
+                const vrScenarios = entry['Participant ID Page']?.questions?.['VR Scenarios Completed']?.response?.join(',');
+                obj["VR Scenarios Completed"] = vrScenarios ? vrScenarios.split('I have completed the VR').join('').replaceAll(' ,', ',').replaceAll('sub', 'Sub').replaceAll('urb', 'Urb').replaceAll('jung', 'Jung').replaceAll('desert', 'Desert') : null;
+            }
+            obj["Note Page - Time Taken (mm:ss)"] = formatTime(entry['Note page'].timeSpentOnPage);
+
+            // get blocks of dms
+            let block = 1;
+            let dm = 1;
+            for (const pageName of (entry['orderLog'] ?? Object.keys(entry)).filter((x) => x.includes('Medic'))) {
+                const page = entry[pageName];
+                if (!page) {
+                    // should never occur
+                    if (lastPage) {
+                        console.error('Page not found! ', pageName);
+                    }
+                    continue;
+                }
+                if ((page.pageType == 'singleMedic' && !pageName.includes('Omnibus')) || (!page.pageType && pageName.includes('Scenario'))) {
+                    const cleanPageName = pageName.split(': ').slice(-1).toString();
+                    obj[`B${block}_DM${dm}_Name`] = cleanPageName;
+                    obj[`B${block}_DM${dm}_Time`] = formatTime(page.timeSpentOnPage);
+                    obj[`B${block}_DM${dm}_Scenario`] = page.scenarioIndex ?? pageName.split(': ')[0];
+                    obj[`B${block}_DM${dm}_Agreement`] = TRUST_MAP[page.questions?.[cleanPageName + ': Do you agree with the decisions that this medic made?']?.response] ?? TRUST_MAP[page.questions?.[cleanPageName + ': Do you agree with the decision that this medic made?']?.response];
+                    obj[`B${block}_DM${dm}_SRAlign`] = TRUST_MAP[page.questions?.[cleanPageName + ': The way this medic makes medical decisions is how I make decisions']?.response] ?? TRUST_MAP[page.questions?.[cleanPageName]?.response];
+                    obj[`B${block}_DM${dm}_Trustworthy`] = TRUST_MAP[page.questions?.[cleanPageName + ': This medic is trustworthy']?.response] ?? TRUST_MAP[page.questions?.[cleanPageName + ': this medic is trustworthy']?.response];
+                    obj[`B${block}_DM${dm}_Trust`] = TRUST_MAP[page.questions?.[cleanPageName + ': I would be comfortable allowing this medic to execute medical triage, even if I could not monitor it']?.response];
+                    dm += 1;
+                }
+                else if ((page.pageType == 'comparison' && !pageName.includes('Omnibus')) || (!page.pageType && pageName.includes(' vs '))) {
+                    const order = pageName.split(' vs ');
+                    obj[`B${block}_Compare_DM1`] = order[0];
+                    obj[`B${block}_Compare_DM2`] = order[1];
+                    obj[`B${block}_Compare_Time`] = formatTime(page.timeSpentOnPage);
+                    obj[`B${block}_Compare_FC1`] = page.questions?.[pageName + ': Forced Choice']?.response ?? page.questions?.[pageName + ': Given the information provided']?.response;
+                    obj[`B${block}_Compare_FC1_Conf`] = CONFIDENCE_MAP[page.questions?.[pageName + ': Rate your confidence about the delegation decision indicated in the previous question']?.response];
+                    obj[`B${block}_Compare_FC1_Explain`] = page.questions?.[pageName + ': Explain your response to the delegation preference question']?.response;
+                    obj[`B${block}_Compare_FC1_Differences`] = page.questions?.[pageName + ': What, if anything, would you have done differently in the presented scenario?']?.response;
+                    block += 1;
+                    dm = 1;
+                }
+                if (pageName.includes('Omnibus')) {
+                    const cleanPageName = pageName.split(': ').slice(-1).toString();
                     if (page.pageType == 'singleMedic') {
-                        obj[`B${block}_DM${dm}_TA1`] = page.scenarioIndex?.includes('vol') || page.scenarioIndex?.includes('qol') ? 'ST' : 'AD';
-                        obj[`B${block}_DM${dm}_TA2`] = page.admAuthor.replace('kitware', 'Kitware').replace('TAD', 'Parallax');
-                        obj[`B${block}_DM${dm}_Type`] = page.admAlignment;
-                        obj[`B${block}_DM${dm}_Target`] = page.admTarget;
-                        obj[`B${block}_DM${dm}_Name`] = pageName;
-                        obj[`B${block}_DM${dm}_Time`] = formatTime(page.timeSpentOnPage);
-                        obj[`B${block}_DM${dm}_Scenario`] = page.scenarioIndex;
-                        obj[`B${block}_DM${dm}_Agreement`] = TRUST_MAP[page.questions?.[pageName + ': Do you agree with the decisions that this medic made?']?.response];
-                        obj[`B${block}_DM${dm}_SRAlign`] = TRUST_MAP[page.questions?.[pageName + ': The way this medic makes medical decisions is how I make decisions']?.response];
-                        obj[`B${block}_DM${dm}_Trustworthy`] = TRUST_MAP[page.questions?.[pageName + ': This medic is trustworthy']?.response];
-                        obj[`B${block}_DM${dm}_Trust`] = TRUST_MAP[page.questions?.[pageName + ': I would be comfortable allowing this medic to execute medical triage, even if I could not monitor it']?.response];
+                        obj[`B${block}_Omni${dm}_Name`] = cleanPageName;
+                        obj[`B${block}_Omni${dm}_Time`] = formatTime(page.timeSpentOnPage);
+                        obj[`B${block}_Omni${dm}_Scenario`] = page.scenarioIndex ?? pageName.split(': ')[0];
+                        obj[`B${block}_Omni${dm}_Agreement`] = TRUST_MAP[page.questions?.[cleanPageName + ': Do you agree with the decisions that this medic made?']?.response] ?? TRUST_MAP[page.questions?.[cleanPageName + ': Do you agree with the decision that this medic made?']?.response];
+                        obj[`B${block}_Omni${dm}_SRAlign`] = TRUST_MAP[page.questions?.[cleanPageName + ': The way this medic makes medical decisions is how I make decisions']?.response] ?? TRUST_MAP[page.questions?.[cleanPageName]?.response];
+                        obj[`B${block}_Omni${dm}_Trustworthy`] = TRUST_MAP[page.questions?.[cleanPageName + ': This medic is trustworthy']?.response] ?? TRUST_MAP[page.questions?.[cleanPageName + ': this medic is trustworthy']?.response];
+                        obj[`B${block}_Omni${dm}_Trust`] = TRUST_MAP[page.questions?.[cleanPageName + ': I would be comfortable allowing this medic to execute medical triage, even if I could not monitor it']?.response];
                         dm += 1;
                     }
                     else if (page.pageType == 'comparison') {
-                        const alignment = page.admAlignment?.split(' vs ');
-                        const order = pageName.replace(' vs  vs ', ' vs ').split(' vs ');
-                        const alignedVsBaseline = order[alignment.indexOf('aligned')] + ' vs ' + order[alignment.indexOf('baseline')];
-                        const alignedVsMisaligned = order[alignment.indexOf('aligned')] + ' vs ' + order[alignment.indexOf('misaligned')];
-                        obj[`B${block}_Compare_DM1`] = order[0] + ' - ' + alignment[0];
-                        obj[`B${block}_Compare_DM2`] = order[1] + ' - ' + alignment[1];
-                        obj[`B${block}_Compare_DM3`] = order[2] + ' - ' + alignment[2];
-                        obj[`B${block}_Compare_Time`] = formatTime(page.timeSpentOnPage);
-                        const fc1 = page.questions?.[alignedVsBaseline + ': Forced Choice']?.response
-                        obj[`B${block}_Compare_FC1`] = fc1 + ' - ' + alignment[order.indexOf(fc1)];
-                        obj[`B${block}_Compare_FC1_Conf`] = CONFIDENCE_MAP[page.questions?.[alignedVsBaseline + ': Rate your confidence about the delegation decision indicated in the previous question']?.response];
-                        obj[`B${block}_Compare_FC1_Explain`] = page.questions?.[alignedVsBaseline + ': Explain your response to the delegation preference question']?.response;
-                        const fc2 = page.questions?.[alignedVsMisaligned + ': Forced Choice']?.response
-                        obj[`B${block}_Compare_FC2`] = fc2 + ' - ' + alignment[order.indexOf(fc2)];
-                        obj[`B${block}_Compare_FC2_Conf`] = CONFIDENCE_MAP[page.questions?.[alignedVsMisaligned + ': Rate your confidence about the delegation decision indicated in the previous question']?.response];
-                        obj[`B${block}_Compare_FC2_Explain`] = page.questions?.[alignedVsMisaligned + ': Explain your response to the delegation preference question']?.response;
+                        const order = cleanPageName.split(' vs ');
+                        obj[`B${block}_Compare_Omni1`] = order[0];
+                        obj[`B${block}_Compare_Omni2`] = order[1];
+                        obj[`B${block}_Omni_Compare_Time`] = formatTime(page.timeSpentOnPage);
+                        obj[`B${block}_Omni_Compare_FC1`] = page.questions?.[cleanPageName + ': Forced Choice']?.response ?? page.questions?.[cleanPageName + ': Given the information provided']?.response;
+                        obj[`B${block}_Omni_Compare_FC1_Conf`] = CONFIDENCE_MAP[page.questions?.[cleanPageName + ': Rate your confidence about the delegation decision indicated in the previous question']?.response];
+                        obj[`B${block}_Omni_Compare_FC1_Explain`] = page.questions?.[cleanPageName + ': Explain your response to the delegation preference question']?.response;
                         block += 1;
                         dm = 1;
                     }
                 }
-
-                allObjs.push(obj);
             }
-            // prep filters and data (sort by pid)
-            allObjs.sort((a, b) => a['Participant ID'] - b['Participant ID']);
-            setVersions(Array.from(new Set(allVersions)).filter((x) => isDefined(x)).map((x) => x.toString()));
-            setEvals(Array.from(new Set(allEvals)).filter((x) => isDefined(x)).map((x) => { return { 'value': x.toString(), 'label': x + ' - ' + EVAL_MAP[x] } }));
-            setFormattedData(allObjs);
-            setFilteredData(allObjs);
-            setHeaders(updatedHeaders);
-            setRoles(Array.from(new Set(allRoles)));
-            setOrigHeaderSet(updatedHeaders);
+
+            allObjs.push(obj);
         }
-    }, [data, pLog]);
+        // prep filters and data (sort by pid)
+        allObjs.sort((a, b) => a['Participant ID'] - b['Participant ID']);
+        setVersions(Array.from(new Set(allVersions)).filter((x) => isDefined(x)).map((x) => x.toString()));
+        setFormattedData(allObjs);
+        setFilteredData(allObjs);
+        setHeaders(updatedHeaders);
+        setRoles(Array.from(new Set(allRoles)));
+        setOrigHeaderSet(updatedHeaders);
+    };
+
+
 
     React.useEffect(() => {
         const filtered = formattedData.filter((x) =>
@@ -270,25 +444,36 @@ export function ResultsTable({ data, pLog }) {
         setFilteredData(filtered);
         // remove extra headers that have no data
         if (formattedData.length > 0) {
-            const usedHeaders = [];
-            for (let x of origHeaderSet) {
-                for (let datapoint of filtered) {
-                    if (isDefined(datapoint[x])) {
-                        usedHeaders.push(x);
-                        break;
-                    }
-                }
-            }
+            const usedHeaders = getUsedHeaders(filtered);
             setHeaders(usedHeaders);
         }
     }, [versionFilters, evalFilters, formattedData, statusFilters, roleFilters, milFilters]);
 
 
+    const getUsedHeaders = (data) => {
+        const usedHeaders = [];
+        for (let x of origHeaderSet) {
+            for (let datapoint of data) {
+                if (isDefined(datapoint[x])) {
+                    usedHeaders.push(x);
+                    break;
+                }
+            }
+        }
+        return usedHeaders;
+    };
+
+
     const refineData = (origData) => {
         // remove unwanted headers from download
         const updatedData = structuredClone(origData);
+        const usedHeaders = getUsedHeaders(updatedData);
         updatedData.map((x) => {
             delete x.eval;
+            for (const h of Object.keys(x)) {
+                if (!usedHeaders.includes(h))
+                    delete x[h];
+            }
             return x;
         });
         return updatedData;
@@ -308,7 +493,7 @@ export function ResultsTable({ data, pLog }) {
         {filteredData.length < formattedData.length && <p className='filteredText'>Showing {filteredData.length} of {formattedData.length} rows based on filters</p>}
         <section className='tableHeader'>
             <div className="filters">
-                {evals.length > 0 && <Autocomplete
+                {!showLegacy && evals.length > 0 && <Autocomplete
                     multiple
                     options={evals}
                     filterSelectedOptions
@@ -324,7 +509,7 @@ export function ResultsTable({ data, pLog }) {
                     )}
                     onChange={(_, newVal) => setEvalFilters(newVal)}
                 />}
-                <Autocomplete
+                {showLegacy && <Autocomplete
                     multiple
                     options={versions}
                     filterSelectedOptions
@@ -338,7 +523,7 @@ export function ResultsTable({ data, pLog }) {
                         />
                     )}
                     onChange={(_, newVal) => setVersionFilters(newVal)}
-                />
+                />}
                 <Autocomplete
                     multiple
                     options={roles}
@@ -403,9 +588,9 @@ export function ResultsTable({ data, pLog }) {
                 </thead>
                 <tbody>
                     {filteredData.map((dataSet, index) => {
-                        return (<tr key={dataSet['Participant_ID'] + '-' + index}>
+                        return (<tr key={dataSet['Participant ID'] + '-' + index}>
                             {headers.map((val) => {
-                                return (<td key={dataSet['Participant_ID'] + '-' + val + '-' + index}>
+                                return (<td key={dataSet['Participant ID'] + '-' + val + '-' + index}>
                                     {dataSet[val] ?? '-'}
                                 </td>);
                             })}
@@ -414,230 +599,5 @@ export function ResultsTable({ data, pLog }) {
                 </tbody>
             </table>
         </div>
-    </>);
-}
-
-// /* A list of names that are not pages to record in the excel sheet */
-const NON_PAGES = ['user', 'surveyVersion', 'startTime', 'timeComplete', 'Participant ID'];
-
-
-
-// const STARTING_HEADERS = ['Participant Id', 'Survey Version', 'Start Time', 'End Time', 'Total Time', 'Completed Simulation', 'Order Log', 'Updated Order Log'];
-
-function OLDResultsTable({ data, pLog }) {
-    const [formattedData, setFormattedData] = React.useState([]);
-    let defaultVersion = useSelector(state => state?.configs?.currentSurveyVersion);
-    defaultVersion = defaultVersion.endsWith('.0') ?
-        defaultVersion.slice(0, -2) :
-        defaultVersion
-    const [filterBySurveyVersion, setVersionOption] = React.useState([defaultVersion]);
-    const [versions, setVersions] = React.useState(['All']);
-    const [selectAll, setSelectAll] = React.useState(false);
-    const [headers, setHeaders] = React.useState([...STARTING_HEADERS]);
-    const fileType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=UTF-8';
-    const fileExtension = '.xlsx';
-
-    React.useEffect(() => {
-        // every time data updates, we need to go through and get all the participant data, 
-        // putting it in an object
-        const allObjs = [];
-        const allHeaders = [...STARTING_HEADERS];
-        const tmpVersion = ['All'];
-        for (let entry of data) {
-            entry = entry.results ?? entry;
-            const entryObj = {};
-            let addToTable = true;
-            const version = entry?.surveyVersion
-            if (!filterBySurveyVersion.includes(version?.toString()) && !selectAll) {
-                addToTable = false;
-            }
-            let pid = entry['Participant ID']?.questions['Participant ID']?.response ?? entry['Participant ID Page']?.questions['Participant ID']?.response ?? entry['pid'];
-            if (!pid) {
-                continue;
-            }
-            const logData = pLog.find(
-                log => log['ParticipantID'] == pid && log['Type'] != 'Test'
-            );
-            if ((version == 4 || version == 5) && !logData) {
-                continue;
-            }
-            entryObj['Participant Id'] = pid;
-
-            entryObj['Survey Version'] = version;
-            if (version && !tmpVersion.includes(version)) {
-                tmpVersion.push(version);
-            }
-            entryObj['Start Time'] = new Date(entry?.startTime)?.toLocaleString();
-            entryObj['End Time'] = new Date(entry?.timeComplete)?.toLocaleString();
-            const timeDifSeconds = (new Date(entry?.timeComplete).getTime() - new Date(entry?.startTime).getTime()) / 1000;
-            entryObj['Total Time'] = formatTime(timeDifSeconds);
-            if (entryObj['Survey Version'] < 2) {
-                entryObj['Completed Simulation'] = (!entry['Participant ID']?.questions?.Condition?.response?.includes('NOT')).toString();
-            } else {
-                entryObj['Completed Simulation'] = (!entry['Participant ID Page']?.questions?.['VR Scenarios Completed']?.response?.includes('none')).toString();
-            }
-
-            // Handle Order Log
-            if (Array.isArray(entry['orderLog']) && Array.isArray(entry['updatedOrderLog'])) {
-                entryObj['Order Log'] = JSON.stringify(entry['orderLog']);
-                entryObj['Updated Order Log'] = JSON.stringify(entry['updatedOrderLog'])
-            } else {
-                entryObj['Order Log'] = entry['orderLog'] || '-';
-                entryObj['Updated Order Log'] = entry['updatedOrderLog'] || '-';
-            }
-
-            for (const page of Object.keys(entry)) {
-                if (!NON_PAGES.includes(page) && typeof (entry[page]) === 'object') {
-                    // get all keys from the page and name them nicely within the excel
-                    for (const key of Object.keys(entry[page])) {
-                        if (key === 'timeSpentOnPage') {
-                            const header_name = page + ' - Time Taken (mm:ss)';
-                            if (!allHeaders.includes(header_name)) {
-                                allHeaders.push(header_name);
-                            }
-                            entryObj[header_name] = formatTime(entry[page][key]);
-                        }
-                        if (key === 'questions') {
-                            for (const q of Object.keys(entry[page]['questions'])) {
-                                const header_name = q.replace('The information about the situation and the medical decisions were presented in an understandable, easy-to-use format', 'Understandable Format')
-                                    .replace('Rate your confidence about the delegation decision indicated in the previous question', 'Delegation Confidence')
-                                    .replace('I have completed disaster response training such as those offered by the American Red Cross, FEMA, or the Community Emergency Response Team (CERT)', 'Completed Disaster Response Training')
-                                    .replace('How many disaster drills (or simulated mass casualty events with live actors) have you participated in before today (Please enter a whole number)', 'Disaster Drill Count')
-                                    .replace('I had enough information in this presentation to make the ratings for the questions asked on the previous pages about the DMs', 'I had enough information to answer these questions');
-                                if (!entry[page][key][q].response) { continue; }
-                                if (typeof (entry[page][key][q].response) === 'string') {
-                                    entryObj[header_name] = entry[page][key][q].response;
-                                    if (!allHeaders.includes(header_name)) {
-                                        allHeaders.push(header_name);
-                                    }
-                                }
-                                else if (typeof (entry[page][key][q].response) !== 'object' || q === "What is your current role (choose all that apply):" || q === "VR Scenarios Completed") {
-                                    if (!allHeaders.includes(header_name)) {
-                                        allHeaders.push(header_name);
-                                    }
-                                    entryObj[header_name] = entry[page][key][q].response.toString();
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            if (addToTable) {
-                allObjs.push(entryObj);
-            }
-        }
-        const found_headers = [];
-        for (let obj of allObjs) {
-            for (const header of allHeaders) {
-                if (!(header in obj)) {
-                    obj[header] = '-';
-                } else {
-                    // only include headers that have at least one response
-                    if (!found_headers.includes(header)) {
-                        found_headers.push(header);
-                    }
-                }
-            }
-        }
-        allObjs.sort((a, b) => a['Participant Id'] - b['Participant Id']);
-        setFormattedData(allObjs);
-        setHeaders(found_headers);
-        setVersions(tmpVersion);
-    }, [data, filterBySurveyVersion, selectAll]);
-
-    const exportToExcel = async () => {
-        // Create a new workbook and worksheet
-        const wb = XLSX.utils.book_new();
-        const dataCopy = structuredClone(formattedData);
-        for (let pid of Object.keys(dataCopy)) {
-            for (let k of Object.keys(dataCopy[pid])) {
-                if (dataCopy[pid][k] == '-') {
-                    dataCopy[pid][k] = '';
-                }
-            }
-        }
-        const ws = XLSX.utils.json_to_sheet(dataCopy);
-
-        // Adjust column widths
-        const colWidths = headers.map(header => ({ wch: Math.max(header.length, 20) }));
-        ws['!cols'] = colWidths;
-
-        // Add the worksheet to the workbook
-        XLSX.utils.book_append_sheet(wb, ws, 'Survey Data');
-
-        // Generate Excel file
-        const excelBuffer = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
-        const data = new Blob([excelBuffer], { type: fileType });
-        FileSaver.saveAs(data, 'survey_data_v' + filterBySurveyVersion.join('_v') + fileExtension);
-    };
-
-    const updateVersions = (selected) => {
-        if (selected.target.checked && !selectAll) {
-            if (selected.target.value === 'All') {
-                setSelectAll(true);
-                setVersionOption([...versions]);
-            } else {
-                setVersionOption([...filterBySurveyVersion, selected.target.value]);
-            }
-        }
-        else {
-            if (selectAll && selected.target.value !== 'All') {
-                setSelectAll(false);
-                setVersionOption(versions.filter((x) => x !== 'All' && x.toString() !== selected.target.value).map((x) => x.toString()));
-            }
-            else {
-                setSelectAll(false);
-                if (selected.target.value === 'All') {
-                    setVersionOption([]);
-                }
-                else {
-                    setVersionOption(filterBySurveyVersion.filter((x) => x !== selected.target.value));
-                }
-            }
-        }
-    };
-
-    return (<>
-        {data && <><section className='tableHeader'>
-            <h2>Tabulated Survey Results</h2>
-            <div className="option-section">
-                <FormControl className='version-select'>
-                    <InputLabel shrink>Survey Version</InputLabel>
-                    <div className='checkboxes'>
-                        {versions.map((v) => {
-                            return <MenuItem key={v} value={v}>
-                                <Checkbox value={v.toString()} checked={filterBySurveyVersion.indexOf(v.toString()) > -1 || selectAll} onChange={updateVersions} />
-                                <ListItemText primary={v} />
-                            </MenuItem>;
-                        })}
-                    </div>
-                </FormControl>
-                <button className='downloadBtn' onClick={exportToExcel}>Download Data</button>
-            </div>
-        </section>
-            <div className='resultTableSection'>
-                <table className='itm-table'>
-                    <thead>
-                        <tr>
-                            {headers.map((val, index) => {
-                                return (<th key={'header-' + index}>
-                                    {val}
-                                </th>);
-                            })}
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {formattedData.map((dataSet, index) => {
-                            return (<tr key={dataSet['ParticipantId'] + '-' + index}>
-                                {headers.map((val) => {
-                                    return (<td key={dataSet['ParticipantId'] + '-' + val}>
-                                        {dataSet[val]}
-                                    </td>);
-                                })}
-                            </tr>);
-                        })}
-                    </tbody>
-                </table>
-            </div></>}
     </>);
 }


### PR DESCRIPTION
Added Legacy Results toggle to the survey results page. It is still organized in the new way with Blocks and DM numbers, but also includes Omnibus results. 

Additionally, I fixed the downloads so downloads should no longer contain columns that have no data. 

Finally, Version is the filter for legacy data and Eval is the filter for MRE/PH1 data. Filters should be erased when toggling between legacy and new data. 