### PR TITLE
store and access pids correctly

### DIFF
--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -78,7 +78,7 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
                 obj['Sim-4'] = sims[3]?.scenario_id;
 
 
-                const surveys = surveyResults.filter((x) => ((x.results?.pid && (x.results.pid == pid)) || x.results?.['Participant ID Page']?.questions?.['Participant ID']?.response == pid)
+                const surveys = surveyResults.filter((x) => ((x.results?.pid && (x.results.pid == pid)) || (x.results?.['Participant ID Page']?.questions?.['Participant ID']?.response ?? x.results?.pid) == pid)
                     && x.results?.['Post-Scenario Measures']);
                 const lastSurvey = surveys?.slice(-1)?.[0];
                 const survey_date = new Date(lastSurvey?.results?.timeComplete);

--- a/dashboard-ui/src/components/DRE-Research/utils.js
+++ b/dashboard-ui/src/components/DRE-Research/utils.js
@@ -141,13 +141,13 @@ export function getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dat
     // find participants that have completed the delegation survey
     const completed_surveys = surveyResults.filter((res) => res.results?.evalNumber == evalNum && isDefined(res.results['Post-Scenario Measures']));
     for (const res of completed_surveys) {
-        const pid = res.results['Participant ID Page']?.questions['Participant ID']?.response;
+        const pid = res.results['Participant ID Page']?.questions['Participant ID']?.response ?? res.results['pid'];
         const orderLog = res.results['orderLog']?.filter((x) => x.includes('Medic'));
         // see if participant is in the participantLog
         const logData = participantLog.find(
             log => log['ParticipantID'] == pid && log['Type'] != 'Test'
         );
-        if (!logData) {
+        if (!logData || logData.textEntryCount < 5) {
             continue;
         }
         const { textResultsForPID, alignments } = getAlignments(evalNum, textResults, pid);

--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -657,6 +657,9 @@ class SurveyPage extends Component {
             this.surveyData['evalName'] = 'Phase 1 Evaluation';
             this.surveyData['orderLog'] = this.state.orderLog;
             this.surveyData['pid'] = this.state.pid;
+            if (this.state.pid) {
+                this.surveyData['Participant ID Page'] = { 'pageName': 'Participant ID Page', 'questions': { 'Participant ID': { 'response': this.state.pid } } };
+            }
         }
 
         // upload the results to mongoDB


### PR DESCRIPTION
First, see that in RQ 1/3/4, online surveys are not populating on dev. Then, on this branch, make sure they do. Then run the ingest script (https://github.com/NextCenturyCorporation/itm-ingest/pull/86). Make sure everything still populates correctly. 

Additionally, this will not populate a row in 1/3/4 unless all 5 text scenarios have been completed. 

Run through an online survey and see that it now populates Participant ID Page in your database, whereas before you only had pid. 