### PR TITLE
Text based scenarios navigation blocking

### DIFF
--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -854,7 +854,7 @@ export const SurveyPageWrapper = (props) => {
         />)
 };
 
-const NavigationGuard = ({ surveyComplete }) => {
+export const NavigationGuard = ({ surveyComplete }) => {
     const history = useHistory();
 
     useEffect(() => {

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -260,10 +260,6 @@ class TextBasedScenariosPage extends Component {
             }
 
         }
-        window.addEventListener('beforeunload', this.handleBeforeUnload);
-
-        // push initial state to prevent back navigation
-        window.history.pushState(null, '', window.location.href);
     }
 
     resetState() {
@@ -642,20 +638,6 @@ class TextBasedScenariosPage extends Component {
         const page = this.survey.getPageByName(pageName);
         return page ? page.questions.map(question => question.name) : [];
     };
-    
-    handleBeforeUnload = (e) => {
-        if (!this.state.allScenariosCompleted) {
-            if (!window.confirm('Please finish the scenarios before leaving the page. If you leave now, you will need to start the scenarios over from the beginning.')) {
-                e.preventDefault();
-                e.returnValue = '';
-                return '';
-            }
-        }
-    };
-
-    componentWillUnmount() {
-        window.removeEventListener('beforeunload', this.handleBeforeUnload);
-    }
 
     render() {
         return (


### PR DESCRIPTION
Standardized navigation blocking behavior for text-based scenarios to be the exact same as the delegation survey. 

Since we have two different entry points for the text-based scenarios, we should test both.

ADEPT entry:
http://localhost:3000/remote-text-survey?adeptQualtrix=true&ContactID=Derek&PROLIFIC_PID=314159&class=Online

OSU entry:
http://localhost:3000/login
<img width="719" alt="Screenshot 2024-12-16 at 10 40 12 AM" src="https://github.com/user-attachments/assets/dd1cb82a-632c-4a59-9edb-ce6f67786756" />


You should be warned if you try to do any of the following before all of the text-based scenarios are complete:
- close the tab
- refresh the page
- hit the browser's back arrow

Upon completing OSU's entry point, it should allow you to close the tab with no warning. ADEPT's entry point should still redirect you as normal when the scenarios are complete.