### PR TITLE
Add optional DRE toggle to ph1 rq1/3/4 pages

### DIFF
--- a/dashboard-ui/src/components/DRE-Research/ExploratoryAnalysis.jsx
+++ b/dashboard-ui/src/components/DRE-Research/ExploratoryAnalysis.jsx
@@ -50,7 +50,7 @@ export function ExploratoryAnalysis() {
             </p>
         </div>
         <div className="section-container">
-            <RQ13 evalNum={selectedEval} graphTitle={'RQ4 Data'} />
+            <RQ13 evalNum={selectedEval} tableTitle={'RQ4 Data'} />
             <p>
                 <b>Variables used from dataset:</b>
             </p>

--- a/dashboard-ui/src/components/DRE-Research/ExploratoryAnalysis.jsx
+++ b/dashboard-ui/src/components/DRE-Research/ExploratoryAnalysis.jsx
@@ -50,8 +50,7 @@ export function ExploratoryAnalysis() {
             </p>
         </div>
         <div className="section-container">
-            <h2>RQ4 Data</h2>
-            <RQ13 evalNum={selectedEval} />
+            <RQ13 evalNum={selectedEval} graphTitle={'RQ4 Data'} />
             <p>
                 <b>Variables used from dataset:</b>
             </p>

--- a/dashboard-ui/src/components/DRE-Research/RQ1.jsx
+++ b/dashboard-ui/src/components/DRE-Research/RQ1.jsx
@@ -55,7 +55,7 @@ export function RQ1() {
             </p>
         </div>
         <div className="section-container">
-            <RQ13 evalNum={selectedEval} graphTitle={'RQ1 Data'} />
+            <RQ13 evalNum={selectedEval} tableTitle={'RQ1 Data'} />
 
         </div>
         <div className="section-container">

--- a/dashboard-ui/src/components/DRE-Research/RQ1.jsx
+++ b/dashboard-ui/src/components/DRE-Research/RQ1.jsx
@@ -55,8 +55,7 @@ export function RQ1() {
             </p>
         </div>
         <div className="section-container">
-            <h2>RQ1 Data</h2>
-            <RQ13 evalNum={selectedEval} />
+            <RQ13 evalNum={selectedEval} graphTitle={'RQ1 Data'} />
 
         </div>
         <div className="section-container">

--- a/dashboard-ui/src/components/DRE-Research/RQ3.jsx
+++ b/dashboard-ui/src/components/DRE-Research/RQ3.jsx
@@ -62,7 +62,7 @@ export function RQ3() {
             </p>
         </div>
         <div className="section-container">
-            <RQ13 evalNum={selectedEval} graphTitle={'RQ3 Data'} />
+            <RQ13 evalNum={selectedEval} tableTitle={'RQ3 Data'} />
 
         </div>
         <div className="section-container">

--- a/dashboard-ui/src/components/DRE-Research/RQ3.jsx
+++ b/dashboard-ui/src/components/DRE-Research/RQ3.jsx
@@ -62,8 +62,7 @@ export function RQ3() {
             </p>
         </div>
         <div className="section-container">
-            <h2>RQ3 Data</h2>
-            <RQ13 evalNum={selectedEval} />
+            <RQ13 evalNum={selectedEval} graphTitle={'RQ3 Data'} />
 
         </div>
         <div className="section-container">

--- a/dashboard-ui/src/components/DRE-Research/dre-rq.css
+++ b/dashboard-ui/src/components/DRE-Research/dre-rq.css
@@ -63,3 +63,11 @@
 .rq-selection-section .nav-list {
     margin-top: 0px;
 }
+
+.floating-toggle {
+    float: right;
+}
+
+.floating-toggle>* {
+    font-size: 18px !important;
+}

--- a/dashboard-ui/src/components/DRE-Research/tables/rq1-rq3.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq1-rq3.jsx
@@ -45,7 +45,7 @@ const GET_SIM_DATA = gql`
 const HEADERS = ['ADM Order', 'Delegator_ID', 'Datasource', 'Delegator_grp', 'Delegator_mil', 'Delegator_Role', 'TA1_Name', 'Trial_ID', 'Attribute', 'Scenario', 'TA2_Name', 'ADM_Type', 'Target', 'Alignment score (ADM|target)', 'Alignment score (Delegator|target)', 'Alignment score (Participant_sim|Observed_ADM(target))', 'Server Session ID (Delegator)', 'ADM_Aligned_Status (Baseline/Misaligned/Aligned)', 'ADM Loading', 'Alignment score (Delegator|Observed_ADM (target))', 'Trust_Rating', 'Delegation preference (A/B)', 'Delegation preference (A/M)', 'Trustworthy_Rating', 'Agreement_Rating', 'SRAlign_Rating'];
 
 
-export function RQ13({ evalNum, graphTitle }) {
+export function RQ13({ evalNum, tableTitle }) {
     const { loading: loadingParticipantLog, error: errorParticipantLog, data: dataParticipantLog } = useQuery(GET_PARTICIPANT_LOG);
     const { loading: loadingSurveyResults, error: errorSurveyResults, data: dataSurveyResults } = useQuery(GET_SURVEY_RESULTS);
     const { loading: loadingTextResults, error: errorTextResults, data: dataTextResults } = useQuery(GET_TEXT_RESULTS, { fetchPolicy: 'no-cache' });
@@ -148,7 +148,7 @@ export function RQ13({ evalNum, graphTitle }) {
     if (errorParticipantLog || errorSurveyResults || errorTextResults || errorADMs || errorComparisonData || errorSim) return <p>Error :</p>;
 
     return (<>
-        <h2>{graphTitle}
+        <h2>{tableTitle}
             {evalNum == 5 && <FormControlLabel className='floating-toggle' control={<Checkbox value={includeDRE} onChange={updateDREStatus} />} label="Include DRE Data" />}
         </h2>
 

--- a/dashboard-ui/src/components/DRE-Research/tables/rq1-rq3.jsx
+++ b/dashboard-ui/src/components/DRE-Research/tables/rq1-rq3.jsx
@@ -9,6 +9,7 @@ import definitionXLFile from '../variables/Variable Definitions RQ1_RQ3.xlsx';
 import definitionPDFFile from '../variables/Variable Definitions RQ1_RQ3.pdf';
 import { getRQ134Data } from "../utils";
 import { DownloadButtons } from "./download-buttons";
+import { Checkbox, FormControlLabel } from "@material-ui/core";
 
 
 const GET_PARTICIPANT_LOG = gql`
@@ -44,17 +45,19 @@ const GET_SIM_DATA = gql`
 const HEADERS = ['ADM Order', 'Delegator_ID', 'Datasource', 'Delegator_grp', 'Delegator_mil', 'Delegator_Role', 'TA1_Name', 'Trial_ID', 'Attribute', 'Scenario', 'TA2_Name', 'ADM_Type', 'Target', 'Alignment score (ADM|target)', 'Alignment score (Delegator|target)', 'Alignment score (Participant_sim|Observed_ADM(target))', 'Server Session ID (Delegator)', 'ADM_Aligned_Status (Baseline/Misaligned/Aligned)', 'ADM Loading', 'Alignment score (Delegator|Observed_ADM (target))', 'Trust_Rating', 'Delegation preference (A/B)', 'Delegation preference (A/M)', 'Trustworthy_Rating', 'Agreement_Rating', 'SRAlign_Rating'];
 
 
-export function RQ13({ evalNum }) {
+export function RQ13({ evalNum, graphTitle }) {
     const { loading: loadingParticipantLog, error: errorParticipantLog, data: dataParticipantLog } = useQuery(GET_PARTICIPANT_LOG);
     const { loading: loadingSurveyResults, error: errorSurveyResults, data: dataSurveyResults } = useQuery(GET_SURVEY_RESULTS);
-    const { loading: loadingTextResults, error: errorTextResults, data: dataTextResults } = useQuery(GET_TEXT_RESULTS, {
-        fetchPolicy: 'no-cache'
-    });
+    const { loading: loadingTextResults, error: errorTextResults, data: dataTextResults } = useQuery(GET_TEXT_RESULTS, { fetchPolicy: 'no-cache' });
     const { loading: loadingADMs, error: errorADMs, data: dataADMs } = useQuery(GET_ADM_DATA, {
         variables: { "evalNumber": evalNum }
     });
+    const { data: dreAdms } = useQuery(GET_ADM_DATA, {
+        variables: { "evalNumber": 4 }
+    });
     const { loading: loadingComparisonData, error: errorComparisonData, data: comparisonData } = useQuery(GET_COMPARISON_DATA);
     const { loading: loadingSim, error: errorSim, data: dataSim } = useQuery(GET_SIM_DATA, { variables: { "evalNumber": evalNum } });
+    const { data: dreSim } = useQuery(GET_SIM_DATA, { variables: { "evalNumber": 4 } });
 
     const [formattedData, setFormattedData] = React.useState([]);
     const [showDefinitions, setShowDefinitions] = React.useState(false);
@@ -76,6 +79,7 @@ export function RQ13({ evalNum }) {
     const [admTypeFilters, setAdmTypeFilters] = React.useState([]);
     const [delGrpFilters, setDelGrpFilters] = React.useState([]);
     const [delMilFilters, setDelMilFilters] = React.useState([]);
+    const [includeDRE, setIncludeDRE] = React.useState(false);
     // data with filters applied
     const [filteredData, setFilteredData] = React.useState([]);
 
@@ -89,8 +93,20 @@ export function RQ13({ evalNum }) {
     }
 
     React.useEffect(() => {
-        if (dataSurveyResults?.getAllSurveyResults && dataParticipantLog?.getParticipantLog && dataTextResults?.getAllScenarioResults && dataADMs?.getAllHistoryByEvalNumber && comparisonData?.getHumanToADMComparison && dataSim?.getAllSimAlignmentByEval) {
+        if (dataSurveyResults?.getAllSurveyResults && dataParticipantLog?.getParticipantLog && dataTextResults?.getAllScenarioResults &&
+            dataADMs?.getAllHistoryByEvalNumber && comparisonData?.getHumanToADMComparison && dataSim?.getAllSimAlignmentByEval &&
+            dreAdms?.getAllHistoryByEvalNumber && dreSim?.getAllSimAlignmentByEval) {
             const data = getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dataTextResults, dataADMs, comparisonData, dataSim);
+            if (includeDRE) {
+                // for ph1, offer option to include dre data, but ONLY THE 25 FULL SETS!
+                const dreData = getRQ134Data(4, dataSurveyResults, dataParticipantLog, dataTextResults, dreAdms, comparisonData, dreSim, true);
+                data.allObjs.push(...dreData.allObjs);
+                data.allTA1s.push(...dreData.allTA1s);
+                data.allTA2s.push(...dreData.allTA2s);
+                data.allAttributes.push(...dreData.allAttributes);
+                data.allScenarios.push(...dreData.allScenarios);
+                data.allTargets.push(...dreData.allTargets);
+            }
             data.allObjs.sort((a, b) => {
                 // Compare PID
                 if (Number(a['Delegator_ID']) < Number(b['Delegator_ID'])) return -1;
@@ -107,8 +123,11 @@ export function RQ13({ evalNum }) {
             setScenarios(Array.from(new Set(data.allScenarios)));
             setTargets(Array.from(new Set(data.allTargets)));
         }
-    }, [dataParticipantLog, dataSurveyResults, dataTextResults, dataADMs, comparisonData, evalNum]);
+    }, [dataParticipantLog, dataSurveyResults, dataTextResults, dataADMs, comparisonData, evalNum, includeDRE, dreAdms, dreSim]);
 
+    const updateDREStatus = (event) => {
+        setIncludeDRE(event.target.checked);
+    };
 
     React.useEffect(() => {
         if (formattedData.length > 0) {
@@ -129,6 +148,10 @@ export function RQ13({ evalNum }) {
     if (errorParticipantLog || errorSurveyResults || errorTextResults || errorADMs || errorComparisonData || errorSim) return <p>Error :</p>;
 
     return (<>
+        <h2>{graphTitle}
+            {evalNum == 5 && <FormControlLabel className='floating-toggle' control={<Checkbox value={includeDRE} onChange={updateDREStatus} />} label="Include DRE Data" />}
+        </h2>
+
         {filteredData.length < formattedData.length && <p className='filteredText'>Showing {filteredData.length} of {formattedData.length} rows based on filters</p>}
         <section className='tableHeader'>
             <div className="filters">

--- a/dashboard-ui/src/components/DRE-Research/utils.js
+++ b/dashboard-ui/src/components/DRE-Research/utils.js
@@ -124,7 +124,7 @@ export function getAlignments(evalNum, textResults, pid) {
     return { textResultsForPID, alignments };
 }
 
-export function getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dataTextResults, dataADMs, comparisonData, dataSim) {
+export function getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dataTextResults, dataADMs, comparisonData, dataSim, fullSetOnly = false) {
     const surveyResults = dataSurveyResults.getAllSurveyResults;
     const participantLog = dataParticipantLog.getParticipantLog;
     const textResults = dataTextResults.getAllScenarioResults;
@@ -148,6 +148,9 @@ export function getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dat
             log => log['ParticipantID'] == pid && log['Type'] != 'Test'
         );
         if (!logData) {
+            continue;
+        }
+        if (fullSetOnly && (logData.surveyEntryCount < 1 || logData.textEntryCount < 5 || logData.simEntryCount < 3)) {
             continue;
         }
         const { textResultsForPID, alignments } = getAlignments(evalNum, textResults, pid);


### PR DESCRIPTION
We want the ability to view COMPLETED DRE data (survey, 5 text, 3 sim) with the phase 1 data on the rq 1/3/4 table. 

Here, I have added a toggle to RQ 1, 3, and 4 to include DRE data. There should only be 25 additional DRE data shown when this toggle is toggled. The list of valid PIDs is below. 

To test:
1. Make sure the tables work normally
2. Make sure the toggle only appears when the data source is Phase 1
3. Make sure there are no extra or missing DRE PIDs when the toggle is on. 
4. Make sure there is no DRE data when the toggle is off

202409101 20249201
202409102 20249202
                     20249203
202409104 20249204
202409105 20249205
202409106 20249206
                     20249207
                     20249208
202409109 20249209
                      20249210
202409111 20249211
                    20249212
202409113 20249213
202409114 
202409115
202409117
202409119
202409120