### PR TITLE
Itm 772 admin approval

### DIFF
--- a/dashboard-ui/src/components/Account/adminPage.jsx
+++ b/dashboard-ui/src/components/Account/adminPage.jsx
@@ -9,6 +9,9 @@ import '../../css/admin-page.css';
 import { setSurveyVersion, setupConfigWithImages } from '../App/setupUtils';
 import { accountsClient, accountsPassword } from '../../services/accountsService';
 import { createBrowserHistory } from 'history';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import CancelIcon from '@material-ui/icons/Cancel';
+import { IconButton, Switch } from '@material-ui/core';
 
 const history = createBrowserHistory({ forceRefresh: true });
 
@@ -18,7 +21,6 @@ const GET_USERS = gql`
         getUsers
     }
 `;
-
 
 const UPDATE_ADMIN_USER = gql`
     mutation updateAdminUser($caller: JSON!, $username: String!, $isAdmin: Boolean!) {
@@ -133,11 +135,12 @@ function AdminPage({ currentUser, updateUserHandler }) {
     const surveyConfigs = useSelector(state => state.configs.surveyConfigs);
     const [surveyVersions, setSurveyVersions] = useState([]);
     const [isLoading, setIsLoading] = useState(false);
-    const [confirmedAdmin, setConfirmedAdmin] = useState(false);
+    const [confirmedAdmin, setConfirmedAdmin] = useState(true);
     const [password, setPassword] = useState('');
     const [passwordError, setPasswordError] = useState('');
     const [sessionId, setSessionId] = useState(null);
     const [errorCount, setErrorCount] = useState(0);
+    const [unapproved, setUnapproved] = useState([]);
 
     const { loading: surveyVersionLoading, error: surveyVersionError, data: surveyVersionData } = useQuery(GET_CURRENT_SURVEY_VERSION, {
         fetchPolicy: 'no-cache'
@@ -303,6 +306,57 @@ function AdminPage({ currentUser, updateUserHandler }) {
             </Card>}
 
             {confirmedAdmin && <><Row className="mb-4">
+                {unapproved.length > 0 &&
+                    <Col>
+                        <Card>
+                            <Card.Header as="h5">Time Sensitive: New User Approvals</Card.Header>
+                            <Card.Body>
+                                <table className='itm-table small-table'>
+                                    <thead>
+                                        <tr>
+                                            <th>
+                                                Email
+                                            </th>
+                                            <th>
+                                                Username
+                                            </th>
+                                            <th className='switch-header'>
+                                                Admin
+                                            </th>
+                                            <th className='switch-header'>
+                                                Evaluator
+                                            </th>
+                                            <th className='switch-header'>
+                                                Experimenter
+                                            </th>
+                                            <th className='switch-header'>
+                                                ADEPT
+                                            </th>
+                                            <th className='action-header'>
+                                                Action
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    {unapproved.map((user) => {
+                                        return (
+                                            <tr>
+                                                <td>{user.emails[0]?.address}</td>
+                                                <td>{user.username}</td>
+                                                <td><Switch /></td>
+                                                <td><Switch /></td>
+                                                <td><Switch /></td>
+                                                <td><Switch /></td>
+                                                <td>
+                                                    <IconButton children={<CheckCircleIcon color='green' className='green-btn' />} />
+                                                    <IconButton children={<CancelIcon className='red-btn' />} /></td>
+                                            </tr>);
+                                    })}
+                                </table>
+                            </Card.Body>
+                        </Card>
+                    </Col>}
+
+
                 <Col md={6}>
                     <Card>
                         <Card.Header as="h5">Survey Version</Card.Header>
@@ -347,6 +401,7 @@ function AdminPage({ currentUser, updateUserHandler }) {
                         let evaluatorSelectedOptions = [];
                         let experimenterSelectedOptions = [];
                         let adeptSelectedOptions = [];
+                        setUnapproved(data[getUsersQueryName].filter((x) => !x.approved));
 
                         const users = data[getUsersQueryName]
                         for (let i = 0; i < users.length; i++) {

--- a/dashboard-ui/src/components/Account/login.css
+++ b/dashboard-ui/src/components/Account/login.css
@@ -139,3 +139,26 @@
     border-radius: 4px;
     margin-top: 10px;
 }
+
+.small-table th, .small-table td {
+    /* max-width: 100px !important; */
+    min-width: 50px !important;
+}
+
+.small-table .green-btn {
+    color: green;
+    font-size: 36px;
+}
+
+.small-table .red-btn {
+    color: rgb(166, 34, 34);
+    font-size: 36px;
+}
+
+.small-table .action-header {
+    width: 160px !important;
+}
+
+.small-table .switch-header {
+    width: 130px !important;
+}

--- a/dashboard-ui/src/components/Account/login.css
+++ b/dashboard-ui/src/components/Account/login.css
@@ -168,3 +168,26 @@
     color: rgb(245, 245, 245) !important;
     letter-spacing: 1px;
 }
+
+.waiting-card {
+    width: 90%;
+    min-width: 800px;
+    margin: auto;
+    margin-top: 20px;
+    padding: 0px;
+}
+
+.return-btn {
+    margin-top: 12px;
+    display: block;
+    background-color: rgb(89, 38, 16) !important;
+    border-color: rgb(133, 57, 24) !important;
+}
+
+.return-btn:hover {
+    filter: brightness(90%);
+}
+
+.return-btn:active {
+    filter: brightness(80%);
+}

--- a/dashboard-ui/src/components/Account/login.css
+++ b/dashboard-ui/src/components/Account/login.css
@@ -162,3 +162,9 @@
 .small-table .switch-header {
     width: 130px !important;
 }
+
+.urgent-header {
+    background-color: rgb(208, 83, 49) !important;
+    color: rgb(245, 245, 245) !important;
+    letter-spacing: 1px;
+}

--- a/dashboard-ui/src/components/Account/login.jsx
+++ b/dashboard-ui/src/components/Account/login.jsx
@@ -96,7 +96,7 @@ class LoginApp extends React.Component {
                 }
             });
 
-            this.props.history.push('/');
+            this.props.history.push('/awaitingApproval');
             this.props.userLoginHandler(results.user);
         } catch (err) {
             $("#create-account-feedback").addClass("feedback-display");

--- a/dashboard-ui/src/components/Account/waitingPage.jsx
+++ b/dashboard-ui/src/components/Account/waitingPage.jsx
@@ -13,8 +13,8 @@ export function WaitingPage({ rejected }) {
                     <b>Status: {rejected ? 'Account Rejected' : 'Awaiting Approval'}</b>
                     <hr />
                     Thank you for your interest in the DARPA In the Moment Program.
-                    <br />
-                    {rejected && 'You have been denied access to the dashboard. If you believe this is a mistake, please contact an administrator.'}
+
+                    {rejected && <><br />You have been denied access to the dashboard. If you believe this is a mistake, please contact an administrator.</>}
                     <br /><br />If you are supposed to be taking the text scenarios, please navigate to <a href='https://darpaitm.caci.com/participantText'>https://darpaitm.com/participantText</a>
                 </div>
                 <Button onClick={() => history.push('/login')} className='return-btn'>Return to Login</Button>

--- a/dashboard-ui/src/components/Account/waitingPage.jsx
+++ b/dashboard-ui/src/components/Account/waitingPage.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export function WaitingPage() {
+    return (
+        <>
+            <div className="home-container">
+                <div className="home-navigation-container">
+                    <div className="evaluation-selector-container">
+                        <div className="evaluation-selector-label"><h3>Welcome to the ITM Program!</h3></div>
+                    </div>
+                </div>
+                <div className="data-collection-only">
+                    Thank you for your interest in the DARPA In the Moment Program.  Your account is awaiting approval. Please check back later. <br /><br />If you are supposed to be taking the text scenarios, please navigate to <a href='https://darpaitm.caci.com/participantText'>https://darpaitm.com/participantText</a>
+                </div>
+            </div>
+        </>
+    );
+}
+

--- a/dashboard-ui/src/components/Account/waitingPage.jsx
+++ b/dashboard-ui/src/components/Account/waitingPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export function WaitingPage() {
+export function WaitingPage({ rejected }) {
     return (
         <>
             <div className="home-container">
@@ -10,7 +10,12 @@ export function WaitingPage() {
                     </div>
                 </div>
                 <div className="data-collection-only">
-                    Thank you for your interest in the DARPA In the Moment Program.  Your account is awaiting approval. Please check back later. <br /><br />If you are supposed to be taking the text scenarios, please navigate to <a href='https://darpaitm.caci.com/participantText'>https://darpaitm.com/participantText</a>
+                    <b>Status: {rejected ? 'Account Rejected' : 'Awaiting Approval'}</b>
+                    <hr />
+                    Thank you for your interest in the DARPA In the Moment Program.
+                    <br />
+                    {rejected && 'You have been denied access to the dashboard. If you believe this is a mistake, please contact an administrator.'}
+                    <br /><br />If you are supposed to be taking the text scenarios, please navigate to <a href='https://darpaitm.caci.com/participantText'>https://darpaitm.com/participantText</a>
                 </div>
             </div>
         </>

--- a/dashboard-ui/src/components/Account/waitingPage.jsx
+++ b/dashboard-ui/src/components/Account/waitingPage.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
+import { Button, Card } from 'react-bootstrap';
+import './login.css';
+import { createBrowserHistory } from 'history';
+const history = createBrowserHistory({ forceRefresh: true });
 
 export function WaitingPage({ rejected }) {
     return (
-        <>
-            <div className="home-container">
-                <div className="home-navigation-container">
-                    <div className="evaluation-selector-container">
-                        <div className="evaluation-selector-label"><h3>Welcome to the ITM Program!</h3></div>
-                    </div>
-                </div>
-                <div className="data-collection-only">
+        <Card className='waiting-card'>
+            <Card.Header><h3>Welcome to the ITM Program!</h3></Card.Header>
+            <Card.Body>
+                <div>
                     <b>Status: {rejected ? 'Account Rejected' : 'Awaiting Approval'}</b>
                     <hr />
                     Thank you for your interest in the DARPA In the Moment Program.
@@ -17,8 +17,9 @@ export function WaitingPage({ rejected }) {
                     {rejected && 'You have been denied access to the dashboard. If you believe this is a mistake, please contact an administrator.'}
                     <br /><br />If you are supposed to be taking the text scenarios, please navigate to <a href='https://darpaitm.caci.com/participantText'>https://darpaitm.com/participantText</a>
                 </div>
-            </div>
-        </>
+                <Button onClick={() => history.push('/login')} className='return-btn'>Return to Login</Button>
+            </Card.Body>
+        </Card>
     );
 }
 

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -153,6 +153,7 @@ function AdmResults() {
 
 function isUserElevated(currentUser) {
     // ignoring adeptUser, because they should already be admins, evaluators, or experimenters
+    console.log(currentUser);
     return currentUser?.admin || currentUser?.evaluator || currentUser?.experimenter;
 }
 
@@ -181,6 +182,8 @@ function Login({ newState, userLoginHandler, participantLoginHandler, participan
 function MyAccount({ newState, userLoginHandler }) {
     if (newState.currentUser === null) {
         history.push("/login");
+    } else if (!newState.currentUser.approved) {
+        history.push('/awaitingApproval');
     } else {
         return <MyAccountPage currentUser={newState.currentUser} updateUserHandler={userLoginHandler} />
     }
@@ -551,6 +554,12 @@ export class App extends React.Component {
                                             }
                                             <div className="main-content">
                                                 <Switch>
+                                                    <Route exact path="/">
+                                                        <Home newState={this.state} />
+                                                    </Route>
+                                                    <Route exact path="/awaitingApproval">
+                                                        <WaitingPage />
+                                                    </Route>
                                                     <Route path="/login">
                                                         <Login newState={this.state} userLoginHandler={this.userLoginHandler} participantLoginHandler={this.participantLoginHandler} testerLogin={false} logout={this.logout} />
                                                     </Route>
@@ -561,17 +570,9 @@ export class App extends React.Component {
                                                     <Route path="/remote-text-survey">
                                                         <StartOnline />
                                                     </Route>
-                                                    {this.state.currentUser && <>
-                                                        <Route exact path="/awaitingApproval">
-                                                            <WaitingPage />
-                                                        </Route>
-                                                        <Route exact path="/">
-                                                            <Home newState={this.state} />
-                                                        </Route>
-                                                        <Route path="/myaccount">
-                                                            <MyAccount newState={this.state} userLoginHandler={this.userLoginHandler} />
-                                                        </Route>
-                                                    </>}
+                                                    <Route path="/myaccount">
+                                                        <MyAccount newState={this.state} userLoginHandler={this.userLoginHandler} />
+                                                    </Route>
                                                     {isUserElevated(this.state.currentUser) &&
                                                         <>
                                                         <Route exact path="/results">
@@ -639,8 +640,8 @@ export class App extends React.Component {
                                                         </Route>
                                                         </>}
                                                     {this.state.currentUser ?
-                                                        (this.state.currentUser?.approved ? 
-                                                            <Route path="*" render={() => <Redirect to="/" />} /> 
+                                                        (this.state.currentUser?.approved ?
+                                                            <Route path="*" render={() => <Redirect to="/" />} />
                                                             : <Route path="*" render={() => <Redirect to="/awaitingApproval" />} />)
                                                         : <Route path="*" render={() => <Redirect to="/login" />} />
                                                     }

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -249,6 +249,15 @@ function ReviewDelegation({ newState, userLoginHandler }) {
     }
 }
 
+function WaitingPageWrapper({ rejected, currentUser }) {
+    if (!rejected && currentUser?.approved) {
+        history.push(('/'));
+    }
+    else {
+        return <WaitingPage rejected={rejected} />
+    }
+}
+
 export class App extends React.Component {
 
     constructor(props) {
@@ -558,7 +567,7 @@ export class App extends React.Component {
                                                         <Home newState={this.state} />
                                                     </Route>
                                                     <Route exact path="/awaitingApproval">
-                                                        <WaitingPage />
+                                                        <WaitingPageWrapper currentUser={currentUser} rejected={this.state.currentUser?.rejected} />
                                                     </Route>
                                                     <Route path="/login">
                                                         <Login newState={this.state} userLoginHandler={this.userLoginHandler} participantLoginHandler={this.participantLoginHandler} testerLogin={false} logout={this.logout} />

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -46,6 +46,7 @@ import { isDefined } from '../AggregateResults/DataFunctions';
 import { PidLookup } from '../Account/pidLookup';
 import StartOnline from '../OnlineOnly/OnlineOnly';
 import { ParticipantProgressTable } from '../Account/participantProgress';
+import { WaitingPage } from '../Account/waitingPage';
 
 
 
@@ -114,6 +115,8 @@ const HIGH_PID = 202411499;
 function Home({ newState }) {
     if (newState.currentUser == null) {
         history.push('/login');
+    } else if (!newState.currentUser.approved) {
+        history.push('/awaitingApproval');
     } else {
         return <HomePage currentUser={newState.currentUser} />;
     }
@@ -153,7 +156,11 @@ function isUserElevated(currentUser) {
     return currentUser?.admin || currentUser?.evaluator || currentUser?.experimenter;
 }
 
-function Login({ newState, userLoginHandler, participantLoginHandler, participantTextLogin, testerLogin }) {
+function Login({ newState, userLoginHandler, participantLoginHandler, participantTextLogin, testerLogin, logout }) {
+    if (newState?.currentUser && !newState?.currentUser?.approved) {
+        logout();
+        return <LoginApp userLoginHandler={userLoginHandler} participantLoginHandler={participantLoginHandler} />;
+    }
     if (testerLogin && (newState.currentUser === null || (!newState.currentUser.admin && !newState.currentUser.experimenter))) {
         history.push('/participantText');
     }
@@ -424,7 +431,7 @@ export class App extends React.Component {
                                                     </Mutation>
                                                 </>
                                             )}
-                                            {currentUser &&
+                                            {currentUser?.approved &&
                                                 <nav className="navbar navbar-expand-lg navbar-light bg-light itm-navbar">
                                                     <a className="navbar-brand" href="/">
                                                         <img className="nav-brand-itm" src={brandImage} alt="" />ITM
@@ -544,22 +551,27 @@ export class App extends React.Component {
                                             }
                                             <div className="main-content">
                                                 <Switch>
-                                                    <Route exact path="/">
-                                                        <Home newState={this.state} />
-                                                    </Route>
                                                     <Route path="/login">
-                                                        <Login newState={this.state} userLoginHandler={this.userLoginHandler} participantLoginHandler={this.participantLoginHandler} testerLogin={false} />
+                                                        <Login newState={this.state} userLoginHandler={this.userLoginHandler} participantLoginHandler={this.participantLoginHandler} testerLogin={false} logout={this.logout} />
                                                     </Route>
                                                     <Route path="/participantText">
                                                         <Login newState={this.state} userLoginHandler={this.userLoginHandler} participantLoginHandler={this.participantLoginHandler} participantTextLogin={true} testerLogin={false} />
                                                     </Route>
                                                     <Route path="/reset-password/:token" component={ResetPassPage} />
-                                                    <Route path="/myaccount">
-                                                        <MyAccount newState={this.state} userLoginHandler={this.userLoginHandler} />
-                                                    </Route>
                                                     <Route path="/remote-text-survey">
                                                         <StartOnline />
                                                     </Route>
+                                                    {this.state.currentUser && <>
+                                                        <Route exact path="/awaitingApproval">
+                                                            <WaitingPage />
+                                                        </Route>
+                                                        <Route exact path="/">
+                                                            <Home newState={this.state} />
+                                                        </Route>
+                                                        <Route path="/myaccount">
+                                                            <MyAccount newState={this.state} userLoginHandler={this.userLoginHandler} />
+                                                        </Route>
+                                                    </>}
                                                     {isUserElevated(this.state.currentUser) &&
                                                         <>
                                                         <Route exact path="/results">
@@ -626,7 +638,12 @@ export class App extends React.Component {
                                                             <ExploratoryAnalysis />
                                                         </Route>
                                                         </>}
-                                                    <Route path="*" render={() => <Redirect to="/" />} /> 
+                                                    {this.state.currentUser ?
+                                                        (this.state.currentUser?.approved ? 
+                                                            <Route path="*" render={() => <Redirect to="/" />} /> 
+                                                            : <Route path="*" render={() => <Redirect to="/awaitingApproval" />} />)
+                                                        : <Route path="*" render={() => <Redirect to="/login" />} />
+                                                    }
                                                 </Switch>
                                             </div>
 

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -153,7 +153,6 @@ function AdmResults() {
 
 function isUserElevated(currentUser) {
     // ignoring adeptUser, because they should already be admins, evaluators, or experimenters
-    console.log(currentUser);
     return currentUser?.admin || currentUser?.evaluator || currentUser?.experimenter;
 }
 

--- a/dashboard-ui/src/services/accountsService.js
+++ b/dashboard-ui/src/services/accountsService.js
@@ -30,6 +30,7 @@ const accountsGraphQL = new GraphQLClient({
       evaluator
       experimenter
       adeptUser
+      approved
     }
   `,
 });

--- a/dashboard-ui/src/services/accountsService.js
+++ b/dashboard-ui/src/services/accountsService.js
@@ -31,6 +31,7 @@ const accountsGraphQL = new GraphQLClient({
       experimenter
       adeptUser
       approved
+      rejected
     }
   `,
 });

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -244,6 +244,7 @@ const typeDefs = gql`
     updateEvaluatorUser(caller: JSON, username: String, isEvaluator: Boolean): JSON,
     updateExperimenterUser(caller: JSON, username: String, isExperimenter: Boolean): JSON,
     updateAdeptUser(caller: JSON, username: String, isAdeptUser: Boolean): JSON,
+    updateUserApproval(caller: JSON, username: String, isApproved: Boolean): JSON,
     uploadSurveyResults(surveyId: String, results: JSON): JSON,
     uploadScenarioResults(results: [JSON]): JSON,
     addNewParticipantToLog(participantData: JSON, lowPid: Int, highPid: Int): JSON,
@@ -644,6 +645,21 @@ const resolvers = {
       }
       else {
         throw new GraphQLError('Users outside of the admin group cannot update ADEPT user status.', {
+          extensions: { code: '404' }
+        });
+      }
+    },
+    updateUserApproval: async (obj, args, context, inflow) => {
+      const session = await dashboardDB.db.collection('sessions').find({ "_id": new ObjectId(args['caller']?.['sessionId']) })?.project({ "userId": 1, "valid": 1 }).toArray().then(result => { return result[0] });
+      const user = await dashboardDB.db.collection('users').find({ "username": args['caller']?.['username'] })?.project({ "_id": 1, "username": 1, "admin": 1 }).toArray().then(result => { return result[0] });
+      if (session?.valid && (session?.userId == user?._id) && user?.admin) {
+        return await dashboardDB.db.collection('users').update(
+          { "username": args["username"] },
+          { $set: { "approved": args["isApproved"] } }
+        );
+      }
+      else {
+        throw new GraphQLError('Users outside of the admin group cannot approve new users.', {
           extensions: { code: '404' }
         });
       }

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -47,6 +47,7 @@ const typeDefs = gql`
     evaluator: Boolean
     experimenter: Boolean
     adeptUser: Boolean
+    approved: Boolean
   }
 
   type Player {

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -49,6 +49,7 @@ const typeDefs = gql`
     experimenter: Boolean
     adeptUser: Boolean
     approved: Boolean
+    rejected: Boolean
   }
 
   type Player {
@@ -244,7 +245,7 @@ const typeDefs = gql`
     updateEvaluatorUser(caller: JSON, username: String, isEvaluator: Boolean): JSON,
     updateExperimenterUser(caller: JSON, username: String, isExperimenter: Boolean): JSON,
     updateAdeptUser(caller: JSON, username: String, isAdeptUser: Boolean): JSON,
-    updateUserApproval(caller: JSON, username: String, isApproved: Boolean): JSON,
+    updateUserApproval(caller: JSON, username: String, isApproved: Boolean, isRejected: Boolean, isAdmin: Boolean, isEvaluator: Boolean, isExperimenter: Boolean, isAdeptUser: Boolean): JSON,
     uploadSurveyResults(surveyId: String, results: JSON): JSON,
     uploadScenarioResults(results: [JSON]): JSON,
     addNewParticipantToLog(participantData: JSON, lowPid: Int, highPid: Int): JSON,
@@ -655,7 +656,16 @@ const resolvers = {
       if (session?.valid && (session?.userId == user?._id) && user?.admin) {
         return await dashboardDB.db.collection('users').update(
           { "username": args["username"] },
-          { $set: { "approved": args["isApproved"] } }
+          {
+            $set: {
+              "approved": args["isApproved"],
+              "rejected": args["isRejected"],
+              "adeptUser": args["isAdeptUser"],
+              "experimenter": args["isExperimenter"],
+              "evaluator": args["isEvaluator"],
+              "admin": args["isAdmin"]
+            }
+          }
         );
       }
       else {


### PR DESCRIPTION
Rebuild first, and run the 772 ingest PR

We do not want random people creating accounts. This ticket sends new users to a waiting room, while adding their information to a new table in the admin page. Admins can access the table and approve or reject prospective users. In the process, they can also choose the user's permissions (admin, evaluator, experimenter, adept).

If a user is rejected, their waiting room status will be updated accordingly and they should no longer appear in the admin table.

If a user is approved, they will be sent to the home page (no longer able to access /awaitingApproval) and they should no longer appear in the admin table.

Rejected users and users awaiting approval should not be able to access _anything_ in the dashboard. The only action they should be able to take is returning to the login page.