### PR TITLE
fixed rq5 table ST vs AD

### DIFF
--- a/dashboard-ui/src/components/Research/tables/rq5.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq5.jsx
@@ -114,7 +114,7 @@ export function RQ5({ evalNum }) {
                         for (const ta2 of ta2s) {
                             const entryObj = {};
                             entryObj['Participant_ID'] = pid;
-                            entryObj['TA1_Name'] = entry['scenario_id'].includes('DryRunEval') ? 'ADEPT' : 'SoarTech';
+                            entryObj['TA1_Name'] = entry['scenario_id'].includes('DryRunEval') || entry['scenario_id'].includes('adept') ? 'ADEPT' : 'SoarTech';
                             allTA1s.push(entryObj['TA1_Name']);
                             entryObj['TA2_Name'] = ta2;
                             allTA2s.push(ta2);

--- a/dashboard-ui/src/components/Research/tables/rq6.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq6.jsx
@@ -97,7 +97,7 @@ export function RQ6({ evalNum }) {
                     for (const att of attributes) {
                         const entryObj = {};
                         entryObj['Participant_ID'] = pid;
-                        entryObj['TA1_Name'] = entry['scenario_id'].includes('DryRunEval') ? 'ADEPT' : 'SoarTech';
+                        entryObj['TA1_Name'] = entry['scenario_id'].includes('DryRunEval') || entry['scenario_id'].includes('adept') ? 'ADEPT' : 'SoarTech';
                         allTA1s.push(entryObj['TA1_Name']);
                         entryObj['Attribute'] = att;
                         allAttributes.push(att);


### PR DESCRIPTION
RQ5 was only looking for DryRunEval for adept scenarios in order to decide between ST and AD, affecting the TA1 column and scenario column. This adds in the "adept" check for phase 1 adept scenarios.

Fixed RQ6 in the same way