### PR TITLE
added text route again

### DIFF
--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -571,12 +571,16 @@ export class App extends React.Component {
                                                     <Route path="/login">
                                                         <Login newState={this.state} userLoginHandler={this.userLoginHandler} participantLoginHandler={this.participantLoginHandler} testerLogin={false} logout={this.logout} />
                                                     </Route>
+
                                                     <Route path="/participantText">
                                                         <Login newState={this.state} userLoginHandler={this.userLoginHandler} participantLoginHandler={this.participantLoginHandler} participantTextLogin={true} testerLogin={false} />
                                                     </Route>
                                                     <Route path="/reset-password/:token" component={ResetPassPage} />
                                                     <Route path="/remote-text-survey">
                                                         <StartOnline />
+                                                    </Route>
+                                                    <Route path="/text-based">
+                                                        <TextBased />
                                                     </Route>
                                                     <Route path="/myaccount">
                                                         <MyAccount newState={this.state} userLoginHandler={this.userLoginHandler} />


### PR DESCRIPTION
During some sort of merge problem, the text route was completely removed. Anyone should be able to access /text-based. To test, try going in through the OSU email route and ensure you can access the text scenarios while you're logged in and logged out.