### PR TITLE
Itm 814 update rq134

### DIFF
--- a/dashboard-ui/src/components/Research/tables/rq1-rq3.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq1-rq3.jsx
@@ -204,7 +204,6 @@ export function RQ13({ evalNum, tableTitle }) {
                     multiple
                     options={ta1s}
                     value={ta1Filters}
-                    filterSelectedOptions
                     size="small"
                     limitTags={2}
                     renderInput={(params) => (
@@ -219,7 +218,6 @@ export function RQ13({ evalNum, tableTitle }) {
                 <Autocomplete
                     multiple
                     options={ta2s}
-                    filterSelectedOptions
                     value={ta2Filters}
                     size="small"
                     limitTags={2}
@@ -236,7 +234,6 @@ export function RQ13({ evalNum, tableTitle }) {
                     multiple
                     options={scenarios}
                     value={scenarioFilters}
-                    filterSelectedOptions
                     size="small"
                     limitTags={2}
                     renderInput={(params) => (
@@ -252,7 +249,6 @@ export function RQ13({ evalNum, tableTitle }) {
                     multiple
                     options={targets}
                     value={targetFilters}
-                    filterSelectedOptions
                     size="small"
                     limitTags={2}
                     renderInput={(params) => (
@@ -268,7 +264,6 @@ export function RQ13({ evalNum, tableTitle }) {
                     multiple
                     options={attributes}
                     value={attributeFilters}
-                    filterSelectedOptions
                     size="small"
                     limitTags={2}
                     renderInput={(params) => (
@@ -284,7 +279,6 @@ export function RQ13({ evalNum, tableTitle }) {
                     multiple
                     options={admTypes}
                     value={admTypeFilters}
-                    filterSelectedOptions
                     size="small"
                     limitTags={2}
                     renderInput={(params) => (
@@ -300,7 +294,6 @@ export function RQ13({ evalNum, tableTitle }) {
                     multiple
                     options={delGrps}
                     value={delGrpFilters}
-                    filterSelectedOptions
                     size="small"
                     limitTags={2}
                     renderInput={(params) => (
@@ -316,7 +309,6 @@ export function RQ13({ evalNum, tableTitle }) {
                     multiple
                     options={delMils}
                     value={delMilFilters}
-                    filterSelectedOptions
                     size="small"
                     limitTags={2}
                     renderInput={(params) => (

--- a/dashboard-ui/src/components/Research/tables/rq1-rq3.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq1-rq3.jsx
@@ -332,7 +332,7 @@ export function RQ13({ evalNum, tableTitle }) {
                         renderInput={(params) => (
                             <TextField
                                 {...params}
-                                label="Hidden Cols"
+                                label="Hidden Columns"
                                 placeholder=""
                             />
                         )}

--- a/dashboard-ui/src/components/Research/tables/rq1-rq3.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq1-rq3.jsx
@@ -199,145 +199,152 @@ export function RQ13({ evalNum, tableTitle }) {
             </p>
         }
         <section className='tableHeader'>
-            <div className="too-many-filters">
-                <Autocomplete
-                    multiple
-                    options={ta1s}
-                    value={ta1Filters}
-                    size="small"
-                    limitTags={2}
-                    renderInput={(params) => (
-                        <TextField
-                            {...params}
-                            label="TA1"
-                            placeholder=""
-                        />
-                    )}
-                    onChange={(_, newVal) => setTA1Filters(newVal)}
-                />
-                <Autocomplete
-                    multiple
-                    options={ta2s}
-                    value={ta2Filters}
-                    size="small"
-                    limitTags={2}
-                    renderInput={(params) => (
-                        <TextField
-                            {...params}
-                            label="TA2"
-                            placeholder=""
-                        />
-                    )}
-                    onChange={(_, newVal) => setTA2Filters(newVal)}
-                />
-                <Autocomplete
-                    multiple
-                    options={scenarios}
-                    value={scenarioFilters}
-                    size="small"
-                    limitTags={2}
-                    renderInput={(params) => (
-                        <TextField
-                            {...params}
-                            label="Scenarios"
-                            placeholder=""
-                        />
-                    )}
-                    onChange={(_, newVal) => setScenarioFilters(newVal)}
-                />
-                <Autocomplete
-                    multiple
-                    options={targets}
-                    value={targetFilters}
-                    size="small"
-                    limitTags={2}
-                    renderInput={(params) => (
-                        <TextField
-                            {...params}
-                            label="Targets"
-                            placeholder=""
-                        />
-                    )}
-                    onChange={(_, newVal) => setTargetFilters(newVal)}
-                />
-                <Autocomplete
-                    multiple
-                    options={attributes}
-                    value={attributeFilters}
-                    size="small"
-                    limitTags={2}
-                    renderInput={(params) => (
-                        <TextField
-                            {...params}
-                            label="Attributes"
-                            placeholder=""
-                        />
-                    )}
-                    onChange={(_, newVal) => setAttributeFilters(newVal)}
-                />
-                <Autocomplete
-                    multiple
-                    options={admTypes}
-                    value={admTypeFilters}
-                    size="small"
-                    limitTags={2}
-                    renderInput={(params) => (
-                        <TextField
-                            {...params}
-                            label="ADM Types"
-                            placeholder=""
-                        />
-                    )}
-                    onChange={(_, newVal) => setAdmTypeFilters(newVal)}
-                />
-                <Autocomplete
-                    multiple
-                    options={delGrps}
-                    value={delGrpFilters}
-                    size="small"
-                    limitTags={2}
-                    renderInput={(params) => (
-                        <TextField
-                            {...params}
-                            label="Delegator_grp"
-                            placeholder=""
-                        />
-                    )}
-                    onChange={(_, newVal) => setDelGrpFilters(newVal)}
-                />
-                <Autocomplete
-                    multiple
-                    options={delMils}
-                    value={delMilFilters}
-                    size="small"
-                    limitTags={2}
-                    renderInput={(params) => (
-                        <TextField
-                            {...params}
-                            label="Delegator_mil"
-                            placeholder=""
-                        />
-                    )}
-                    onChange={(_, newVal) => setDelMilFilters(newVal)}
-                />
-                <Autocomplete
-                    multiple
-                    options={HEADERS}
-                    size="small"
-                    limitTags={1}
-                    value={columnsToHide}
-                    renderInput={(params) => (
-                        <TextField
-                            {...params}
-                            label="Hidden Cols"
-                            placeholder=""
-                        />
-                    )}
-                    onChange={(_, newVal) => setColumnsToHide(newVal)}
-                />
-                <TextField label="Search PIDs" size="small" value={searchPid} onInput={updatePidSearch}></TextField>
+            <div className='complexHeader'>
+                <div className="too-many-filters">
+                    <Autocomplete
+                        multiple
+                        options={ta1s}
+                        value={ta1Filters}
+                        size="small"
+                        limitTags={2}
+                        renderInput={(params) => (
+                            <TextField
+                                {...params}
+                                label="TA1"
+                                placeholder=""
+                            />
+                        )}
+                        onChange={(_, newVal) => setTA1Filters(newVal)}
+                    />
+                    <Autocomplete
+                        multiple
+                        options={ta2s}
+                        value={ta2Filters}
+                        size="small"
+                        limitTags={2}
+                        renderInput={(params) => (
+                            <TextField
+                                {...params}
+                                label="TA2"
+                                placeholder=""
+                            />
+                        )}
+                        onChange={(_, newVal) => setTA2Filters(newVal)}
+                    />
+                    <Autocomplete
+                        multiple
+                        options={scenarios}
+                        value={scenarioFilters}
+                        size="small"
+                        limitTags={2}
+                        renderInput={(params) => (
+                            <TextField
+                                {...params}
+                                label="Scenarios"
+                                placeholder=""
+                            />
+                        )}
+                        onChange={(_, newVal) => setScenarioFilters(newVal)}
+                    />
+                    <Autocomplete
+                        multiple
+                        options={targets}
+                        value={targetFilters}
+                        size="small"
+                        limitTags={2}
+                        renderInput={(params) => (
+                            <TextField
+                                {...params}
+                                label="Targets"
+                                placeholder=""
+                            />
+                        )}
+                        onChange={(_, newVal) => setTargetFilters(newVal)}
+                    />
+                    <Autocomplete
+                        multiple
+                        options={attributes}
+                        value={attributeFilters}
+                        size="small"
+                        limitTags={2}
+                        renderInput={(params) => (
+                            <TextField
+                                {...params}
+                                label="Attributes"
+                                placeholder=""
+                            />
+                        )}
+                        onChange={(_, newVal) => setAttributeFilters(newVal)}
+                    />
+                    <Autocomplete
+                        multiple
+                        options={admTypes}
+                        value={admTypeFilters}
+                        size="small"
+                        limitTags={2}
+                        renderInput={(params) => (
+                            <TextField
+                                {...params}
+                                label="ADM Types"
+                                placeholder=""
+                            />
+                        )}
+                        onChange={(_, newVal) => setAdmTypeFilters(newVal)}
+                    />
+                    <Autocomplete
+                        multiple
+                        options={delGrps}
+                        value={delGrpFilters}
+                        size="small"
+                        limitTags={2}
+                        renderInput={(params) => (
+                            <TextField
+                                {...params}
+                                label="Delegator_grp"
+                                placeholder=""
+                            />
+                        )}
+                        onChange={(_, newVal) => setDelGrpFilters(newVal)}
+                    />
+                    <Autocomplete
+                        multiple
+                        options={delMils}
+                        value={delMilFilters}
+                        size="small"
+                        limitTags={2}
+                        renderInput={(params) => (
+                            <TextField
+                                {...params}
+                                label="Delegator_mil"
+                                placeholder=""
+                            />
+                        )}
+                        onChange={(_, newVal) => setDelMilFilters(newVal)}
+                    />
+                </div>
+                <div className='largeInputs'>
+                    <Autocomplete
+                        multiple
+                        options={HEADERS}
+                        size="small"
+                        limitTags={1}
+                        value={columnsToHide}
+                        renderInput={(params) => (
+                            <TextField
+                                {...params}
+                                label="Hidden Cols"
+                                placeholder=""
+                            />
+                        )}
+                        onChange={(_, newVal) => setColumnsToHide(newVal)}
+                    />
+                    <TextField label="Search PIDs" size="small" value={searchPid} onInput={updatePidSearch}></TextField>
+                </div>
+
             </div>
+
             <DownloadButtons formattedData={formattedData} filteredData={refineData(filteredData)} HEADERS={HEADERS.filter((x) => !columnsToHide.includes(x))} fileName={'RQ-1_and_RQ-3 data'} extraAction={openModal} />
+
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/Research/tables/rq1-rq3.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq1-rq3.jsx
@@ -157,6 +157,18 @@ export function RQ13({ evalNum, tableTitle }) {
         setSearchPid('');
     };
 
+    const refineData = (origData) => {
+        // remove unwanted headers from download
+        const updatedData = structuredClone(origData);
+        updatedData.map((x) => {
+            for (const h of columnsToHide) {
+                delete x[h];
+            }
+            return x;
+        });
+        return updatedData;
+    };
+
     React.useEffect(() => {
         if (formattedData.length > 0) {
             setFilteredData(formattedData.filter((x) =>
@@ -333,7 +345,7 @@ export function RQ13({ evalNum, tableTitle }) {
                 />
                 <TextField label="Search PIDs" size="small" value={searchPid} onInput={updatePidSearch}></TextField>
             </div>
-            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-1_and_RQ-3 data'} extraAction={openModal} />
+            <DownloadButtons formattedData={formattedData} filteredData={refineData(filteredData)} HEADERS={HEADERS.filter((x) => !columnsToHide.includes(x))} fileName={'RQ-1_and_RQ-3 data'} extraAction={openModal} />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/Research/utils.js
+++ b/dashboard-ui/src/components/Research/utils.js
@@ -255,8 +255,8 @@ export function getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dat
                 }
                 page = res.results[page];
                 const entryObj = {};
-                entryObj['ADM Order'] = wrong_del_materials.includes(pid) ? 1 : logData['ADMOrder'];
                 entryObj['Delegator_ID'] = pid;
+                entryObj['ADM Order'] = wrong_del_materials.includes(pid) ? 1 : logData['ADMOrder'];
                 entryObj['Datasource'] = evalNum == 4 ? 'DRE' : logData.Type == 'Online' ? 'P1E_online' : 'P1E_IRL';
                 entryObj['Delegator_grp'] = logData['Type'] == 'Civ' ? 'Civilian' : logData['Type'] == 'Mil' ? 'Military' : logData['Type'];
                 const roles = res.results?.['Post-Scenario Measures']?.questions?.['What is your current role (choose all that apply):']?.['response'];

--- a/dashboard-ui/src/components/SurveyResults/resultsTable.css
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.css
@@ -140,15 +140,29 @@
     max-width: 180px;
 }
 
+.too-many-filters>* {
+    min-width: 150px;
+    max-width: 150px;
+}
+
 .filters .large-box {
     min-width: 220px !important;
+}
+
+.too-many-filters {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    gap: 8px;
+    width: 60%;
+    flex-wrap: wrap;
 }
 
 #big-filter {
     min-width: 160px !important;
 }
 
-.filters button {
+.filters button, .too-many-filters button {
     border: none !important;
     padding: 0px !important;
 }
@@ -203,8 +217,8 @@
 }
 
 .hide-header {
-    background-color: transparent;
-    border: none;
+    background-color: transparent !important;
+    border: none !important;
     float: right;
     border-radius: 50%;
     color: rgba(177, 176, 176, 0.87);
@@ -222,4 +236,32 @@
 .hide-header:active {
     background-color: rgba(215, 215, 215, 0.295);
     justify-content: space-between;
+}
+
+.rq134Header {
+    position: relative;
+}
+
+.rq134Header .hide-header {
+    position: absolute;
+    bottom: 0px;
+    right: 8px;
+}
+
+.reset-btn {
+    color: rgb(89, 38, 16);
+    text-decoration: underline;
+    margin-left: 8px;
+    border-radius: 8px;
+    padding: 2px;
+}
+
+.reset-btn:hover {
+    cursor: pointer;
+    background-color: rgba(239, 239, 239, 0.329);
+}
+
+.reset-btn:active {
+    cursor: pointer;
+    background-color: rgba(225, 223, 223, 0.603);
 }

--- a/dashboard-ui/src/components/SurveyResults/resultsTable.css
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.css
@@ -150,19 +150,49 @@
 }
 
 .too-many-filters {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    grid-template-rows: repeat(2, auto);
     gap: 8px;
-    width: 60%;
-    flex-wrap: wrap;
 }
+
+.largeInputs {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.largeInputs>* {
+    min-width: 240px !important;
+    max-width: 300px !important;
+}
+
+.complexHeader {
+    display: flex;
+    gap: 8px;
+}
+
+@media only screen and (max-width: 1380px) {
+    .too-many-filters {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        grid-template-rows: repeat(4, auto);
+        gap: 8px;
+    }
+
+    .complexHeader {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+}
+
 
 #big-filter {
     min-width: 160px !important;
 }
 
-.filters button, .too-many-filters button {
+.filters button, .too-many-filters button, .largeInputs button {
     border: none !important;
     padding: 0px !important;
 }
@@ -240,6 +270,7 @@
 
 .rq134Header {
     position: relative;
+    padding-bottom: 12px !important;
 }
 
 .rq134Header .hide-header {


### PR DESCRIPTION
1. Added a reset filters button (does not change the DRE checkbox and does not unhide hidden columns. That is intentional). To see it in action, add some filters and you'll see it pop up next to "Showing x of y columns". Click it and see the table reset
2. Moved delegator_id to the far left of the table. It just makes sense.
3. Added hide columns feature
4. Added search-by-pid feature
5. Moved filters around to make it more visually pleasing (also changed it so that only 2 tags will appear)
6. BUG FIX: Prior to this ticket, if you checked the Include DRE checkbox and then navigated to the DRE data, all data would be duplicated. That is fixed here by resetting the DRE checkbox every time evalNumber updates.