### PR TITLE
Itm 821 adept dre data

### DIFF
--- a/dashboard-ui/src/components/Research/tables/rq1-rq3.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq1-rq3.jsx
@@ -204,7 +204,6 @@ export function RQ13({ evalNum, tableTitle }) {
                     multiple
                     options={ta1s}
                     value={ta1Filters}
-                    filterSelectedOptions
                     size="small"
                     limitTags={2}
                     renderInput={(params) => (
@@ -219,7 +218,6 @@ export function RQ13({ evalNum, tableTitle }) {
                 <Autocomplete
                     multiple
                     options={ta2s}
-                    filterSelectedOptions
                     value={ta2Filters}
                     size="small"
                     limitTags={2}
@@ -236,7 +234,6 @@ export function RQ13({ evalNum, tableTitle }) {
                     multiple
                     options={scenarios}
                     value={scenarioFilters}
-                    filterSelectedOptions
                     size="small"
                     limitTags={2}
                     renderInput={(params) => (
@@ -252,7 +249,6 @@ export function RQ13({ evalNum, tableTitle }) {
                     multiple
                     options={targets}
                     value={targetFilters}
-                    filterSelectedOptions
                     size="small"
                     limitTags={2}
                     renderInput={(params) => (
@@ -268,7 +264,6 @@ export function RQ13({ evalNum, tableTitle }) {
                     multiple
                     options={attributes}
                     value={attributeFilters}
-                    filterSelectedOptions
                     size="small"
                     limitTags={2}
                     renderInput={(params) => (
@@ -284,7 +279,6 @@ export function RQ13({ evalNum, tableTitle }) {
                     multiple
                     options={admTypes}
                     value={admTypeFilters}
-                    filterSelectedOptions
                     size="small"
                     limitTags={2}
                     renderInput={(params) => (
@@ -300,7 +294,6 @@ export function RQ13({ evalNum, tableTitle }) {
                     multiple
                     options={delGrps}
                     value={delGrpFilters}
-                    filterSelectedOptions
                     size="small"
                     limitTags={2}
                     renderInput={(params) => (
@@ -316,7 +309,6 @@ export function RQ13({ evalNum, tableTitle }) {
                     multiple
                     options={delMils}
                     value={delMilFilters}
-                    filterSelectedOptions
                     size="small"
                     limitTags={2}
                     renderInput={(params) => (

--- a/dashboard-ui/src/components/Research/tables/rq1-rq3.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq1-rq3.jsx
@@ -42,8 +42,8 @@ const GET_SIM_DATA = gql`
         getAllSimAlignmentByEval(evalNumber: $evalNumber)
     }`;
 
-const HEADERS = ['Delegator_ID', 'ADM Order', 'Datasource', 'Delegator_grp', 'Delegator_mil', 'Delegator_Role', 'TA1_Name', 'Trial_ID', 'Attribute', 'Scenario', 'TA2_Name', 'ADM_Type', 'Target', 'Alignment score (ADM|target)', 'Alignment score (Delegator|target)', 'Alignment score (Participant_sim|Observed_ADM(target))', 'Server Session ID (Delegator)', 'ADM_Aligned_Status (Baseline/Misaligned/Aligned)', 'ADM Loading', 'Competence Error', 'Alignment score (Delegator|Observed_ADM (target))', 'Trust_Rating', 'Delegation preference (A/B)', 'Delegation preference (A/M)', 'Trustworthy_Rating', 'Agreement_Rating', 'SRAlign_Rating'];
-
+const HEADERS_DRE = ['Delegator_ID', 'ADM Order', 'Datasource', 'Delegator_grp', 'Delegator_mil', 'Delegator_Role', 'TA1_Name', 'Trial_ID', 'Attribute', 'Scenario', 'TA2_Name', 'ADM_Type', 'Target', 'Alignment score (ADM|target)', 'Alignment score (Delegator|target)', 'Alignment score (Participant_sim|Observed_ADM(target))', 'Server Session ID (Delegator)', 'ADM_Aligned_Status (Baseline/Misaligned/Aligned)', 'ADM Loading', 'Competence Error', 'Alignment score (Delegator|Observed_ADM (target))', 'Trust_Rating', 'Delegation preference (A/B)', 'Delegation preference (A/M)', 'Trustworthy_Rating', 'Agreement_Rating', 'SRAlign_Rating'];
+const HEADERS_PH1 = ['Delegator_ID', 'ADM Order', 'Datasource', 'Delegator_grp', 'Delegator_mil', 'Delegator_Role', 'TA1_Name', 'Trial_ID', 'Attribute', 'Scenario', 'TA2_Name', 'ADM_Type', 'Target', 'Alignment score (ADM|target)', 'DRE_ADM|Target', 'Alignment score (Delegator|target)', 'DRE_Delegator|Target', 'Alignment score (Participant_sim|Observed_ADM(target))', 'Server Session ID (Delegator)', 'ADM_Aligned_Status (Baseline/Misaligned/Aligned)', 'ADM Loading', 'DRE_ADM_loading', 'Competence Error', 'Alignment score (Delegator|Observed_ADM (target))', 'DRE_Delegator|Observed_ADM', 'Trust_Rating', 'Delegation preference (A/B)', 'Delegation preference (A/M)', 'Trustworthy_Rating', 'Agreement_Rating', 'SRAlign_Rating'];
 
 export function RQ13({ evalNum, tableTitle }) {
     const { loading: loadingParticipantLog, error: errorParticipantLog, data: dataParticipantLog } = useQuery(GET_PARTICIPANT_LOG);
@@ -86,6 +86,7 @@ export function RQ13({ evalNum, tableTitle }) {
     const [columnsToHide, setColumnsToHide] = React.useState([]);
     // searching rows
     const [searchPid, setSearchPid] = React.useState('');
+    const HEADERS = evalNum == 5 ? HEADERS_PH1 : HEADERS_DRE;
 
 
     const openModal = () => {

--- a/dashboard-ui/src/components/Research/tables/rq1-rq3.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq1-rq3.jsx
@@ -157,6 +157,18 @@ export function RQ13({ evalNum, tableTitle }) {
         setSearchPid('');
     };
 
+    const refineData = (origData) => {
+        // remove unwanted headers from download
+        const updatedData = structuredClone(origData);
+        updatedData.map((x) => {
+            for (const h of columnsToHide) {
+                delete x[h];
+            }
+            return x;
+        });
+        return updatedData;
+    };
+
     React.useEffect(() => {
         if (formattedData.length > 0) {
             setFilteredData(formattedData.filter((x) =>
@@ -333,7 +345,7 @@ export function RQ13({ evalNum, tableTitle }) {
                 />
                 <TextField label="Search PIDs" size="small" value={searchPid} onInput={updatePidSearch}></TextField>
             </div>
-            <DownloadButtons formattedData={formattedData} filteredData={filteredData} HEADERS={HEADERS} fileName={'RQ-1_and_RQ-3 data'} extraAction={openModal} />
+            <DownloadButtons formattedData={formattedData} filteredData={refineData(filteredData)} HEADERS={HEADERS.filter((x) => !columnsToHide.includes(x))} fileName={'RQ-1_and_RQ-3 data'} extraAction={openModal} />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/Research/utils.js
+++ b/dashboard-ui/src/components/Research/utils.js
@@ -284,25 +284,59 @@ export function getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dat
                 const foundADM = admData.find((adm) => adm.history[0].parameters.adm_name == page['admName'] && (adm.history[0].response?.id ?? adm.history[1].response?.id) == page['scenarioIndex'].replace('IO', 'MJ') &&
                     adm.history[adm.history.length - 1].parameters.target_id == page['admTarget']);
                 const alignment = foundADM?.history[foundADM.history.length - 1]?.response?.score ?? '-';
+
                 entryObj['Alignment score (ADM|target)'] = alignment;
+                if (evalNum == 5)
+                    entryObj['DRE_ADM|Target'] = entry['TA1'] == 'Adept' ? page.dreAdmAlignment : alignment;
+
+                // if DRE data is included in PH1 set, update DRE columns accordingly
+                if (evalNum == 4 && fullSetOnly) {
+                    entryObj['DRE_ADM|Target'] = entryObj['Alignment score (ADM|target)'];
+                    entryObj['Alignment score (ADM|target)'] = entry['TA1'] == 'Adept' ? page.ph1AdmAlignment : entryObj['Alignment score (ADM|target)']
+                }
+
                 const simEntry = simData.find((x) => x.evalNumber == evalNum && x.pid == pid &&
                     (['QOL', 'VOL'].includes(entryObj['Attribute']) ? x.ta1 == 'st' : x.ta1 == 'ad') &&
                     x.scenario_id.toUpperCase().includes(entryObj['Attribute'].replace('IO', 'MJ')));
                 const alignmentData = simEntry?.data?.alignment?.adms_vs_text;
                 entryObj['Alignment score (Participant_sim|Observed_ADM(target))'] = alignmentData?.find((x) => (x['adm_author'] == (entry['TA2'] == 'Kitware' ? 'kitware' : 'TAD')) &&
                     x['adm_alignment'].includes(entryObj['ADM_Type']) && x['adm_target'] == page['admTarget'])?.score ?? '-';
+
                 entryObj['Alignment score (Delegator|target)'] = alignments.find((a) => a.target == page['admTarget'] || (evalNum == 5 && a.target == page['admTarget']?.replace('.', '')))?.score ?? '-';
+                if (evalNum == 5)
+                    entryObj['DRE_Delegator|Target'] = entry['TA1'] == 'Adept' ? page.dreTxtAlignment : entryObj['Alignment score (Delegator|target)'];
+                // if DRE data is included in PH1 set, update DRE columns accordingly
+                if (evalNum == 4 && fullSetOnly) {
+                    entryObj['DRE_Delegator|Target'] = entryObj['Alignment score (Delegator|target)'];
+                    entryObj['Alignment score (Delegator|target)'] = entry['TA1'] == 'Adept' ? page.ph1TxtAlignment : entryObj['Alignment score (Delegator|target)']
+                }
+
                 entryObj['Server Session ID (Delegator)'] = t == 'comparison' ? '-' : textResultsForPID.find((r) => r.scenario_id.includes(entryObj['TA1_Name'] == 'Adept' ? 'MJ' : (entryObj['Target'].includes('qol') ? 'qol' : 'vol')))?.[entryObj['TA1_Name'] == 'Adept' ? 'combinedSessionId' : 'serverSessionId'] ?? '-';
                 entryObj['ADM_Aligned_Status (Baseline/Misaligned/Aligned)'] = t == 'comparison' ? '-' : t;
+
                 entryObj['ADM Loading'] = t == 'comparison' ? '-' : t == 'baseline' ? 'normal' : ['least aligned', 'most aligned'].includes(page['admChoiceProcess']) ? 'normal' : 'exemption';
+                if (evalNum == 5)
+                    entryObj['DRE_ADM_loading'] = entry['TA1'] == 'Adept' ? page.dreChoiceProcess : entryObj['ADM Loading'];
+                // if DRE data is included in PH1 set, update DRE columns accordingly
+                if (evalNum == 4 && fullSetOnly) {
+                    entryObj['DRE_ADM_loading'] = entryObj['ADM Loading'];
+                    entryObj['ADM Loading'] = entry['TA1'] == 'Adept' ? page.ph1ChoiceProcess : entryObj['ADM Loading']
+                }
+
                 entryObj['Competence Error'] = evalNum == 5 && entry['TA2'] == 'Kitware' && entryObj['ADM_Type'] == 'aligned' && PH1_COMPETENCE[entryObj['Scenario']].includes(entryObj['Target']) ? 1 : 0;
 
                 const comparison_entry = comparisons?.find((x) => x['ph1_server'] !== true && x['adm_type'] == t && x['pid'] == pid && getDelEnvMapping(res.results.surveyVersion)[entryObj['Scenario']].includes(x['adm_scenario']) && ((entry['TA2'] == 'Parallax' && x['adm_author'] == 'TAD') || (entry['TA2'] == 'Kitware' && x['adm_author'] == 'kitware')) && x['adm_scenario']?.toLowerCase().includes(entryObj['Attribute']?.toLowerCase()));
                 const alignmentComparison = comparison_entry?.score ?? '-'
                 entryObj['Alignment score (Delegator|Observed_ADM (target))'] = alignmentComparison;
-                if (evalNum == 4 && fullSetOnly && entryObj['TA1_Name'] == 'Adept') {
+                if (evalNum == 5) {
+                    const dre_comparison_entry = comparisons?.find((x) => x['dre_server'] === true && x['adm_type'] == t && x['pid'] == pid && getDelEnvMapping(res.results.surveyVersion)[entryObj['Scenario']].includes(x['adm_scenario']) && ((entry['TA2'] == 'Parallax' && x['adm_author'] == 'TAD') || (entry['TA2'] == 'Kitware' && x['adm_author'] == 'kitware')) && x['adm_scenario']?.toLowerCase().includes(entryObj['Attribute']?.toLowerCase()));
+                    entryObj['DRE_Delegator|Observed_ADM'] = entry['TA1'] == 'Adept' ? dre_comparison_entry?.score : entryObj['Alignment score (Delegator|Observed_ADM (target))'];
+                }
+                if (evalNum == 4 && fullSetOnly) {
                     const ph1_comparison_entry = comparisons?.find((x) => x['ph1_server'] === true && x['adm_type'] == t && x['pid'] == pid && getDelEnvMapping(res.results.surveyVersion)[entryObj['Scenario']].includes(x['adm_scenario']) && ((entry['TA2'] == 'Parallax' && x['adm_author'] == 'TAD') || (entry['TA2'] == 'Kitware' && x['adm_author'] == 'kitware')) && x['adm_scenario']?.toLowerCase().includes(entryObj['Attribute']?.toLowerCase()));
-                    entryObj['Alignment score (Delegator|Observed_ADM (target))'] = ph1_comparison_entry?.score ?? '-';
+                    entryObj['DRE_Delegator|Observed_ADM'] = entryObj['Alignment score (Delegator|Observed_ADM (target))'];
+                    if (entryObj['TA1_Name'] == 'Adept')
+                        entryObj['Alignment score (Delegator|Observed_ADM (target))'] = ph1_comparison_entry?.score ?? '-';
                 }
 
                 entryObj['Trust_Rating'] = RATING_MAP[page['pageType'] == 'singleMedic' ? page['questions']?.[page['pageName'] + ': I would be comfortable allowing this medic to execute medical triage, even if I could not monitor it']?.['response'] ?? '-' : '-'];

--- a/dashboard-ui/src/components/Research/utils.js
+++ b/dashboard-ui/src/components/Research/utils.js
@@ -255,8 +255,8 @@ export function getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dat
                 }
                 page = res.results[page];
                 const entryObj = {};
-                entryObj['ADM Order'] = wrong_del_materials.includes(pid) ? 1 : logData['ADMOrder'];
                 entryObj['Delegator_ID'] = pid;
+                entryObj['ADM Order'] = wrong_del_materials.includes(pid) ? 1 : logData['ADMOrder'];
                 entryObj['Datasource'] = evalNum == 4 ? 'DRE' : logData.Type == 'Online' ? 'P1E_online' : 'P1E_IRL';
                 entryObj['Delegator_grp'] = logData['Type'] == 'Civ' ? 'Civilian' : logData['Type'] == 'Mil' ? 'Military' : logData['Type'];
                 const roles = res.results?.['Post-Scenario Measures']?.questions?.['What is your current role (choose all that apply):']?.['response'];

--- a/dashboard-ui/src/components/SurveyResults/resultsTable.css
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.css
@@ -140,15 +140,29 @@
     max-width: 180px;
 }
 
+.too-many-filters>* {
+    min-width: 150px;
+    max-width: 150px;
+}
+
 .filters .large-box {
     min-width: 220px !important;
+}
+
+.too-many-filters {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    gap: 8px;
+    width: 60%;
+    flex-wrap: wrap;
 }
 
 #big-filter {
     min-width: 160px !important;
 }
 
-.filters button {
+.filters button, .too-many-filters button {
     border: none !important;
     padding: 0px !important;
 }
@@ -203,8 +217,8 @@
 }
 
 .hide-header {
-    background-color: transparent;
-    border: none;
+    background-color: transparent !important;
+    border: none !important;
     float: right;
     border-radius: 50%;
     color: rgba(177, 176, 176, 0.87);
@@ -222,4 +236,32 @@
 .hide-header:active {
     background-color: rgba(215, 215, 215, 0.295);
     justify-content: space-between;
+}
+
+.rq134Header {
+    position: relative;
+}
+
+.rq134Header .hide-header {
+    position: absolute;
+    bottom: 0px;
+    right: 8px;
+}
+
+.reset-btn {
+    color: rgb(89, 38, 16);
+    text-decoration: underline;
+    margin-left: 8px;
+    border-radius: 8px;
+    padding: 2px;
+}
+
+.reset-btn:hover {
+    cursor: pointer;
+    background-color: rgba(239, 239, 239, 0.329);
+}
+
+.reset-btn:active {
+    cursor: pointer;
+    background-color: rgba(225, 223, 223, 0.603);
 }

--- a/dashboard-ui/src/components/SurveyResults/resultsTable.css
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.css
@@ -240,6 +240,7 @@
 
 .rq134Header {
     position: relative;
+    padding-bottom: 12px !important;
 }
 
 .rq134Header .hide-header {


### PR DESCRIPTION
Added more data to RQ 1/3/4. 

Yes, variables will need to be updated. I plan on doing that in a separate ticket maybe today, maybe Monday. 

To test, run https://github.com/NextCenturyCorporation/itm-ingest/pull/102

Then check the RQ 1/3/4 tables. You'll notice a few new columns. Since I haven't updated variables yet, I'll do my best to explain here (new columns will only show up if the drop down is PH1):
**DRE_ADM|Target** - The ADM probes were run through the DRE server. This is the alignment against the target specified in the Target column. If Include DRE Data is selected, this still holds true: the number in this column will be the value gotten from running the ADM probes through the DRE server, meaning they should match the Alignment score (ADM|target) column if the DRE dropdown was selected. The Alignment score (ADM|target) if the PH1 dropdown is selected is now ALWAYS the ADM alignment against the target when run through the PH1 server

Everything else follows this pattern, so I won't over-explain:
**DRE_Delegator|Target** - The text probe alignment from the delegator according to the DRE server. Alignment score (Delegator|target) with PH1 dropdown is text probe alignment from delegator according to PH1 server
**DRE_ADM_loading** - We looked at the most and least aligned targets for the delegator (text probes) according to the DRE server. If the most aligned target matched what was shown as aligned, or least aligned matched what was shown as misaligned, this is "normal". Otherwise, it's "exception". Baseline should always be normal.
**DRE_Delegator|Observed_ADM** - The comparison value between text probes and the delegation ADM (fewer probes) according to the DRE server
