### PR TITLE
added kdmas to adm-probe-responses for ADEPT

### DIFF
--- a/dashboard-ui/src/components/AdmCharts/admProbeResponses.jsx
+++ b/dashboard-ui/src/components/AdmCharts/admProbeResponses.jsx
@@ -189,6 +189,10 @@ export const ADMProbeResponses = (props) => {
         return probeResponse?.parameters?.choice || '-';
     };
 
+    const getKdma = (history, attribute) => {
+        return history.find(entry => entry.command === 'TA1 Session Alignment')?.response?.kdma_values?.find((kdma) => kdma.kdma == attribute)?.value;
+    }
+
     if (evalNameLoading) return <div>Loading...</div>;
     if (evalNameError) return <div>Error loading evals</div>;
 
@@ -277,7 +281,9 @@ export const ADMProbeResponses = (props) => {
                     'Alignment Target': alignmentTarget,
                     'TA1 Session ID': getSessionId(data.history)
                 };
-
+            if (getCurrentScenarioName().includes('Adept')) {
+                row['KDMA'] = getKdma(data.history, alignmentTarget.includes('Moral') ? 'Moral judgement' : 'Ingroup Bias');
+            }
 
             const probeColumns = new Set();
             testDataArray.forEach(({ data }) => {
@@ -465,6 +471,7 @@ export const ADMProbeResponses = (props) => {
                                                                     <>
                                                                         <th>Alignment Target</th>
                                                                         <th>TA1 Session ID</th>
+                                                                        {getCurrentScenarioName().includes('Adept') && <th>KDMA</th>}
                                                                     </>
                                                                 )}
                                                                 {sortedProbeColumns.map(probeId => (
@@ -479,6 +486,7 @@ export const ADMProbeResponses = (props) => {
                                                                         <>
                                                                             <td>{alignmentTarget}</td>
                                                                             <td>{getSessionId(data.history)}</td>
+                                                                            {getCurrentScenarioName().includes('Adept') && <td>{getKdma(data.history, alignmentTarget.includes('Moral') ? 'Moral judgement' : 'Ingroup Bias')}</td>}
                                                                         </>
                                                                     )}
                                                                     {sortedProbeColumns.map(probeId => (

--- a/dashboard-ui/src/css/results-page.css
+++ b/dashboard-ui/src/css/results-page.css
@@ -62,7 +62,7 @@ nav.MuiList-root.nav-list.MuiList-padding {
 }
 
 .test-overview-area {
-    max-width: 80%;
+    max-width: 78%;
     margin: 10px 20px;
     flex: 1;
 }


### PR DESCRIPTION
http://localhost:3000/adm-probe-responses

KDMAs should show up for ADEPT only. KDMA should match the target attribute. Should appear in both downloads.

Styling update is because the evaluation menu had a weird size on a smaller screen. This fixes it for a normal-size screen, but not for mobile/tablet. I will be making a ticket to put in a more long-term fix for that styling bug 