### PR TITLE
Itm 827

### DIFF
--- a/dashboard-ui/src/css/results-page.css
+++ b/dashboard-ui/src/css/results-page.css
@@ -11,7 +11,7 @@
 
 .nav-section,
 .nav-section-compare {
-    flex: 0 0 20%; 
+    flex: 0 0 18%; 
     border: 1px solid transparent;
     margin-left: 5px;
     border-radius: 8px;
@@ -65,7 +65,7 @@ nav.MuiList-root.nav-list.MuiList-padding {
 }
 
 .test-overview-area {
-    flex: 0 0 80%; 
+    flex: 0 0 82%; 
     margin: 10px 0;
     overflow-x: auto;
 }

--- a/dashboard-ui/src/css/results-page.css
+++ b/dashboard-ui/src/css/results-page.css
@@ -1,5 +1,6 @@
 .layout {
     background-color: #F8F8F8;
+    min-height: 100vh;
 }
 
 .layout-board {
@@ -10,10 +11,11 @@
 
 .nav-section,
 .nav-section-compare {
+    flex: 0 0 20%; 
     border: 1px solid transparent;
     margin-left: 5px;
     border-radius: 8px;
-    min-width: 275px;
+    height: fit-content;
 }
 
 .nav-header {
@@ -24,6 +26,7 @@
     height: 50px;
     padding: 12px 15px 0 15px;
     margin-top: 10px;
+    width: 100%;
 }
 
 .nav-header-text {
@@ -34,7 +37,7 @@
 .nav-menu {
     display: flex;
     flex-direction: column;
-    width: 300px;
+    width: 100%;
     background-color: #F8F8F8;
 }
 
@@ -62,9 +65,9 @@ nav.MuiList-root.nav-list.MuiList-padding {
 }
 
 .test-overview-area {
-    max-width: 78%;
-    margin: 10px 20px;
-    flex: 1;
+    flex: 0 0 80%; 
+    margin: 10px 0;
+    overflow-x: auto;
 }
 
 .tableCellKey {


### PR DESCRIPTION
[Ticket](https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?assignee=60ba425da547eb00686ee0ce&selectedIssue=ITM-827)

This UI bug was occurring on both http://localhost:3000/results and http://localhost:3000/adm-probe-responses. Minor other spacing issues addressed. Should now see fixed styling:

<img width="1832" alt="Screenshot 2025-01-16 at 10 16 57 AM" src="https://github.com/user-attachments/assets/241b8029-dbe9-4c33-9be1-7656f870d13c" />
<img width="1826" alt="Screenshot 2025-01-16 at 10 17 36 AM" src="https://github.com/user-attachments/assets/10894839-2d83-4f49-8618-8a1c8352d068" />
