### PR TITLE
added treatment counts to adms for adept scenarios

### DIFF
--- a/dashboard-ui/src/components/Results/resultsTable.jsx
+++ b/dashboard-ui/src/components/Results/resultsTable.jsx
@@ -334,7 +334,7 @@ class ResultsTable extends React.Component {
                                                                 <Table className='itm-table' stickyHeader aria-label="simple table">
                                                                     <TableBody className='TableBodyScrollable'>
                                                                         {testData.history.map((item, index) => (
-                                                                            <ActionRow key={item.command + index} item={item} ta1={this.formatScenarioString(this.state.scenario).split(':')[0]} />
+                                                                            <ActionRow key={item.command + index} item={item} />
                                                                         ))}
                                                                     </TableBody>
                                                                 </Table>
@@ -377,11 +377,11 @@ class ResultsTable extends React.Component {
 }
 
 
-function ActionRow({ item, ta1 }) {
+function ActionRow({ item }) {
     const [open, setOpen] = React.useState(false);
 
     const renderNestedItems = (item, response = null) => {
-    // pass response through for ADEPT treatment counts
+        // pass response through for treatment counts
         if (isObject(item)) {
             return renderNestedTable(item, response);
         } else if (Array.isArray(item)) {
@@ -403,7 +403,7 @@ function ActionRow({ item, ta1 }) {
             <Table size="small">
                 <TableBody>
                     {Object.entries(tableData).map(([key, value], i) => {
-                        if (isTreatment && response && key == 'treatment' && value == 'Hemostatic gauze') {
+                        if (isTreatment && response && key == 'treatment') {
                             for (const c of (response?.characters ?? [])) {
                                 if (c['id'] == character) {
                                     for (const injury of c['injuries']) {
@@ -459,7 +459,7 @@ function ActionRow({ item, ta1 }) {
                 <TableCell className="noBorderCell tableCellCommand">
                     <Typography><strong>Command:</strong> {item.command}</Typography>
                     <Typography>Parameters: {!(Object.keys(item.parameters).length > 0) ? "None" : ""}</Typography>  
-                    {renderNestedItems(item.parameters, item.command == 'Take Action' && ta1 == 'Adept' ? item.response : null)}
+                    {renderNestedItems(item.parameters, item.command == 'Take Action' ? item.response : null)}
                 </TableCell>
             </TableRow>
             <TableRow>


### PR DESCRIPTION
http://localhost:3000/results

This page now contains a "current count" parenthetical next to treatments. The number next to "current count" should be the total number of treatments applied up to and including the action (it should match treatments_applied).

I clicked through many of the evals/scenarios/targets to make sure there weren't any undefined errors, but please do the same and make sure the counts show for all treatments across ADEPT and ST. 