### PR TITLE
Adm probe responses download all fix

### DIFF
--- a/dashboard-ui/src/components/AdmCharts/admProbeResponses.jsx
+++ b/dashboard-ui/src/components/AdmCharts/admProbeResponses.jsx
@@ -173,6 +173,7 @@ export const ADMProbeResponses = (props) => {
             });
 
             setQueryData(newQueryData);
+            setAllTableData({});
         }
     }, [admData, currentScenario, currentEval, alignmentTargets]);
 
@@ -181,6 +182,7 @@ export const ADMProbeResponses = (props) => {
         setQueryString("history.parameters.adm_name");
         setQueryData({});
         setAlignmentTargets([]);
+        setAllTableData({});
     }, [currentEval]);
 
     const getChoiceForProbe = (history, probeId) => {


### PR DESCRIPTION
The download all button on http://localhost:3000/adm-probe-responses was not accurately reflecting the data in the individual tables (instead it was duplicating data and overwriting what should actually be there). The individual table downloads were already working. To test, download all and compare the excel sheet to what is shown in the UI. 