### PR TITLE
add dre data to 134 for jan eval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ docker_setup/ServerCertificate.crt
 docker_setup/darpaitm.key
 .DS_Store
 node_modules
+package-lock.json

--- a/dashboard-ui/src/components/Research/tables/rq134.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq134.jsx
@@ -88,7 +88,7 @@ export function RQ134({ evalNum, tableTitle }) {
     const [columnsToHide, setColumnsToHide] = React.useState([]);
     // searching rows
     const [searchPid, setSearchPid] = React.useState('');
-    const HEADERS = evalNum == 5 ? HEADERS_PH1 : HEADERS_DRE;
+    const HEADERS = evalNum == 5 || evalNum == 6 ? HEADERS_PH1 : HEADERS_DRE;
 
 
     const openModal = () => {

--- a/dashboard-ui/src/components/Research/tables/rq6.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq6.jsx
@@ -9,6 +9,7 @@ import gql from "graphql-tag";
 import { getAlignments } from "../utils";
 import { DownloadButtons } from "./download-buttons";
 import { Checkbox, FormControlLabel } from "@material-ui/core";
+import { isDefined } from "../../AggregateResults/DataFunctions";
 
 
 const GET_PARTICIPANT_LOG = gql`
@@ -134,8 +135,10 @@ export function RQ6({ evalNum }) {
                     }
                 }
             }
+            // remove empty rows
+            const nonEmpty = allObjs.filter((x) => isDefined(x['Alignment score (Participant_Text|Participant_Sim)']));
             // sort
-            allObjs.sort((a, b) => {
+            nonEmpty.sort((a, b) => {
                 // Compare PID
                 if (Number(a['Participant_ID']) < Number(b['Participant_ID'])) return -1;
                 if (Number(a['Participant_ID']) > Number(b['Participant_ID'])) return 1;
@@ -147,8 +150,8 @@ export function RQ6({ evalNum }) {
                 // if TA1 is equal, compare attribute
                 return a.Attribute - b.Attribute;
             });
-            setFormattedData(allObjs);
-            setFilteredData(allObjs);
+            setFormattedData(nonEmpty);
+            setFilteredData(nonEmpty);
             setTA1s(Array.from(new Set(allTA1s)));
             setAttributes(Array.from(new Set(allAttributes)));
             setScenarios(Array.from(new Set(allScenarios)));

--- a/dashboard-ui/src/components/Research/utils.js
+++ b/dashboard-ui/src/components/Research/utils.js
@@ -287,7 +287,7 @@ export function getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dat
                 const alignment = foundADM?.history[foundADM.history.length - 1]?.response?.score ?? '-';
 
                 entryObj['Alignment score (ADM|target)'] = alignment;
-                if (evalNum == 5)
+                if (evalNum == 5 || evalNum == 6)
                     entryObj['DRE Alignment score (ADM|target)'] = entry['TA1'] == 'Adept' ? page.dreAdmAlignment : alignment;
 
                 // if DRE data is included in PH1 set, update DRE columns accordingly


### PR DESCRIPTION
Run the ingest PR (https://github.com/NextCenturyCorporation/itm-ingest/pull/108).

Look at RQ 1/3/4 to make sure the DRE columns populate for Jan eval (using both the toggle and the dropdown)

This also removes rows with an empty last column from RQ6