### PR TITLE
Delegator_mil column Jan Eval Updated

### DIFF
--- a/dashboard-ui/src/components/Research/tables/rq134.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq134.jsx
@@ -110,6 +110,14 @@ export function RQ134({ evalNum, tableTitle }) {
             dataADMs?.getAllHistoryByEvalNumber && comparisonData?.getHumanToADMComparison && dataSim?.getAllSimAlignmentByEval &&
             dreAdms?.getAllHistoryByEvalNumber && dreSim?.getAllSimAlignmentByEval && janSim?.getAllSimAlignmentByEval) {
             const data = getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dataTextResults, dataADMs, comparisonData, dataSim);
+            
+            if (evalNum === 6) {
+                data.allObjs = data.allObjs.map(obj => ({
+                    ...obj,
+                    Delegator_mil: 'yes'
+                }));
+            }
+
             if (includeDRE) {
                 // for ph1, offer option to include dre data, but ONLY THE 25 FULL SETS!
                 const dreData = getRQ134Data(4, dataSurveyResults, dataParticipantLog, dataTextResults, dreAdms, comparisonData, dreSim, true);
@@ -122,6 +130,10 @@ export function RQ134({ evalNum, tableTitle }) {
             }
             if (includeJAN) {
                 const janData = getRQ134Data(6, dataSurveyResults, dataParticipantLog, dataTextResults, dataADMs, comparisonData, janSim);
+                janData.allObjs = janData.allObjs.map(obj => ({
+                    ...obj,
+                    Delegator_mil: 'yes'
+                }));
                 data.allObjs.push(...janData.allObjs);
                 data.allTA1s.push(...janData.allTA1s);
                 data.allTA2s.push(...janData.allTA2s);

--- a/dashboard-ui/src/components/Research/utils.js
+++ b/dashboard-ui/src/components/Research/utils.js
@@ -257,7 +257,7 @@ export function getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dat
                 const entryObj = {};
                 entryObj['Delegator_ID'] = pid;
                 entryObj['ADM Order'] = wrong_del_materials.includes(pid) ? 1 : logData['ADMOrder'];
-                entryObj['Datasource'] = evalNum == 4 ? 'DRE' : logData.Type == 'Online' ? 'P1E_online' : 'P1E_IRL';
+                entryObj['Datasource'] = evalNum == 4 ? 'DRE' : evalNum == 5 ? (logData.Type == 'Online' ? 'P1E_online' : 'P1E_IRL') : (logData.Type == 'Online' ? 'P1E_online_2025' : 'P1E_IRL_2025');
                 entryObj['Delegator_grp'] = logData['Type'] == 'Civ' ? 'Civilian' : logData['Type'] == 'Mil' ? 'Military' : logData['Type'];
                 const roles = res.results?.['Post-Scenario Measures']?.questions?.['What is your current role (choose all that apply):']?.['response'];
                 // override 102, who is military


### PR DESCRIPTION
"We need to create an override in the UI (the RQ Tables), that says if a column is describing the answer to Military or Civilian and the data is coming from Eval 6, then we override their answer to always be Military.  We do not want to change the database.  We want to persist this into the download features as well."

No changes to database. The `Delegator_Mil` column in the research tables should be `yes` for all Jan 6 Eval participants. This includes when phase 1 eval is selected but `Include Jan 2025 Eval Data` is checked. Also download the data to make sure this change persists there.