### PR TITLE
fixed adm labels on results pages

### DIFF
--- a/dashboard-ui/src/components/AdmCharts/admCharts.jsx
+++ b/dashboard-ui/src/components/AdmCharts/admCharts.jsx
@@ -31,13 +31,13 @@ class AdmCharts extends React.Component {
     }
 
     getHeaderLabel(id, name) {
-        if(this.state.currentEval < 3) {
+        if (this.state.currentEval.value < 3) {
             if(id.toLowerCase().indexOf("adept") > -1 ) {
                 return ("BBN: " + id + " " + name);
             } else {
                 return ("Soartech: " + id + " " + name);
             }
-        } else if (this.state.currentEval == 3) {
+        } else if (this.state.currentEval.value == 3) {
             if(id.toLowerCase().indexOf("metricseval") > -1 ) {
                 return ("ADEPT: " + id + " " + name);
             } else {

--- a/dashboard-ui/src/components/Results/resultsTable.jsx
+++ b/dashboard-ui/src/components/Results/resultsTable.jsx
@@ -129,7 +129,7 @@ class ResultsTable extends React.Component {
             } else {
                 return ("Soartech: " + id);
             }
-        } else if (this.state.currentEval == 3) {
+        } else if (this.state.evalNumber == 3) {
             if (id.toLowerCase().indexOf("metricseval") > -1) {
                 return ("ADEPT: " + id);
             } else {


### PR DESCRIPTION
On /adm-results and /results, all scenarios had been labelled with ADEPT for evals prior to DRE. Now the labels are correct.

