### PR TITLE
Remove empty chart from /results

### DIFF
--- a/dashboard-ui/src/components/Results/resultsTable.jsx
+++ b/dashboard-ui/src/components/Results/resultsTable.jsx
@@ -351,7 +351,7 @@ class ResultsTable extends React.Component {
                                 {this.state.evalNumber >= 4 ?
                                     <RQ2223 evalNum={this.state.evalNumber} /> :
                                     <div className="graph-section">
-                                        <h2>Please select a{this.state.scenario == "" ? " scenario" : this.state.adm == "" ? "n adm" : "n alignment target"} to view results</h2>
+                                        <h2>Please select a{this.state.scenario == "" ? " scenario" : this.state.adm == "" ? "n ADM" : "n alignment target"} to view results</h2>
                                     </div>}
                             </>
                         }

--- a/dashboard-ui/src/components/Results/resultsTable.jsx
+++ b/dashboard-ui/src/components/Results/resultsTable.jsx
@@ -348,7 +348,11 @@ class ResultsTable extends React.Component {
                                 }
                             </Query> :
                             <>
-                                <RQ2223 evalNum={this.state.evalNumber} />
+                                {this.state.evalNumber >= 4 ?
+                                    <RQ2223 evalNum={this.state.evalNumber} /> :
+                                    <div className="graph-section">
+                                        <h2>Please select a{this.state.scenario == "" ? " scenario" : this.state.adm == "" ? "n adm" : "n alignment target"} to view results</h2>
+                                    </div>}
                             </>
                         }
                     </div>


### PR DESCRIPTION
In pre-DRE evals, the RQ2 table was showing up empty on the /results page. Those empty tables are now replaced with simple text about what the user needs to do in order to begin seeing results.