### PR TITLE
Survey Results Endpoint Security Update

### DIFF
--- a/dashboard-ui/src/components/SurveyResults/surveyResults.jsx
+++ b/dashboard-ui/src/components/SurveyResults/surveyResults.jsx
@@ -40,6 +40,7 @@ const VIZ_PANEL_OPTIONS = {
 
 export function SurveyResults() {
     const { loading, error, data } = useQuery(GET_SURVEY_RESULTS, { fetchPolicy: 'network-only' });
+    console.log(data)
     const { data: dataParticipantLog } = useQuery(GET_PARTICIPANT_LOG);
     const [scenarioIndices, setScenarioIndices] = React.useState(null);
     const [selectedScenario, setSelectedScenario] = React.useState("");

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -455,14 +455,14 @@ const resolvers = {
     },
     getAllSurveyResults: async (obj, args, context, inflow) => {
       // return all survey results except for those containing "test" in participant ID
-
+      
       const excludeTestID = {
         "results.Participant ID.questions.Participant ID.response": { $not: /test/i },
         "results.Participant ID Page.questions.Participant ID.response": { $not: /test/i },
         "Participant ID.questions.Participant ID.response": { $not: /test/i },
         "Participant ID Page.questions.Participant ID.response": { $not: /test/i }
       };
-
+      
       // Filter based on surveyVersion and participant ID starting with "2024" (only for version 2)
       const surveyVersionFilter = {
         $or: [
@@ -475,20 +475,25 @@ const resolvers = {
           }
         ]
       };
+    
       return await context.db.collection('surveyResults').find({
         $and: [excludeTestID, surveyVersionFilter]
+      }).project({
+        // dont return user field
+        "results.user": 0,
+        "user": 0
       }).toArray().then(result => { return result; });
     },
     getAllSurveyResultsByEval: async (obj, args, context, inflow) => {
       // return all survey results except for those containing "test" in participant ID
-
+      
       const excludeTestID = {
         "results.Participant ID.questions.Participant ID.response": { $not: /test/i },
         "results.Participant ID Page.questions.Participant ID.response": { $not: /test/i },
         "Participant ID.questions.Participant ID.response": { $not: /test/i },
         "Participant ID Page.questions.Participant ID.response": { $not: /test/i }
       };
-
+      
       // Filter based on surveyVersion and participant ID starting with "2024" (only for version 2)
       const surveyVersionFilter = {
         $or: [
@@ -501,11 +506,15 @@ const resolvers = {
           }
         ]
       };
+      
       return await context.db.collection('surveyResults').find({
         $and: [excludeTestID, surveyVersionFilter, {
           $or: [{ "evalNumber": args["evalNumber"] }, { "results.evalNumber": args["evalNumber"] }]
         }]
-
+      }).project({
+        // dont return user field
+        "results.user": 0,
+        "user": 0
       }).toArray().then(result => { return result; });
     },
     getAllScenarioResults: async (obj, args, context, inflow) => {


### PR DESCRIPTION
A `user` field was attached to the survey results documents (not always) that contained username and email information. I changed the endpoints that pull the survey results to omit this field. I added a console log to http://localhost:3000/survey-results that shows the data we are pulling to the front end. Glance through it real quick to make sure you don't see a `user` field in any of that data. I will delete this console log before merging. You will need to rebuild gql container. 