### PR TITLE
Itm 929

### DIFF
--- a/dashboard-ui/src/components/Research/tables/rq23_ph2.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq23_ph2.jsx
@@ -17,7 +17,7 @@ const getAnalysisData = gql`
 const HEADERS = ['ADM Name', 'ADM Type', 'PID', 'Human Scenario', 'Target Type', 'MJ Alignment Target', 'IO Alignment Target', 'MJ KDMA - MJ2', 'MJ KDMA - MJ4', 'MJ KDMA - MJ5', 'MJ KDMA - AVE', 'IO KDMA - MJ2', 'IO KDMA - MJ4', 'IO KDMA - MJ5', 'IO KDMA - AVE', 'Alignment (Target|ADM_MJ2)', 'Alignment (Target|ADM_MJ4)', 'Alignment (Target|ADM_MJ5)', 'Alignment Average (Target|ADM)'];
 
 const BASELINE_ADMS = [];
-const ALIGNED_ADMS = ['ALIGN-ADM-RelevanceComparativeRegression-ADEPT__4e570b6d-8f9e-4e3c-8d0f-ffcde73a5792', 'ALIGN-ADM-ComparativeRegression-ADEPT__b3da51ed-57ff-429b-8ae8-6ff9dc44b65d', 'ALIGN-ADM-RelevanceComparativeRegression-ADEPT__785ccc32-bf56-4bfc-a034-b64a3222102b'];
+const ALIGNED_ADMS = ['ALIGN-ADM-ComparativeRegression-ADEPT', 'ALIGN-ADM-RelevanceComparativeRegression-ADEPT'];
 
 export function Phase2_RQ23() {
     const { loading: loading, error: error, data: data } = useQuery(getAnalysisData);

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -332,7 +332,7 @@ const resolvers = {
       }
       
       return await context.db.collection('admTargetRuns')
-        .distinct(args["admQueryStr"], query)
+        .distinct("adm_name", query)
         .then(result => { return result });
     },
     getAlignmentTargetsPerScenario: async (obj, args, context, inflow) => {
@@ -346,7 +346,7 @@ const resolvers = {
       }
       
       let alignmentTargets = await context.db.collection('admTargetRuns')
-        .distinct("history.response.id", query)
+        .distinct("alignment_target", query)
         .then(result => { return result });
       
       // The scenarioID still comes back in this distinct because of the way the JSON is configured, remove it before sending the array
@@ -375,8 +375,8 @@ const resolvers = {
       } else {
         queryObj = {
           $and: [
-            { "history.response.id": args["alignmentTarget"] },
-            { "history.response.id": args["scenarioID"] }
+            { "alignment_target": args["alignmentTarget"] },
+            { "scenario": args["scenarioID"] }
           ]
         };
 
@@ -384,7 +384,7 @@ const resolvers = {
           queryObj.$and.push({ "evalNumber": args["evalNumber"] });
         }
 
-        queryObj[args["admQueryStr"]] = args["admName"];
+        queryObj["adm_name"] = args["admName"];
       }
 
       return await context.db.collection('admTargetRuns').findOne(queryObj).then(result => { return result });


### PR DESCRIPTION
Run [ingest](https://github.com/NextCenturyCorporation/itm-ingest/pull/122) first. Rebuild the gql container. 

Small update to rq2.3 table to account for the change in adm names. I updated a few gql queries to use the top level data instead of digging through the history array of the documents. 

Make sure these pages still work as expected:
http://localhost:3000/adm-probe-responses
http://localhost:3000/results
http://localhost:3000/research-results/rq2 (phase 2)