### PR TITLE
Fixed broken tests

### DIFF
--- a/dashboard-ui/src/__mocks__/mockDbSchema.js
+++ b/dashboard-ui/src/__mocks__/mockDbSchema.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { ObjectId } = require('mongodb');
 
 function createSchema(collectionName, schema) {
     const namedSchema = new mongoose.Schema(
@@ -97,7 +98,12 @@ const TextBasedConfig = createSchema('textBasedConfig', {
     eval: { type: String, required: true }
 });
 
+const SessionConfig = createSchema("sessions", {
+    _id: { type: ObjectId, required: true },
+    userId: { type: String, required: true },
+    token: { type: String, required: true },
+    valid: { type: Boolean, required: true },
+});
 
 
-
-export { SurveyConfig, SurveyResults, SurveyVersion, UiStyle, ParticipantLog, AdmLog, UserScenarioResults, User, TextBasedConfig };
+export { SurveyConfig, SurveyResults, SurveyVersion, UiStyle, ParticipantLog, AdmLog, UserScenarioResults, User, TextBasedConfig, SessionConfig };

--- a/dashboard-ui/src/__mocks__/testUtils.js
+++ b/dashboard-ui/src/__mocks__/testUtils.js
@@ -81,7 +81,9 @@ export async function logout(page) {
 export async function testRouteRedirection(route, expectedRedirect = '/login') {
     let currentUrl = page.url();
     await page.goto(`${process.env.REACT_APP_TEST_URL}${route}`);
-    await page.waitForSelector(FOOTER_TEXT);
+    if (route == '/text-based')
+        await page.waitForNavigation();
+    await page.waitForSelector(FOOTER_TEXT, { timeout: 6000 });
     currentUrl = page.url();
     expect(currentUrl).toBe(`${process.env.REACT_APP_TEST_URL}${expectedRedirect}`);
 }

--- a/dashboard-ui/src/__tests__/RouteContent.test.jsx
+++ b/dashboard-ui/src/__tests__/RouteContent.test.jsx
@@ -2,12 +2,16 @@
  * @jest-environment puppeteer
  */
 
-import { checkRouteContent, loginAdmin, FOOTER_TEXT } from "../__mocks__/testUtils";
+import { checkRouteContent, loginAdmin, createAccount, FOOTER_TEXT } from "../__mocks__/testUtils";
 
 
 describe('Verify content on page matches expectation for route', () => {
     // log in as admin
     beforeAll(async () => {
+        await page.goto(`${process.env.REACT_APP_TEST_URL}/login`);
+        // wait for the page to stop loading
+        await page.waitForSelector('#password');
+        await createAccount(page, 'admin', 'admin@123.com', 'secretAdminPassword123');
         await loginAdmin(page);
     }, 30000);
 
@@ -50,7 +54,8 @@ describe('Verify content on page matches expectation for route', () => {
     });
 
     it('Check /results route content', async () => {
-        await checkRouteContent(page, '/results', ['Evaluation', 'Scenario', 'Trial_ID', 'Target Type']);
+        // based off ph2 RQ2 table
+        await checkRouteContent(page, '/results', ['Evaluation', 'Scenario', 'ADM Name', 'Target Type']);
     });
     it('Check /adm-results route content', async () => {
         // TODO: find how to check this a little better (more unique)

--- a/dashboard-ui/src/setupTests.js
+++ b/dashboard-ui/src/setupTests.js
@@ -6,7 +6,7 @@ import { ApolloServer } from 'apollo-server';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { mergeTypeDefs, mergeResolvers } from '@graphql-tools/merge';
 import { typeDefs, resolvers } from '../../node-graphql/server.schema.js';
-import { ParticipantLog, SurveyConfig, SurveyResults, SurveyVersion, TextBasedConfig, UiStyle, UserScenarioResults } from './__mocks__/mockDbSchema.js';
+import { ParticipantLog, SessionConfig, SurveyConfig, SurveyResults, SurveyVersion, TextBasedConfig, UiStyle, UserScenarioResults } from './__mocks__/mockDbSchema.js';
 import { surveyResultMock, surveyV5, textConfigMocks, userScenarioResultMock } from './__mocks__/mockData.js';
 
 global.fetch = unfetch;
@@ -67,6 +67,15 @@ beforeAll(async () => {
         const surveyConfig5 = new SurveyConfig(surveyV5);
         await surveyConfig4.save();
         await surveyConfig5.save();
+        const { ObjectId } = require('mongodb');
+
+        const sessionConfig = new SessionConfig({
+            _id: new ObjectId("67991d239acd0b5980ffbf69"),
+            userId: "67991d239acd0b1b94ffbf64",
+            token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MzgwODc3MTUsImV4cCI6MTczODY5MjUxNX0.CNOtRGTcSSSOxMkEGKS5gRUosdzm2XjHdmBEnrcMwAM",
+            valid: true
+        });
+        await sessionConfig.save();
 
         const participantLog = new ParticipantLog({
             "Type": "Mil",
@@ -204,7 +213,7 @@ beforeAll(async () => {
                                         return null;
                                     }
                                     const { User } = require('./__mocks__/mockDbSchema.js');
-                                    const newUser = new User({
+                                    const userData = {
                                         username: user.username,
                                         emails: [{ address: user.email, verified: false }],
                                         admin: foundUser.admin,
@@ -213,7 +222,12 @@ beforeAll(async () => {
                                         adeptUser: foundUser.adeptUser,
                                         approved: foundUser.approved,
                                         rejected: foundUser.rejected
-                                    });
+                                    };
+                                    const { ObjectId } = require('mongodb');
+                                    if (user.username == 'admin')
+                                        userData['_id'] = new ObjectId("67991d239acd0b1b94ffbf64");
+
+                                    const newUser = new User(userData);
 
                                     await newUser.save();
 


### PR DESCRIPTION
4 tests were failing - 2 consistently and 2 others inconsistently.

The consistently failing tests were the result of updated code:
1. /results route content check was looking for Trial_ID in the RQ2.3 table, but we updated this table to use the Phase 2 RQ2.3 table for Phase 2 data, and that does not have Trial_ID. I updated the content it was searching for to match reality
2. The administrator page route content check was also failing because of the new permissions in graphql required to access user information. This fix required mocking the sessions database and creating the admin account at the beginning of the test file to make sure it existed in the user database. This allows all the checks in getUsers to pass so we can see the full admin page.
3. The 2 failing inconsistently had to do with an expected redirect from text-based. The error said "cannot find context id". A quick google search said "The "Cannot find context with specified id" error in Jest and Puppeteer typically arises from issues with execution contexts becoming invalid or detached during the test execution. This often occurs when the page navigates, reloads, or when frames are involved." and recommended using waitForNavigation. This fixed the problem!

To test, run the tests a few times and make sure they are consistently passing. They are on my end!