### PR TITLE
removed extra columns from text based results tables

### DIFF
--- a/dashboard-ui/src/components/TextBasedResults/TextBasedResultsPage.jsx
+++ b/dashboard-ui/src/components/TextBasedResults/TextBasedResultsPage.jsx
@@ -30,6 +30,8 @@ const GET_PARTICIPANT_LOG = gql`
         getParticipantLog
     }`;
 
+const KEYS_WITHOUT_TIME = ['kdmas', 'group_targets', 'lowAlignmentData', 'highAlignmentData'];
+
 function shortenAnswer(answer) {
     // shortens an answer so the whole thing is visible and understandable without taking up too much screen real estate
     switch (answer) {
@@ -247,7 +249,7 @@ function ParticipantView({ data, scenarioName, textBasedConfigs }) {
                             formatted[page['_id']]['Alignment Data'] = 'Download file to view alignment data';
                             obj['Alignment Data'] = temp;
                         }
-                    } else if (key !== 'lowAlignmentData' && key !== 'highAlignmentData') {
+                    } else if (!KEYS_WITHOUT_TIME.includes(key)) {
                         // top level pages with timing
                         const time_key = key + ' time (s)';
                         if (typeof (page[key]) === 'object' && !Array.isArray(page[key])) {


### PR DESCRIPTION
http://localhost:3000/text-based-results

In the participant table tab, ST scenarios had two extra columns:
![image](https://github.com/user-attachments/assets/0ace8d7d-a913-44e7-a5ee-8f861d2b8216)
This ticket removes them.