### PR TITLE
fix eval filters on delegation results page

### DIFF
--- a/dashboard-ui/src/components/Research/tables/BlockedTable.jsx
+++ b/dashboard-ui/src/components/Research/tables/BlockedTable.jsx
@@ -47,7 +47,13 @@ export function BlockedTable({ evalNum }) {
         }
         else {
             const newEvalNumbers = structuredClone(evalNumbers);
-            const index = newEvalNumbers.indexOf(evalObj);
+            let index = -1;
+            for (let i = 0; i < newEvalNumbers.length; i++) {
+                if (newEvalNumbers[i]['value'] == evalObj["value"]) {
+                    index = i;
+                    break;
+                }
+            }
             if (index > -1) {
                 newEvalNumbers.splice(index, 1);
             }

--- a/dashboard-ui/src/components/SurveyResults/resultsTable.jsx
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.jsx
@@ -108,7 +108,8 @@ export function ResultsTable({ data, pLog, exploratory = false, comparisonData =
     }, [data, pLog, showLegacy]);
 
     React.useEffect(() => {
-        setEvalFilters(evalNumbers);
+        if (exploratory)
+            setEvalFilters(evalNumbers);
     }, [evalNumbers]);
 
     const searchForDreComparison = (comparisonEntry, pid, admType, scenario) => {


### PR DESCRIPTION
The delegation results page's eval filters were broken - no matter what you chose, it would force you to keep just eval 5 selected. This was due to the difference between how the exploratory analysis page changes eval filters and how the delegation page changes filters. I updated it so only the exploratory version changes filters through props.

While testing, I found that the exploratory version was not deselecting evals as it should (i.e. check the DRE box, then uncheck, and the DRE results stay). I fixed this as well. Please check both tables (delegation results, and the same table on the exploratory analysis page) and ensure the filters work properly now.