### PR TITLE
ADM Probe Responses Table

### DIFF
--- a/dashboard-ui/src/components/AdmCharts/admProbeResponses.jsx
+++ b/dashboard-ui/src/components/AdmCharts/admProbeResponses.jsx
@@ -195,10 +195,24 @@ export const ADMProbeResponses = (props) => {
     }, [currentEval]);
 
     const getChoiceForProbe = (history, probeId) => {
-        const probeResponse = history
+        const probeResponses = history
             .filter(entry => entry.command === 'Respond to TA1 Probe')
-            .find(entry => entry.parameters?.probe_id === probeId);
-        return probeResponse?.parameters?.choice || '-';
+            .filter(entry => entry.parameters?.probe_id === probeId);
+        
+        // no response found
+        if (probeResponses.length === 0) {
+            return '-';
+        }
+        
+        // more than response, include all of them
+        if (probeResponses.length > 1) {
+            return probeResponses
+                .map(response => response.parameters?.choice || '-')
+                .join(', ');
+        }
+        
+        // normal case, one response
+        return probeResponses[0].parameters?.choice || '-';
     };
 
     const getKdma = (history, attribute) => {


### PR DESCRIPTION
[Ticket](https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?jql=assignee%20%3D%2060ba425da547eb00686ee0ce&selectedIssue=ITM-976)

http://localhost:3000/adm-probe-responses

Look at MJ5 under Phase 1 and make sure that you can see multiple probe responses for Probe 3. Not every ADM sends more than one response, but most do (cross-reference with the `admTargetRuns` collection in Mongo Compass)