### PR TITLE
Delegation Materials and New Text-based

### DIFF
--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -145,20 +145,24 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
     }, [dataParticipantLog, dataSim, dataSurveyResults, dataTextResults]);
 
     const formatCell = (header, dataSet) => {
-        const val = dataSet[header];
-        const getClassName = (header, val) => {
-            if (SCENARIO_HEADERS.includes(header) && isDefined(val)) {
-                return 'li-green-cell';
-            }
-            if ((header == 'Delegation' && val == 1) || (header == 'Text' && val == 5) || (header == 'Sim Count' && val == 4)) {
-                return 'dk-green-cell';
-            }
-            return 'white-cell';
-        };
-        return (<td key={dataSet['Participant_ID'] + '-' + header} className={getClassName(header, val) + ' ' + (header.length < 5 ? 'small-column' : '') + ' ' + (header.length > 17 ? 'large-column' : '')}>
-            {header == 'Survey Link' && val ? <button onClick={() => copyLink(val)} className='downloadBtn'>Copy Link</button> : <span>{val ?? '-'}</span>}
-        </td>);
+    const val = dataSet[header];
+    const getClassName = (header, val) => {
+        if (SCENARIO_HEADERS.includes(header) && isDefined(val)) {
+            return 'li-green-cell';
+        }
+        // phase dependent
+        const textThreshold = selectedPhase === 'Phase 2' ? 4 : 5;
+        if ((header == 'Delegation' && val == 1) || 
+            (header == 'Text' && val >= textThreshold) || 
+            (header == 'Sim Count' && val == 4)) {
+            return 'dk-green-cell';
+        }
+        return 'white-cell';
     };
+    return (<td key={dataSet['Participant_ID'] + '-' + header} className={getClassName(header, val) + ' ' + (header.length < 5 ? 'small-column' : '') + ' ' + (header.length > 17 ? 'large-column' : '')}>
+        {header == 'Survey Link' && val ? <button onClick={() => copyLink(val)} className='downloadBtn'>Copy Link</button> : <span>{val ?? '-'}</span>}
+    </td>);
+};
 
     const copyLink = (linkToCopy) => {
         navigator.clipboard.writeText(linkToCopy);

--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -128,6 +128,13 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
                 obj['Evaluation'] = obj['Evaluation'] ?? lastScenario?.evalName;
                 const completedScenarios = scenarios.map((x) => x.scenario_id);
 
+                if (!obj['Evaluation']) {
+                    // Fall back if no sim, del, or text based scenarios
+                    if (pid.startsWith('202506')) {
+                        obj['Evaluation'] = 'June 2025 Collaboration';
+                    }
+                }
+
                 // set scenario completions using utility function
                 setScenarioCompletion(obj, completedScenarios);
 

--- a/dashboard-ui/src/components/App/Header.jsx
+++ b/dashboard-ui/src/components/App/Header.jsx
@@ -16,7 +16,7 @@ export function Header({ currentUser, logout }) {
             </li>
             {(isUserElevated(currentUser) &&
                 <NavDropdown title="Data Collection">
-                    <NavDropdown.Item as={Link} className="dropdown-item" to="/survey">
+                    <NavDropdown.Item as={"span"} style={{ cursor: 'not-allowed', opacity: 0.6 }} className="dropdown-item text-muted" /*to="/survey"*/>
                         Take Delegation Survey
                     </NavDropdown.Item>
                     {(currentUser.admin === true || currentUser.evaluator) && (

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -82,6 +82,13 @@ const GET_CONFIGS_DEL_MEDIA = gql`
         getAllImageUrls
     }`;
 
+const GET_CONFIGS_PHASE_2 = gql`
+    query GetConfigsNoImages {
+        getAllSurveyConfigs
+        getAllTextBasedConfigs
+    }
+`
+
 
 const LOW_PID = 202506100;
 const HIGH_PID = 202506299;
@@ -110,7 +117,9 @@ export function App() {
             setSurveyVersion(versionData.getCurrentSurveyVersion);
             setIsVersionDataLoaded(true);
             if (parseFloat(versionData.getCurrentSurveyVersion) <= 3.0) {
-                setConfigQuery(GET_CONFIGS_DEL_MEDIA);
+                // temporary for testing, set back
+                setConfigQuery(GET_CONFIGS_PHASE_2)
+                //setConfigQuery(GET_CONFIGS_DEL_MEDIA);
             } else {
                 setConfigQuery(GET_CONFIGS);
             }

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -117,10 +117,12 @@ export function App() {
             setSurveyVersion(versionData.getCurrentSurveyVersion);
             setIsVersionDataLoaded(true);
             if (parseFloat(versionData.getCurrentSurveyVersion) <= 3.0) {
-                // temporary for testing, set back
+                setConfigQuery(GET_CONFIGS_DEL_MEDIA);
+            } else if (parseFloat(versionData.getCurrentSurveyVersion) >= 6.0) {
+                console.log("correct configs query")
                 setConfigQuery(GET_CONFIGS_PHASE_2)
-                //setConfigQuery(GET_CONFIGS_DEL_MEDIA);
-            } else {
+            }
+            else {
                 setConfigQuery(GET_CONFIGS);
             }
             setSendConfigQuery(true);

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -233,6 +233,8 @@ export function App() {
                 x.ParticipantID >= LOW_PID && x.ParticipantID <= HIGH_PID
             ).map((x) => Number(x['ParticipantID'])), LOW_PID - 1) + 1;
 
+            const scenarioSet = Math.floor(Math.random() * 3) + 1;
+
             const participantData = {
                 "ParticipantID": newPid,
                 "Type": isTester ? "Test" : "emailParticipant",
@@ -242,10 +244,10 @@ export function App() {
                 "textEntryCount": 0,
                 "hashedEmail": hashedEmail,
                 
-                "AF-text-scenario": Math.floor(Math.random() * 3) + 1,
-                "MF-text-scenario": Math.floor(Math.random() * 3) + 1,
-                "PS-text-scenario": Math.floor(Math.random() * 3) + 1,
-                "SS-text-scenario": Math.floor(Math.random() * 3) + 1
+                "AF-text-scenario": scenarioSet,
+                "MF-text-scenario": scenarioSet,
+                "PS-text-scenario": scenarioSet,
+                "SS-text-scenario": scenarioSet
             };
 
             const addRes = await addParticipant({

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -119,7 +119,6 @@ export function App() {
             if (parseFloat(versionData.getCurrentSurveyVersion) <= 3.0) {
                 setConfigQuery(GET_CONFIGS_DEL_MEDIA);
             } else if (parseFloat(versionData.getCurrentSurveyVersion) >= 6.0) {
-                console.log("correct configs query")
                 setConfigQuery(GET_CONFIGS_PHASE_2)
             }
             else {

--- a/dashboard-ui/src/components/Survey/comparisonPhase2.jsx
+++ b/dashboard-ui/src/components/Survey/comparisonPhase2.jsx
@@ -78,7 +78,8 @@ export class ComparisonPhase2 extends SurveyQuestionElementBase {
                             rows: element.rows,
                             scenarioDescription: element.scenarioDescription,
                             supplies: element.supplies,
-                            dmName: element.dmName
+                            dmName: element.dmName,
+                            options: element.options
                         };
                     }
                 }
@@ -162,6 +163,7 @@ export class ComparisonPhase2 extends SurveyQuestionElementBase {
                                 </h3>
                                 <DynamicPhase2 
                                     rows={dmData.rows} 
+                                    options={firstDmData.options}
                                     scenarioDescription={null} 
                                     supplies={null}
                                     showHeaderOnly={false} 

--- a/dashboard-ui/src/components/Survey/dynamicPhase2.jsx
+++ b/dashboard-ui/src/components/Survey/dynamicPhase2.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Table, Container, Row, Col } from 'react-bootstrap';
 import '../../css/dynamicPhase2.css';
 
-const DynamicPhase2 = ({ rows, scenarioDescription, supplies }) => {
+const DynamicPhase2 = ({ rows, scenarioDescription, supplies, options }) => {
     const renderSupplies = () => {
         if (!supplies || supplies.length === 0) return null;
 
@@ -45,6 +45,7 @@ const DynamicPhase2 = ({ rows, scenarioDescription, supplies }) => {
                 <thead>
                     <tr>
                         <th className="table-header table-header-number"></th>
+                        <th className='table-header table-header-description'></th>
                         <th className="table-header table-header-patient">Choice A</th>
                         <th className="table-header table-header-patient">Choice B</th>
                     </tr>
@@ -55,6 +56,7 @@ const DynamicPhase2 = ({ rows, scenarioDescription, supplies }) => {
                             <td className="row-number">
                                 {index + 1}
                             </td>
+                            <td className={`patient-cell`}>{row['probe_unstructured']}</td>
                             <td className={`patient-cell ${row['choice'] === 'Patient A' ? 'patient-cell-selected' : 'patient-cell-default'}`}>
                                 <div className="badge-container">
                                     {row['choice'] === 'Patient A' ? (
@@ -66,7 +68,7 @@ const DynamicPhase2 = ({ rows, scenarioDescription, supplies }) => {
                                     )}
                                 </div>
                                 <div className="patient-description">
-                                    {row['Patient A']}
+                                    {options[0]}
                                 </div>
                             </td>
                             <td className={`patient-cell ${row['choice'] === 'Patient B' ? 'patient-cell-selected' : 'patient-cell-default'}`}>
@@ -80,7 +82,7 @@ const DynamicPhase2 = ({ rows, scenarioDescription, supplies }) => {
                                     )}
                                 </div>
                                 <div className="patient-description">
-                                    {row['Patient B']}
+                                    {options[1]}
                                 </div>
                             </td>
                         </tr>

--- a/dashboard-ui/src/components/Survey/dynamicPhase2.jsx
+++ b/dashboard-ui/src/components/Survey/dynamicPhase2.jsx
@@ -27,13 +27,17 @@ const DynamicPhase2 = ({ rows, scenarioDescription, supplies, options }) => {
         return (
             <div className="instruction-section">
                 <h4 className="instruction-title">
-                    Consider a decision-maker who chose to treat the highlighted patients first, when given the following choices.
+                    Consider a decision-maker who made the highlighted choices. 
                 </h4>
                 <p className="instruction-subtitle">
                     {scenarioDescription}
                 </p>
             </div>
         );
+    };
+
+    const isChoiceSelected = (rowChoice, optionIndex, options) => {
+        return rowChoice === options[optionIndex];
     };
 
     return (
@@ -51,42 +55,47 @@ const DynamicPhase2 = ({ rows, scenarioDescription, supplies, options }) => {
                     </tr>
                 </thead>
                 <tbody>
-                    {rows.map((row, index) => (
-                        <tr key={index} className="border-bottom">
-                            <td className="row-number">
-                                {index + 1}
-                            </td>
-                            <td className={`patient-cell`}>{row['probe_unstructured']}</td>
-                            <td className={`patient-cell ${row['choice'] === 'Patient A' ? 'patient-cell-selected' : 'patient-cell-default'}`}>
-                                <div className="badge-container">
-                                    {row['choice'] === 'Patient A' ? (
-                                        <div className="selected-badge">
-                                            ✓ SELECTED
-                                        </div>
-                                    ) : (
-                                        <div className="badge-spacer"></div>
-                                    )}
-                                </div>
-                                <div className="patient-description">
-                                    {options[0]}
-                                </div>
-                            </td>
-                            <td className={`patient-cell ${row['choice'] === 'Patient B' ? 'patient-cell-selected' : 'patient-cell-default'}`}>
-                                <div className="badge-container">
-                                    {row['choice'] === 'Patient B' ? (
-                                        <div className="selected-badge">
-                                            ✓ SELECTED
-                                        </div>
-                                    ) : (
-                                        <div className="badge-spacer"></div>
-                                    )}
-                                </div>
-                                <div className="patient-description">
-                                    {options[1]}
-                                </div>
-                            </td>
-                        </tr>
-                    ))}
+                    {rows.map((row, index) => {
+                        const isChoiceASelected = isChoiceSelected(row['choice'], 0, options);
+                        const isChoiceBSelected = isChoiceSelected(row['choice'], 1, options);
+                        
+                        return (
+                            <tr key={index} className="border-bottom">
+                                <td className="row-number">
+                                    {index + 1}
+                                </td>
+                                <td className={`patient-cell`}>{row['probe_unstructured']}</td>
+                                <td className={`patient-cell ${isChoiceASelected ? 'patient-cell-selected' : 'patient-cell-default'}`}>
+                                    <div className="badge-container">
+                                        {isChoiceASelected ? (
+                                            <div className="selected-badge">
+                                                ✓ SELECTED
+                                            </div>
+                                        ) : (
+                                            <div className="badge-spacer"></div>
+                                        )}
+                                    </div>
+                                    <div className="patient-description">
+                                        {options[0]}
+                                    </div>
+                                </td>
+                                <td className={`patient-cell ${isChoiceBSelected ? 'patient-cell-selected' : 'patient-cell-default'}`}>
+                                    <div className="badge-container">
+                                        {isChoiceBSelected ? (
+                                            <div className="selected-badge">
+                                                ✓ SELECTED
+                                            </div>
+                                        ) : (
+                                            <div className="badge-spacer"></div>
+                                        )}
+                                    </div>
+                                    <div className="patient-description">
+                                        {options[1]}
+                                    </div>
+                                </td>
+                            </tr>
+                        );
+                    })}
                 </tbody>
             </Table>
         </Container>

--- a/dashboard-ui/src/components/Survey/dynamicTemplatePhase2.jsx
+++ b/dashboard-ui/src/components/Survey/dynamicTemplatePhase2.jsx
@@ -38,6 +38,22 @@ export class DynamicTemplatePhase2Model extends Question {
     set supplies(supplies) {
         this.setPropertyValue("supplies", supplies)
     }
+
+    get probe_question() {
+        return this.getPropertyValue("probe_question")
+    }
+
+    set probe_question(probe_question) {
+        this.setPropertyValue("probe_question", probe_question)
+    }
+
+    get options() {
+        return this.getPropertyValue("options")
+    }
+
+    set options(options) {
+        this.setPropertyValue("options", options)
+    }
 }
 
 Serializer.addClass(
@@ -54,6 +70,14 @@ Serializer.addClass(
         },
         {
             name: "supplies",
+            default: []
+        },
+        {
+            name: "probe_question",
+            default: ''
+        },
+        {
+            name: "options",
             default: []
         }
     ],
@@ -106,9 +130,23 @@ export class DynamicTemplatePhase2 extends SurveyQuestionElementBase {
         return this.question.supplies;
     }
 
+    get probe_question() {
+        return this.question.probe_question;
+    }
+
+    get options() {
+        return this.question.options
+    }
+
     renderElement() {
         return (
-            <DynamicPhase2 rows={this.rows} scenarioDescription={this.scenarioDescription} supplies={this.supplies}/>
+            <DynamicPhase2 
+                rows={this.rows} 
+                scenarioDescription={this.scenarioDescription} 
+                supplies={this.supplies}
+                probe_question={this.probe_question}
+                options={this.options}
+            />
         )
     }
 }

--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -15,11 +15,10 @@ import { useQuery, useMutation } from 'react-apollo'
 import { generateComparisonPagev4_5, getKitwareAdms, getOrderedAdeptTargets, getParallaxAdms, getUID, shuffle, survey3_0_groups, surveyVersion_x_0, orderLog13 } from './surveyUtils';
 import Bowser from "bowser";
 import { useSelector } from "react-redux";
-import { isDefined } from "../AggregateResults/DataFunctions";
 import { Spinner } from 'react-bootstrap';
 import { admOrderMapping, getDelEnvMapping, getEnvMappingToText, getKitwareBaselineMapping, getTadBaselineMapping } from "./delegationMappings";
 import { useHistory } from 'react-router-dom';
-import testConfig from "./testConfig.json"
+import { isDefined } from "../AggregateResults/DataFunctions";
 import { ComparisonPhase2 } from "./comparisonPhase2";
 
 const COUNT_HUMAN_GROUP_FIRST = gql`
@@ -124,7 +123,7 @@ class SurveyPage extends Component {
         this.surveyConfigClone = structuredClone(this.state.surveyConfig);
         this.initializeSurvey();
 
-        this.survey = new Model(testConfig.survey);
+        this.survey = new Model(this.surveyConfigClone);
         this.survey.applyTheme(surveyTheme);
 
         this.surveyData = {};
@@ -195,13 +194,13 @@ class SurveyPage extends Component {
     }
 
     initializeSurvey = () => {
-        if ((this.state.surveyVersion == 4.0 || this.state.surveyVersion == 5.0) && this.state.pid != null) {
+        if ((this.state.surveyVersion == 4.0 || this.state.surveyVersion == 5.0 || this.state.surveyVersion == 6.0) && this.state.pid != null) {
             this.setState({
                 isSurveyLoaded: false
             });
         }
         const { groupedDMs, comparisonPages, removed } = this.prepareSurveyInitialization();
-        if ((this.state.surveyVersion != 4.0 && this.state.surveyVersion != 5.0)) {
+        if ((this.state.surveyVersion != 4.0 && this.state.surveyVersion != 5.0 && this.state.surveyVersion != 6.0)) {
             if (this.state.surveyVersion == 1.3) {
                 this.assign_omnibus_1_3(groupedDMs)
             }
@@ -420,6 +419,12 @@ class SurveyPage extends Component {
             delete comparisonPages[`${removed[0]}${removed[1]}`];
 
             return { groupedDMs, removed, comparisonPages };
+        }
+        else if (this.state.surveyVerison == 6.0) {
+            const allPages = this.surveyConfigClone.pages;
+            const pages = [...allPages.slice(0, 4)];
+
+            return {}
         }
     }
 
@@ -707,7 +712,7 @@ class SurveyPage extends Component {
 
         if (this.state.surveyVersion == 6.0){
             this.surveyData['evalName'] = 'June 2025 Collaboration'
-            this.surveyData['evalNumber'] = 9
+            this.surveyData['evalNumber'] = 8
             this.surveyData['pid'] = this.state.pid;
             this.surveyData['orderLog'] = this.state.orderLog;
         }

--- a/dashboard-ui/src/components/Survey/testConfig.json
+++ b/dashboard-ui/src/components/Survey/testConfig.json
@@ -44,8 +44,8 @@
                         "title": "Phase 2 Mockup",
                         "dmName": "Test medic 1",
                         "probe_question": "Who do you treat first?",
-                        "options": ["Treat Patient A", "Treat Patient B"],
-                        "scenarioDescription": "Imagine that you are deployed as a military medic in a foreign country. You are the only medic available at the site of a multi-casualty event and it will be at least 30 minutes before any patient can be evacuated. Who do you treat first?",
+                        "options": ["Move to treat the casualty now", "Wait in your current location"],
+                        "scenarioDescription": "Imagine that you are deployed as a military medic in a foreign country. You are the only medic with your unit. It will be at least 30 minutes before any casualty can be evacuated.",
                         "supplies": [
                             {
                                 "type": "Hemostatic gauze",
@@ -100,24 +100,24 @@
                         ],
                         "rows": [
                             {
-                                "choice": "Patient B",
-                                "probe_unstructured": "Patient A has massive bleeding from a partial amputation of their left foot. They are a US warfighter from a different branch of the military than you. Patient B has a dislocated left knee with no bleeding. They are a warfighter in the same military unit as you."
+                                "choice": "Move to treat the casualty now",
+                                "probe_unstructured": "Your squad is patrolling dismounted when it receives fire from a sniper and sustains one casualty. Your unit does not have a good idea of the suspected sniper location. You have not received any additional fire in the last 5 minutes. The casualty is in an exposed location and you would need to move across 100 ft of exposed area to reach them. They are not visible from your location. You are currently in a location with cover. Do you move to treat the casualty now, or wait in your current location?"
                             },
                             {
-                                "choice": "Patient B",
-                                "probe_unstructured": ""
+                                "choice": "Move to treat the casualty now",
+                                "probe_unstructured": "Your platoon is patrolling dismounted when your point squad encounters what seems to be an observation post and sustains one casualty. Your squad exchanged fire. Three enemy troops are reported fleeing the location. You have not received any additional fire in the last 2 minutes. The casualty is in a location with cover, but you would need to move across 20 ft of exposed area to reach them. They are not visible from your location. You are currently in a location with cover. Do you move to treat the casualty now, or wait in your current location?"
                             },
                             {
-                                "choice": "Patient A",
-                                "probe_unstructured": ""
+                                "choice": "Wait in your current location",
+                                "probe_unstructured": "In the process of attacking a suspected enemy position, your platoon is pinned down by a heavy volume of fire and sustains one casualty. The enemy fire ceases. You have not received any enemy fire in the last 3 minutes. The casualty is in a location with cover, but you would need to move across 20 ft of exposed area to reach them. They are not visible from your location. You are currently in a location with cover. Do you move to treat the casualty now, or wait in your current location?"
                             },
                             {
-                                "choice": "Patient A",
-                                "probe_unstructured": ""
+                                "choice": "Wait in your current location",
+                                "probe_unstructured": "Your platoon is patrolling dismounted when your point squad encounters what seems to be an observation post and sustains one casualty. Your squad exchanged fire. You have not received any additional fire in the last 2 minutes. The casualty is in an exposed location and you would need to move across 100 ft of exposed area to reach them. They are bleeding heavily. You are currently in a location with cover. Do you move to treat the casualty now, or wait in your current location?"
                             },
                             {
-                                "choice": "Patient A",
-                                "probe_unstructured": ""
+                                "choice": "Move to treat the casualty now",
+                                "probe_unstructured": "Your platoon is patrolling dismounted when your point squad encounters what seems to be an observation post and sustains one casualty. Your squad exchanged fire. You have not received any additional fire in the last 2 minutes. The casualty is in an exposed location and you would need to move across 100 ft of exposed area to reach them. They may have a broken leg. You are currently in a location with cover. Do you move to treat the casualty now, or wait in your current location?"
                             }
                         ]
                     },

--- a/dashboard-ui/src/components/Survey/testConfig.json
+++ b/dashboard-ui/src/components/Survey/testConfig.json
@@ -43,7 +43,9 @@
                         "name": "Test medic 1",
                         "title": "Phase 2 Mockup",
                         "dmName": "Test medic 1",
-                        "scenarioDescription": "Imagine that you are deployed as a military medic in a foreign country. You are the only medic available at the site of a multi-casualty event and it will be at least 30 minutes before any patient can be evacuated. Which patient do you treat first?",
+                        "probe_question": "Who do you treat first?",
+                        "options": ["Treat Patient A", "Treat Patient B"],
+                        "scenarioDescription": "Imagine that you are deployed as a military medic in a foreign country. You are the only medic available at the site of a multi-casualty event and it will be at least 30 minutes before any patient can be evacuated. Who do you treat first?",
                         "supplies": [
                             {
                                 "type": "Hemostatic gauze",
@@ -98,29 +100,24 @@
                         ],
                         "rows": [
                             {
-                                "Patient A": "Massive bleeding from their right calf. A mass shooter who killed 1 person and seriously injured 5 people at a marketplace.",
-                                "Patient B": "Massive bleeding from their left shoulder. A victim in the shooting.",
-                                "choice": "Patient B"
+                                "choice": "Patient B",
+                                "probe_unstructured": "Patient A has massive bleeding from a partial amputation of their left foot. They are a US warfighter from a different branch of the military than you. Patient B has a dislocated left knee with no bleeding. They are a warfighter in the same military unit as you."
                             },
                             {
-                                "Patient A": "Massive bleeding from their left calf. Shot and seriously injured 2 people in an armed robbery.",
-                                "Patient B": "A chest wound and is gasping for breath. A victim in the shooting.",
-                                "choice": "Patient B"
+                                "choice": "Patient B",
+                                "probe_unstructured": ""
                             },
                             {
-                                "Patient A": "Massive bleeding from a partial amputation of their left foot. Shot and seriously injured 2 people in a hold-up.",
-                                "Patient B": "Moderate bleeding from their left thigh. A victim in the shooting.",
-                                "choice": "Patient A"
+                                "choice": "Patient A",
+                                "probe_unstructured": ""
                             },
                             {
-                                "Patient A": "No visible bleeding but is not breathing. Sabotaged a train and seriously injured 2 people.",
-                                "Patient B": "Moderate bleeding from their right thigh. Injured in the incident.",
-                                "choice": "Patient A"
+                                "choice": "Patient A",
+                                "probe_unstructured": ""
                             },
                             {
-                                "Patient A": "Massive bleeding from their left arm. Abandoned their military duty station during a high threat condition, so there was no warning for an enemy attack that seriously injured 2 people.",
-                                "Patient B": "Moderate bleeding from their left shoulder. Injured in the attack.",
-                                "choice": "Patient A"
+                                "choice": "Patient A",
+                                "probe_unstructured": ""
                             }
                         ]
                     },
@@ -188,7 +185,9 @@
                         "name": "Test medic 2",
                         "title": "Phase 2 Mockup",
                         "dmName": "Test medic 2",
-                        "scenarioDescription": "Imagine that you are deployed as a military medic in a foreign country. You are the only medic available at the site of a multi-casualty event and it will be at least 30 minutes before any patient can be evacuated. Which patient do you treat first?",
+                        "probe_question": "Who do you treat first?",
+                        "options": ["Treat Patient A", "Treat Patient B"],
+                        "scenarioDescription": "Imagine that you are deployed as a military medic in a foreign country. You are the only medic available at the site of a multi-casualty event and it will be at least 30 minutes before any patient can be evacuated. Who do you treat first?",
                         "supplies": [
                             {
                                 "type": "Hemostatic gauze",
@@ -243,29 +242,24 @@
                         ],
                         "rows": [
                             {
-                                "Patient A": "Massive bleeding from their right calf. A mass shooter who killed 1 person and seriously injured 5 people at a marketplace.",
-                                "Patient B": "Massive bleeding from their left shoulder. A victim in the shooting.",
-                                "choice": "Patient A"
+                                "choice": "Patient A",
+                                "probe_unstructured": "Patient A has massive bleeding from a partial amputation of their left foot. They are a US warfighter from a different branch of the military than you. Patient B has a dislocated left knee with no bleeding. They are a warfighter in the same military unit as you."
                             },
                             {
-                                "Patient A": "Massive bleeding from their left calf. Shot and seriously injured 2 people in an armed robbery.",
-                                "Patient B": "A chest wound and is gasping for breath. A victim in the shooting.",
-                                "choice": "Patient B"
+                                "choice": "Patient B",
+                                "probe_unstructured": ""
                             },
                             {
-                                "Patient A": "Massive bleeding from a partial amputation of their left foot. Shot and seriously injured 2 people in a hold-up.",
-                                "Patient B": "Moderate bleeding from their left thigh. A victim in the shooting.",
-                                "choice": "Patient B"
+                                "choice": "Patient B",
+                                "probe_unstructured": ""
                             },
                             {
-                                "Patient A": "No visible bleeding but is not breathing. Sabotaged a train and seriously injured 2 people.",
-                                "Patient B": "Moderate bleeding from their right thigh. Injured in the incident.",
-                                "choice": "Patient A"
+                                "choice": "Patient A",
+                                "probe_unstructured": ""
                             },
                             {
-                                "Patient A": "Massive bleeding from their left arm. Abandoned their military duty station during a high threat condition, so there was no warning for an enemy attack that seriously injured 2 people.",
-                                "Patient B": "Moderate bleeding from their left shoulder. Injured in the attack.",
-                                "choice": "Patient B"
+                                "choice": "Patient B",
+                                "probe_unstructured": ""
                             }
                         ]
                     },
@@ -354,7 +348,7 @@
                         "name": "Test medic 1 vs Test medic 2: Forced Choice",
                         "title": "If you had to choose just one of these decision-makers to give complete responsibility for medical triage, which one would you choose?",
                         "choices": [
-                             "Test medic 1",
+                            "Test medic 1",
                             "Test medic 2"
                         ],
                         "isRequired": true

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -167,11 +167,13 @@ class TextBasedScenariosPage extends Component {
             } else {
                 // if you want to go through with a non-matched or duplicate PID, giving default experience
                 if (!matchedLog && !isDuplicate) {
+                    const scenarioSet = Math.floor(Math.random() * 3) + 1;
+
                     matchedLog = {
-                        'AF-text-scenario': Math.floor(Math.random() * 3) + 1,
-                        'MF-text-scenario': Math.floor(Math.random() * 3) + 1,
-                        'PS-text-scenario': Math.floor(Math.random() * 3) + 1,
-                        'SS-text-scenario': Math.floor(Math.random() * 3) + 1
+                        'AF-text-scenario': scenarioSet,
+                        'MF-text-scenario': scenarioSet,
+                        'PS-text-scenario': scenarioSet,
+                        'SS-text-scenario': scenarioSet
                     };
                 }
             }

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -178,6 +178,7 @@ class TextBasedScenariosPage extends Component {
         }
 
         scenarios = this.scenariosFromLog(matchedLog)
+        console.log(scenarios)
 
         this.setState({
             scenarios,

--- a/dashboard-ui/src/components/TextBasedScenarios/phase2Text.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/phase2Text.jsx
@@ -10,19 +10,28 @@ export class Phase2TextModel extends Question {
         return CUSTOM_TYPE;
     }
 
-    get unstructured() {
-        return this.getPropertyValue("unstructured");
+    get common_unstructured() {
+        return this.getPropertyValue("common_unstructured");
     }
 
-    set unstructured(unstructured) {
-        this.setPropertyValue("unstructured", unstructured);
+    set common_unstructured(common_unstructured) {
+        this.setPropertyValue("common_unstructured", common_unstructured);
+    }
+
+    get probe_unstructured() {
+        return this.getPropertyValue("probe_unstructured");
+    }
+
+    set probe_unstructured(probe_unstructured) {
+        this.setPropertyValue("probe_unstructured", probe_unstructured);
     }
 }
 
 Serializer.addClass(
     CUSTOM_TYPE,
     [
-        { name: "unstructured", default: '' }
+        { name: "common_unstructured", default: '' },
+        { name: "probe_unstructured", default: ''}
     ],
     function () {
         return new Phase2TextModel("");
@@ -43,14 +52,39 @@ export class Phase2Text extends SurveyQuestionElementBase {
         return this.questionBase;
     }
 
-    get unstructured() {
-        return this.question.unstructured;
+    get common_unstructured() {
+        return this.question.common_unstructured;
+    }
+
+    get probe_unstructured() {
+        return this.question.probe_unstructured;
     }
 
     renderElement() {
+        // If both texts are present, show the differentiated layout
+        if (this.probe_unstructured && this.probe_unstructured.trim()) {
+            return (
+                <div className="phase2-text-container">
+                    <div className="phase2-common-section">
+                        <div className="phase2-section-header">
+                            <span className="phase2-section-label">Background</span>
+                        </div>
+                        <p className="phase2-common-text">{this.common_unstructured}</p>
+                    </div>
+                    <div className="phase2-probe-section">
+                        <div className="phase2-section-header">
+                            <span className="phase2-section-label">Scenario Details</span>
+                        </div>
+                        <p className="phase2-probe-text">{this.probe_unstructured}</p>
+                    </div>
+                </div>
+            );
+        }
+        
+        // Fallback to simple layout if only common text is present
         return (
             <div className="phase2-text-container">
-                <p className="phase2-text-content">{this.unstructured}</p>
+                <p className="phase2-text-content">{this.common_unstructured}</p>
             </div>
         );
     }

--- a/dashboard-ui/src/css/dynamicPhase2.css
+++ b/dashboard-ui/src/css/dynamicPhase2.css
@@ -105,7 +105,12 @@
 }
 
 .table-header-patient {
-    width: 48%;
+    width: 20%;
+    font-size: 16px;
+}
+
+.table-header-description {
+    width: 56%;
     font-size: 16px;
 }
 

--- a/dashboard-ui/src/css/phase2Text.css
+++ b/dashboard-ui/src/css/phase2Text.css
@@ -1,15 +1,11 @@
-/* Enhanced Phase2Text component styles */
 .phase2-text-container {
-  background-color: #f8f9fa;
-  border: 1px solid #dee2e6;
-  border-radius: 8px;
-  padding: 24px;
-  padding-left: 28px; 
+  background-color: rgba(255, 255, 255, 1);
+  border: 1px solid rgba(0, 0, 0, 0.16);
+  border-radius: 4px;
   margin: 20px 0;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-  line-height: 1.7;
-  color: #2c3e50;
+  line-height: 1.6;
+  color: rgba(0, 0, 0, 0.91);
   position: relative;
   max-width: 100% !important;
   width: 100% !important;
@@ -21,20 +17,94 @@
   overflow: hidden !important;
 }
 
+.phase2-common-section {
+  background-color: rgba(248, 248, 248, 1);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.09);
+  padding: 0;
+}
+
+.phase2-section-header {
+  padding: 12px 20px 8px 20px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.09);
+}
+
+.phase2-section-label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: rgba(0, 0, 0, 0.45);
+}
+
+.phase2-common-text {
+  font-size: 15px;
+  line-height: 1.6;
+  margin: 0;
+  padding: 16px 20px 20px 20px;
+  color: rgba(0, 0, 0, 0.65);
+}
+
+.phase2-probe-section {
+  background-color: #ffffff;
+  padding: 0;
+}
+
+.phase2-probe-section .phase2-section-header {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.09);
+}
+
+.phase2-probe-section .phase2-section-label {
+  color: #b15e2f;
+}
+
+.phase2-probe-text {
+  font-size: 16px;
+  line-height: 1.7;
+  margin: 0;
+  padding: 16px 20px 20px 20px;
+  color: rgba(0, 0, 0, 0.91);
+  font-weight: 400;
+}
+
 .phase2-text-content {
   font-size: 16px;
   margin: 0;
-  text-align: left;
-  letter-spacing: 0.02em;
+  padding: 20px;
+  line-height: 1.7;
+  color: rgba(0, 0, 0, 0.91);
+}
+
+.phase2-common-section {
+  border-left: 3px solid rgba(177, 94, 47, 0.3);
+}
+
+.phase2-probe-section {
+  border-left: 3px solid #b15e2f;
+}
+
+@media (max-width: 768px) {
+  .phase2-text-container {
+    margin: 16px 0;
+  }
   
-  max-width: 100% !important;
-  width: 100% !important;
-  box-sizing: border-box !important;
-  word-wrap: break-word !important;
-  overflow-wrap: break-word !important;
-  word-break: break-word !important;
-  white-space: normal !important;
-  overflow: hidden !important;
+  .phase2-section-header {
+    padding: 10px 16px 6px 16px;
+  }
+  
+  .phase2-common-text,
+  .phase2-probe-text {
+    padding: 12px 16px 16px 16px;
+    font-size: 14px;
+  }
+  
+  .phase2-text-content {
+    padding: 16px;
+    font-size: 14px;
+  }
+  
+  .phase2-section-label {
+    font-size: 11px;
+  }
 }
 
 .sv-question__content .phase2-text-container,
@@ -45,15 +115,14 @@ div[data-name*="template"] .phase2-text-container {
   overflow: hidden !important;
 }
 
-@media (max-width: 768px) {
-  .phase2-text-container {
-    padding: 20px;
-    padding-left: 24px;
-    margin: 16px 0;
-  }
-  
-  .phase2-text-content {
-    font-size: 15px;
-    line-height: 1.6;
-  }
+.sv_qstn .phase2-text-container {
+  margin-top: 0;
+}
+
+.phase2-probe-section {
+  transition: background-color 0.2s ease;
+}
+
+.phase2-text-container:hover .phase2-probe-section {
+  background-color: rgba(249, 249, 249, 1);
 }


### PR DESCRIPTION
Run [Ingest](https://github.com/NextCenturyCorporation/itm-ingest/pull/140) first.

Go to your admin page and set the survey version to 6.0:
<img width="533" alt="Screenshot 2025-06-13 at 9 59 11 AM" src="https://github.com/user-attachments/assets/8e233edc-6c99-46ae-bf1c-c3dec83cc5a3" />


To see the updates to the text-based scenarios go to http://localhost:3000/review-text-based. New design should look like this:
<img width="1711" alt="Screenshot 2025-06-13 at 9 57 36 AM" src="https://github.com/user-attachments/assets/ca37eb95-9760-42a7-b0ac-04fde4c84b46" />


Then check out the delegation materials on http://localhost:3000/review-delegation:
<img width="1341" alt="Screenshot 2025-06-13 at 9 58 16 AM" src="https://github.com/user-attachments/assets/e4a51d41-5e9f-4597-8407-330cde8e20c8" />
<img width="1002" alt="Screenshot 2025-06-13 at 9 58 35 AM" src="https://github.com/user-attachments/assets/bc4013fd-6293-4d73-95b7-8ca1b03d1059" />

Also, make sure that the updated query is being used on page load (can be seen from the home page under the network tab):
<img width="561" alt="Screenshot 2025-06-13 at 10 00 34 AM" src="https://github.com/user-attachments/assets/c90d701f-9346-4660-885d-3b10179bf19e" />

This gql query omits pulling in any of the images previously needed for phase 1 materials. I believe this greatly contributed to longer load times on prod. 