### PR TITLE
Itm 1042

### DIFF
--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -64,7 +64,14 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
 
     const getCompletionOptions = () => {
         const textThreshold = selectedPhase === 'Phase 2' ? 4 : 5;
-        return [`All Text (${textThreshold})`, 'Missing Text', 'Delegation (1)', 'No Delegation', 'All Sim (4)', 'Any Sim', 'Adept + OW Sim', 'No Sim'];
+        const baseOptions = [`All Text (${textThreshold})`, 'Missing Text', 'Delegation (1)', 'No Delegation', 'All Sim (4)', 'Any Sim', 'No Sim'];
+        
+        if (selectedPhase === 'Phase 1') {
+            // phase 1 option
+            baseOptions.splice(-1, 0, 'Adept + OW Sim');
+        }
+        
+        return baseOptions;
     };
 
     React.useEffect(() => {

--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -432,17 +432,17 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
                 />
                 <TextField label="Search PIDs" size="small" value={searchPid} onInput={updatePidSearch}></TextField>
             </div>
-            <DownloadButtons 
+            <DownloadButtons
                 formattedData={refineData(formattedData.filter((x) => {
                     const isPhase2Eval = x['Evaluation'] === 'June 2025 Collaboration';
                     return selectedPhase === 'Phase 2' ? isPhase2Eval : !isPhase2Eval;
-                }))} 
-                filteredData={refineData(filteredData)} 
-                HEADERS={getHeaders().filter((x) => !columnsToHide.includes(x))} 
-                fileName={'Participant_Progress'} 
-                extraAction={refreshData} 
-                extraActionText={'Refresh Data'} 
-                isParticipantData={true} 
+                }))}
+                filteredData={refineData(filteredData)}
+                HEADERS={HEADERS.filter((x) => !columnsToHide.includes(x))}  // ← Use HEADERS instead
+                fileName={'Participant_Progress'}
+                extraAction={refreshData}
+                extraActionText={'Refresh Data'}
+                isParticipantData={true}
             />
         </section>
         <div className='resultTableSection'>

--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -115,6 +115,9 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
                     obj['Del-2'] = lastSurvey?.results?.[delScenarios[1]]?.scenarioIndex;
                     obj['Del-3'] = lastSurvey?.results?.[delScenarios[2]]?.scenarioIndex;
                     obj['Del-4'] = lastSurvey?.results?.[delScenarios[3]]?.scenarioIndex;
+                    if (delScenarios.length > 4) {
+                        obj['Del-5'] = lastSurvey?.results?.[delScenarios[4]]?.scenarioIndex;
+                    }
                 }
                 if (obj['Delegation'] > 0) obj['Survey Link'] = null;
 
@@ -122,7 +125,7 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
 
                 const scenarios = textResults.filter((x) => x.participantID == pid);
                 const lastScenario = scenarios?.slice(-1)?.[0];
-                const text_start_date = new Date(lastScenario?.startTime);
+                const text_start_date = new Date(scenarios[0]?.startTime);
                 const text_end_date = new Date(lastScenario?.timeComplete);
                 obj['Text Start Date-Time'] = text_start_date != 'Invalid Date' ? `${text_start_date?.getMonth() + 1}/${text_start_date?.getDate()}/${text_start_date?.getFullYear()} - ${text_start_date?.toLocaleTimeString('en-US', { hour12: false })}` : undefined;
                 obj['Text End Date-Time'] = text_end_date != 'Invalid Date' ? `${text_end_date?.getMonth() + 1}/${text_end_date?.getDate()}/${text_end_date?.getFullYear()} - ${text_end_date?.toLocaleTimeString('en-US', { hour12: false })}` : undefined;
@@ -134,7 +137,7 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
                 const textThreshold = obj['Evaluation'] === 'June 2025 Collaboration' ? 4 : 5;
                 if (obj['Text'] < textThreshold) {
                     obj['Survey Link'] = null;
-                } 
+                }
 
                 if (!obj['Evaluation']) {
                     // Fall back if no sim, del, or text based scenarios

--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -309,9 +309,15 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
     const refineData = (origData) => {
         // remove unwanted headers from download
         const updatedData = structuredClone(origData);
+        const currentHeaders = getHeaders();
         updatedData.map((x) => {
             for (const h of columnsToHide) {
                 delete x[h];
+            }
+            // remove fields that aren't in the current phase's headers
+            const keysToDelete = Object.keys(x).filter(key => !currentHeaders.includes(key));
+            for (const key of keysToDelete) {
+                delete x[key];
             }
             return x;
         });
@@ -426,7 +432,18 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
                 />
                 <TextField label="Search PIDs" size="small" value={searchPid} onInput={updatePidSearch}></TextField>
             </div>
-            <DownloadButtons formattedData={formattedData} filteredData={refineData(filteredData)} HEADERS={HEADERS.filter((x) => !columnsToHide.includes(x))} fileName={'Participant_Progress'} extraAction={refreshData} extraActionText={'Refresh Data'} isParticipantData={true} />
+            <DownloadButtons 
+                formattedData={refineData(formattedData.filter((x) => {
+                    const isPhase2Eval = x['Evaluation'] === 'June 2025 Collaboration';
+                    return selectedPhase === 'Phase 2' ? isPhase2Eval : !isPhase2Eval;
+                }))} 
+                filteredData={refineData(filteredData)} 
+                HEADERS={getHeaders().filter((x) => !columnsToHide.includes(x))} 
+                fileName={'Participant_Progress'} 
+                extraAction={refreshData} 
+                extraActionText={'Refresh Data'} 
+                isParticipantData={true} 
+            />
         </section>
         <div className='resultTableSection'>
             <table className='itm-table'>

--- a/dashboard-ui/src/components/Research/utils.js
+++ b/dashboard-ui/src/components/Research/utils.js
@@ -56,8 +56,9 @@ export const exportToExcel = async (filename, formattedData, headers, participan
     if (participantData) {
         // apply conditional formatting to participant data
         const keys = Object.keys(dataCopy[Object.keys(dataCopy)[0]]);
-        const lightGreenIfNotNull = ['Sim-1', 'Sim-2', 'Sim-3', 'Sim-4', 'IO1', 'MJ1', 'MJ2', 'MJ4', 'MJ5', 'QOL1', 'QOL2', 'QOL3', 'QOL4', 'VOL1', 'VOL2', 'VOL3', 'VOL4'];
-
+        const lightGreenIfNotNull = ['Sim-1', 'Sim-2', 'Sim-3', 'Sim-4', 'IO1', 'MJ1', 'MJ2', 'MJ4', 'MJ5', 'QOL1', 'QOL2', 'QOL3', 'QOL4', 'VOL1', 'VOL2', 'VOL3', 'VOL4', 'AF1', 'AF2', 'AF3', 'MF1', 'MF2', 'MF3', 'PS1', 'PS2', 'PS3', 'SS1', 'SS2', 'SS3'];
+        const phase2 = dataCopy[0]['Evaluation'] === 'June 2025 Collaboration'
+        console.log(phase2)
         for (let row = 1; row <= dataCopy.length; row++) {
             for (let col = 0; col < keys.length; col++) {
                 const cellRef = XLSX.utils.encode_cell({ r: row, c: col });
@@ -72,7 +73,7 @@ export const exportToExcel = async (filename, formattedData, headers, participan
                             }
                         };
                     }
-                    if ((keys[col] == 'Delegation' && val == 1) || (keys[col] == 'Text' && val == 5) || (keys[col] == 'Sim Count' && val == 4)) {
+                    if ((keys[col] == 'Delegation' && val == 1) || (keys[col] == 'Text' && ((val == 5 && !phase2) || (val == 4 && phase2))) || (keys[col] == 'Sim Count' && val == 4)) {
                         cell.s = {
                             fill: {
                                 fgColor: { rgb: '7bbc7b' }  // Dark green color

--- a/dashboard-ui/src/components/Research/utils.js
+++ b/dashboard-ui/src/components/Research/utils.js
@@ -58,7 +58,6 @@ export const exportToExcel = async (filename, formattedData, headers, participan
         const keys = Object.keys(dataCopy[Object.keys(dataCopy)[0]]);
         const lightGreenIfNotNull = ['Sim-1', 'Sim-2', 'Sim-3', 'Sim-4', 'IO1', 'MJ1', 'MJ2', 'MJ4', 'MJ5', 'QOL1', 'QOL2', 'QOL3', 'QOL4', 'VOL1', 'VOL2', 'VOL3', 'VOL4', 'AF1', 'AF2', 'AF3', 'MF1', 'MF2', 'MF3', 'PS1', 'PS2', 'PS3', 'SS1', 'SS2', 'SS3'];
         const phase2 = dataCopy[0]['Evaluation'] === 'June 2025 Collaboration'
-        console.log(phase2)
         for (let row = 1; row <= dataCopy.length; row++) {
             for (let col = 0; col < keys.length; col++) {
                 const cellRef = XLSX.utils.encode_cell({ r: row, c: col });


### PR DESCRIPTION
[Ticket](https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?assignee=60ba425da547eb00686ee0ce&jql=assignee%20IN%20%2860ba425da547eb00686ee0ce%2C%20empty%29&selectedIssue=ITM-1042)

http://localhost:3000/participant-progress-table

A lot of funkiness with the progress table should now be cleaned up:

- Phase 2 table should now have a del-5 column
- Text based scenario start and end times are properly being pulled (before it was grabbing the start and end times from the same scenario)
- The .xlsx download should now separate the two phases and only include the headers for that phase. These column headers should be in the same order as in the UI and the highlighting behavior should carry over into the download
- You shouldn't see any phase 1 fields (e.g `MJ-1`) in the phase 2 data and vice versa