### PR TITLE
Adm results undefined fix

### DIFF
--- a/dashboard-ui/src/components/AdmCharts/scoreChart.jsx
+++ b/dashboard-ui/src/components/AdmCharts/scoreChart.jsx
@@ -66,9 +66,7 @@ class ScoreChart extends React.Component {
                 ({ loading, error, data }) => {
                     if (loading) return <div>No stats yet</div> 
                     if (error) return <div>Error</div>
-
                     const chartData = data[GET_HISTORIES_BY_ID]?.filter((x) => x.evalNumber == this.props.evalNumber);
-                    
                     let admNameParameter = "ADM Name";
                     if(this.props.evalNumber > 2) {
                         admNameParameter = "adm_name";
@@ -76,7 +74,12 @@ class ScoreChart extends React.Component {
 
                     let newScores = {};
                     chartData.map((item) => {
-                        const performer = item.history[0].parameters[admNameParameter];
+                        let performer;
+                        if (item.evaluation) {
+                            performer = item.evaluation.adm_name
+                        } else {
+                            performer = item.history[0].parameters[admNameParameter];
+                        }
                         const prevPerformerData = newScores[performer] || { total: 0, count: 0 };
                         newScores[performer] = {
                             total: prevPerformerData.total + item.history[item.history.length - 1].response.score,

--- a/dashboard-ui/src/components/AdmCharts/scoreChart.jsx
+++ b/dashboard-ui/src/components/AdmCharts/scoreChart.jsx
@@ -74,11 +74,9 @@ class ScoreChart extends React.Component {
 
                     let newScores = {};
                     chartData.map((item) => {
-                        let performer;
-                        if (item.evaluation) {
-                            performer = item.evaluation.adm_name
-                        } else {
-                            performer = item.history[0].parameters[admNameParameter];
+                        let performer = item.evaluation?.adm_name || item.history?.[0]?.parameters?.[admNameParameter];
+                        if (!performer) {
+                            performer = item.history?.[1]?.parameters?.[admNameParameter];
                         }
                         const prevPerformerData = newScores[performer] || { total: 0, count: 0 };
                         newScores[performer] = {

--- a/dashboard-ui/src/components/Research/tables/rq23_ph2.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq23_ph2.jsx
@@ -199,7 +199,7 @@ export function Phase2_RQ23() {
         <section className='tableHeader'>
             <div className="filters">
                 <Autocomplete
-                    style={{ 'min-width': '300px' }}
+                    style={{ 'minWidth': '300px' }}
                     multiple
                     options={admNames}
                     filterSelectedOptions

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -167,7 +167,7 @@ const resolvers = {
         [{ "$group": { "_id": { evalNumber: "$evalNumber", evalName: "$evalName" } } }]).sort({ 'evalNumber': -1 }).toArray().then(result => { return result });
     },
     getAllHistoryByID: async (obj, args, context, inflow) => {
-      return await context.db.collection('admTargetRuns').find({ "history.response.id": args.historyId }, { projection: { "evaluation": 1, "history.parameters.adm_name": 1, "history.response.score": 1, "evalNumber": 1 } }).toArray().then(result => { return result; });
+      return await context.db.collection('admTargetRuns').find({ "history.response.id": args.historyId }, { projection: { "evaluation": 1, "history.parameters.adm_name": 1, "history.parameters.ADM Name": 1, "history.response.score": 1, "evalNumber": 1 } }).toArray().then(result => { return result; });
     },
     getScenario: async (obj, args, context, inflow) => {
       return await context.db.collection('scenarios').findOne({ "id": args["scenarioId"] }).then(result => { return result; });

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -167,7 +167,7 @@ const resolvers = {
         [{ "$group": { "_id": { evalNumber: "$evalNumber", evalName: "$evalName" } } }]).sort({ 'evalNumber': -1 }).toArray().then(result => { return result });
     },
     getAllHistoryByID: async (obj, args, context, inflow) => {
-      return await context.db.collection('admTargetRuns').find({ "history.response.id": args.historyId }, { projection: { "history.parameters.adm_name": 1, "history.response.score": 1, "evalNumber": 1 } }).toArray().then(result => { return result; });
+      return await context.db.collection('admTargetRuns').find({ "history.response.id": args.historyId }, { projection: { "evaluation": 1, "history.parameters.adm_name": 1, "history.response.score": 1, "evalNumber": 1 } }).toArray().then(result => { return result; });
     },
     getScenario: async (obj, args, context, inflow) => {
       return await context.db.collection('scenarios').findOne({ "id": args["scenarioId"] }).then(result => { return result; });


### PR DESCRIPTION
http://localhost:3000/adm-results

ADM names were not properly being pulled in for a few ADMS for the latest eval (as well as old ones like MVP and September Milestone).
<img width="1535" alt="Screenshot 2025-06-25 at 12 28 36 PM" src="https://github.com/user-attachments/assets/e348d2f9-d41c-49ba-9a6e-5a6094fc87dd" />

 
This should now be fixed. 
<img width="1674" alt="Screenshot 2025-06-25 at 12 28 52 PM" src="https://github.com/user-attachments/assets/9bc27e90-43b6-4a2d-aa09-daa1b03fadb5" />


Edit: May have to rebuild gql container