### PR TITLE
Itm 1061

### DIFF
--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -90,8 +90,8 @@ const GET_CONFIGS_PHASE_2 = gql`
 `
 
 
-const LOW_PID = 202506100;
-const HIGH_PID = 202506299;
+const LOW_PID = 202507100;
+const HIGH_PID = 202507299;
 
 
 

--- a/dashboard-ui/src/components/OnlineOnly/OnlineOnly.jsx
+++ b/dashboard-ui/src/components/OnlineOnly/OnlineOnly.jsx
@@ -81,12 +81,10 @@ export default function StartOnline() {
 
 
     const startSurvey = async () => {
-        // get pid
-        // get current plog
         const result = await refetch();
         // calculate new pid
-        const lowPid = 202506100;
-        const highPid = 202506299;
+        const lowPid = 202507100;
+        const highPid = 202507299;
         let newPid = Math.max(...result.data.getParticipantLog.filter((x) =>
             !["202409113A", "202409113B"].includes(x['ParticipantID']) &&
             x.ParticipantID >= lowPid && x.ParticipantID <= highPid

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -196,15 +196,17 @@ class TextBasedScenariosPage extends Component {
 
     scenariosFromLog = (participantLog) => {
         const scenarioIds = [
-            `June2025-AF${participantLog['AF-text-scenario']}-eval`,
-            `June2025-MF${participantLog['MF-text-scenario']}-eval`,
-            `June2025-PS${participantLog['PS-text-scenario']}-eval`,
-            `June2025-SS${participantLog['SS-text-scenario']}-eval`
+            `July2025-AF${participantLog['AF-text-scenario']}-eval`,
+            `July2025-MF${participantLog['MF-text-scenario']}-eval`,
+            `July2025-PS${participantLog['PS-text-scenario']}-eval`,
+            `July2025-SS${participantLog['SS-text-scenario']}-eval`
         ];
 
         const scenarios = Object.values(this.props.textBasedConfigs).filter(config =>
             config.scenario_id && scenarioIds.includes(config.scenario_id)
         );
+
+        console.log(scenarios)
 
         for (let i = scenarios.length - 1; i > 0; i--) {
             const j = Math.floor(Math.random() * (i + 1));
@@ -356,8 +358,8 @@ class TextBasedScenariosPage extends Component {
         });
 
         scenarioData.scenarioOrder = this.state.scenarios.map(scenario => scenario.scenario_id);
-        scenarioData.evalNumber = 8
-        scenarioData.evalName = 'June 2025 Collaboration'
+        scenarioData.evalNumber = 9
+        scenarioData.evalName = 'July 2025 Collaboration'
         await this.getAlignmentScore(scenarioData)
         const sanitizedData = this.sanitizeKeys(scenarioData);
 
@@ -368,7 +370,7 @@ class TextBasedScenariosPage extends Component {
             sanitizedData,
             isUploadButtonEnabled: true
         }, () => {
-            if (this.uploadButtonRef.current && !scenarioId.includes('adept') && !scenarioId.includes('June2025')) {
+            if (this.uploadButtonRef.current && !scenarioId.includes('adept') && !scenarioId.includes('2025')) {
                 this.uploadButtonRef.current.click();
             }
         });
@@ -380,7 +382,7 @@ class TextBasedScenariosPage extends Component {
     }
 
     getAlignmentScore = async (scenario) => {
-        if (scenario.scenario_id.includes('adept') || scenario.scenario_id.includes('June2025')) {
+        if (scenario.scenario_id.includes('adept') || scenario.scenario_id.includes('2025')) {
             if (this.state.adeptSessionsCompleted === 0) {
                 await this.beginRunningSession(scenario)
             } else {


### PR DESCRIPTION
First, run the [ingest pr](https://github.com/NextCenturyCorporation/itm-ingest/pull/149)

Set up your ADEPT server locally and change your `.env` file to point to it. You may need to rebuild your dashboard container. 

http://localhost:3000/review-text-based

You should be able to preview any of the new scenarios listed here under `Phase 2 July 2025 Collaboration`.

Next, sign out and go to the text scenario entry point that in person participants will be using:
<img width="601" height="518" alt="Screenshot 2025-07-21 at 12 28 20 PM" src="https://github.com/user-attachments/assets/ff07a445-22ca-4239-8faf-0bed2f077986" />

Once you enter your email and hit start, you should see a console log. I added this in as a sanity check that the correct scenarios are being loaded. There should be four scenarios, all from the same set (e.g AF2, MF2, SS2, PS2) and they should all have July2025 in their `scenario_id` field. I will delete this console log before merging. 

Click through to the end, making sure you do not encounter any errors. Once you complete the scenarios, you should be able to find your results in the `userScenarioResults` collection using this query `{evalNumber: 9}`. Check that `kdmas` and `mostLeastAligned` are populating. 
 