### PR TITLE
ITM 1069: Fix Participant Progress Table to Always Show Complete Survey Results

### DIFF
--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -179,18 +179,19 @@ export function ParticipantProgressTable({ canViewProlific = false }) {
                 const incompleteSurveys = surveyResults.filter((x) => ((x.results?.pid && (x.results.pid === pid)) || x.results?.['Participant ID Page']?.questions?.['Participant ID']?.response === pid));
                 const lastSurvey = surveys?.slice(-1)?.[0];
                 const lastIncompleteSurvey = incompleteSurveys?.slice(-1)?.[0];
-                const survey_start_date = lastSurvey ? new Date(lastSurvey?.results?.startTime) : new Date(lastIncompleteSurvey?.results?.startTime);
+                const surveyToUse = lastSurvey || lastIncompleteSurvey;
+                const survey_start_date =new Date(surveyToUse?.results?.startTime);
                 const survey_end_date = new Date(lastSurvey?.results?.timeComplete);
                 obj['Del Start Date-Time'] = String(survey_start_date) !== 'Invalid Date' ? `${survey_start_date?.getMonth() + 1}/${survey_start_date?.getDate()}/${survey_start_date?.getFullYear()} - ${survey_start_date?.toLocaleTimeString('en-US', { hour12: false })}` : undefined;
                 obj['Del End Date-Time'] = String(survey_end_date) !== 'Invalid Date' ? `${survey_end_date?.getMonth() + 1}/${survey_end_date?.getDate()}/${survey_end_date?.getFullYear()} - ${survey_end_date?.toLocaleTimeString('en-US', { hour12: false })}` : undefined;
-                const delScenarios = lastIncompleteSurvey?.results?.orderLog?.filter((x) => x.includes(' vs '));
+                const delScenarios = surveyToUse?.results?.orderLog?.filter((x) => x.includes(' vs '));
                 if (delScenarios) {
-                    obj['Del-1'] = lastIncompleteSurvey?.results?.[delScenarios[0]]?.scenarioIndex;
-                    obj['Del-2'] = lastIncompleteSurvey?.results?.[delScenarios[1]]?.scenarioIndex;
-                    obj['Del-3'] = lastIncompleteSurvey?.results?.[delScenarios[2]]?.scenarioIndex;
-                    obj['Del-4'] = lastIncompleteSurvey?.results?.[delScenarios[3]]?.scenarioIndex;
+                    obj['Del-1'] = surveyToUse?.results?.[delScenarios[0]]?.scenarioIndex;
+                    obj['Del-2'] = surveyToUse?.results?.[delScenarios[1]]?.scenarioIndex;
+                    obj['Del-3'] = surveyToUse?.results?.[delScenarios[2]]?.scenarioIndex;
+                    obj['Del-4'] = surveyToUse?.results?.[delScenarios[3]]?.scenarioIndex;
                     if (delScenarios.length > 4) {
-                        obj['Del-5'] = lastIncompleteSurvey?.results?.[delScenarios[4]]?.scenarioIndex;
+                        obj['Del-5'] = surveyToUse?.results?.[delScenarios[4]]?.scenarioIndex;
                     }
                 }
                 if (obj['Delegation'] > 0) obj['Survey Link'] = null;


### PR DESCRIPTION
**Original Ticket:** [Here](https://nextcentury.atlassian.net/browse/ITM-1069?atlOrigin=eyJpIjoiYjNhZTNhZDc0Y2U5NDlhMDk3ZjcyZjBkN2I0N2IwZTQiLCJwIjoiaiJ9)

**Description:** This PR is a patch to resolve an edge case in the Participant Progress table reported by @nextcen-dgemoets. When the same participant (defined by the same PID) has both fully complete survey information and an incomplete/in-progress survey, the delegation survey results reflected the incomplete record (meaning that the `Delegation` column of the table indicated that the participant had only completed a subset of delegation materials and some to all `Del#` column cells were left blank). Whenever complete delegation survey results are available, these should be used. This PR resolves this edge case behavior. If complete results are available, these will reflect in the table instead of newer incomplete delegation survey results. 

**How To Test:**

**NOTE:** If you have already run through/completed both the text based scenarios and delegation survey and your Participant Progress table reflects this (`Delegation` column shows a value of 5 with the cell background colored in green and all `Del#` cells are populated), feel free to optionally skip directly to Step 3.  
1. If you have not completed the text delegation materials already (you can check by visiting the `userScenarioResults` collection of your database in Mongo compass and filtering with the query `{ evalNumber: 9 }`, then start with this. You can do this by visiting the http://localhost:3000/login page of the dashboard, selecting the `Text Scenario Login` tab, and completing the entirety of the scenario questions. Once done, ensure that the `mostLeastAligned` and `kdmas` information is populated (not set to null or contain empty cells). 
2. Enter the PID that was assigned to you (visible as a parameter in these `userScenarioResults` documents) in the survey page:  http://localhost:3000/survey. Complete the entirety of the survey. Once you are done (a confirmation page will appear in your browser). 
3. Navigate to the Participant Progress table (http://localhost:3000/participant-progress-table). View the row corresponding to your PID and check the `Delegation` column value. It should be 5. Next, check to ensure that all `Del#` cells are populated and that the ADM information popup loads for each of these cells.  Check the `surveyResults` collection and filter by your PID `({ "results.pid": "<your PID here>" }`. Ensure that only a single document is present.
4. Start the survey again with the same PID. You should receive a warning indicating that "The Participant ID you entered has already been used". Select `Next` and begin the survey once again. Click through only a few of the pages and then exit the survey. You can do this by clicking on the ITM logo in the top left corner of the page, then pressing `Leave`. 
5. Refresh Mongo compass. Check the `surveyResults` collection to make sure that the new incomplete Delegation survey information appears as a new document you could not see before.
6. Restart your Docker containers as a safe measure to ensure that new database data is used for the progress table population.
7. Revisit the Participant Progress table. Make sure that the `Delegation` column still shows that all 5 surveys have been completed and that the `Del#` cells still populate (even for delegation survey items you did not complete in Step 4). Finally, ensure that the `ADM Information` popup still loads for each of the `Del#` cells. 