### PR TITLE
Handle Duplicate Emails

### DIFF
--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -10,7 +10,7 @@ import { isDefined } from '../AggregateResults/DataFunctions';
 // Components
 import ResultsPage from '../Results/results';
 import HomePage from '../Home/home';
-import { SurveyPageWrapper } from '../Survey/survey';
+import { SURVEY_VERSION_DATA, SurveyPageWrapper } from '../Survey/survey';
 import { TextBasedScenariosPageWrapper } from '../TextBasedScenarios/TextBasedScenariosPage';
 import { ReviewTextBasedPage } from '../ReviewTextBased/ReviewTextBased';
 import { ReviewDelegationPage } from '../ReviewDelegation/ReviewDelegation';
@@ -41,6 +41,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import 'material-design-icons/iconfont/material-icons.css';
 import 'react-dropdown/style.css';
 import 'react-dual-listbox/lib/react-dual-listbox.css';
+import store from '../../store/store';
 
 
 const history = createBrowserHistory();
@@ -230,8 +231,9 @@ export function App() {
 
     const participantLoginHandler = async (hashedEmail, isTester) => {
         const dbPLog = await fetchParticipantLog();
+        const evalNum = SURVEY_VERSION_DATA[store.getState().configs.currentSurveyVersion].evalNumber;
 
-        const foundParticipant = dbPLog.data.getParticipantLog.find((x) => x.hashedEmail === hashedEmail);
+        const foundParticipant = dbPLog.data.getParticipantLog.find((x) => x.hashedEmail === hashedEmail && x.evalNum == evalNum);
 
         if (foundParticipant) {
             const pid = foundParticipant['ParticipantID'];
@@ -253,6 +255,8 @@ export function App() {
                 "surveyEntryCount": 0,
                 "textEntryCount": 0,
                 "hashedEmail": hashedEmail,
+                "evalNum": evalNum,
+                "timeCreated": new Date(),
                 
                 "AF-text-scenario": scenarioSet,
                 "MF-text-scenario": scenarioSet,

--- a/dashboard-ui/src/components/OnlineOnly/OnlineOnly.jsx
+++ b/dashboard-ui/src/components/OnlineOnly/OnlineOnly.jsx
@@ -7,6 +7,8 @@ import { TextBasedScenariosPageWrapper } from "../TextBasedScenarios/TextBasedSc
 import { useHistory, useLocation } from 'react-router-dom';
 import bcrypt from 'bcryptjs';
 import '../../css/scenario-page.css';
+import store from "../../store/store";
+import { SURVEY_VERSION_DATA } from "../Survey/survey";
 
 const GET_PARTICIPANT_LOG = gql`
     query GetParticipantLog {
@@ -68,7 +70,7 @@ export default function StartOnline() {
         const participantData = {
             "ParticipantID": newPid, "Type": "Online", "prolificId": currentSearchParams.get('PROLIFIC_PID'), "contactId": currentSearchParams.get('ContactID'),
             "claimed": true, "simEntryCount": 0, "surveyEntryCount": 0, "textEntryCount": 0, "hashedEmail": bcrypt.hashSync(newPid.toString(), "$2a$10$" + process.env.REACT_APP_EMAIL_SALT),
-            "AF-text-scenario": scenarioSet, "MF-text-scenario": scenarioSet, "PS-text-scenario": scenarioSet, "SS-text-scenario": scenarioSet
+            "AF-text-scenario": scenarioSet, "MF-text-scenario": scenarioSet, "PS-text-scenario": scenarioSet, "SS-text-scenario": scenarioSet, 'evalNum': SURVEY_VERSION_DATA[store.getState().configs.currentSurveyVersion].evalNum
         };
         // update database
         const addRes = await addParticipant({ variables: { participantData, lowPid, highPid } });

--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -68,6 +68,13 @@ const ADD_PARTICIPANT = gql`
     mutation addNewParticipantToLog($participantData: JSON!, $lowPid: Int!, $highPid: Int!) {
         addNewParticipantToLog(participantData: $participantData, lowPid: $lowPid, highPid: $highPid) 
     }`;
+
+export const SURVEY_VERSION_DATA = {
+    "7.0": { evalName: 'July 2025 Collaboration', evalNumber: 9 },
+    "6.0": { evalName: 'June 2025 Collaboration', evalNumber: 8 },
+    "5.0": { evalName: 'Jan 2025 Eval', evalNumber: 6 },
+    "4.0": { evalName: 'Dry Run Evaluation', evalNumber: 4 }
+};
 class SurveyPage extends Component {
 
     constructor(props) {
@@ -105,13 +112,6 @@ class SurveyPage extends Component {
             this.postConfigSetup();
         }
     }
-
-    SURVEY_VERSION_DATA = {
-            "7.0": { evalName: 'July 2025 Collaboration', evalNumber: 9 },
-            "6.0": { evalName: 'June 2025 Collaboration', evalNumber: 8 },
-            "5.0": { evalName: 'Jan 2025 Eval', evalNumber: 6 },
-            "4.0": { evalName: 'Dry Run Evaluation', evalNumber: 4 }
-    };
 
     setSeenScenarios = () => {
         if (this.survey.getQuestionByName("Text Scenarios Completed")) {

--- a/node-graphql/server.accounts.js
+++ b/node-graphql/server.accounts.js
@@ -39,7 +39,7 @@ async function createUniqueIndex() {
         
         // This should allow for multiple hashedEmail fields to be null (april eval 2025)
         await dashboardDB.db.collection('participantLog').createIndex(
-            { "hashedEmail": 1 },
+            { "hashedEmail": 1, "evalNum": 1 },
             { 
                 unique: true,
                 partialFilterExpression: { hashedEmail: { $type: "string" } }


### PR DESCRIPTION
On main, try to start a text scenario through the login page using "123@123.com". You will be brought to an antiquated page that asks for a PID, mil/civ, and VR experience. Notice the PID in the url is not from our current eval. This was the intended functionality, but we need an upgrade:
- Within an evaluation, we don't want duplicate emails
- If a duplicate email is entered within an evaluation, the participant should be given the same PID in case they didn't finish the first time, or in the case of a race condition
- Between evaluations, we want to allow duplicate emails in the case of duplicate participants, with a new PID assigned to the same email for different evaluations (i.e. 123@123.com might have pid 201 for eval 4, but have pid 701 for eval 9. This is allowed. But it can never have 701 and 702 within eval 9)
- On main, we require the hashedEmail field to be unique across all participants (unless it's null). In this branch, we require the hashedEmail field to be unique across all participants within an evaluation, not within the entire collection

To test: run https://github.com/NextCenturyCorporation/itm-ingest/pull/152 first. Then test with different and duplicate emails to make sure no old functionality broke (i.e. new pids are still assigned to different emails) and the new functionality works (123@123.com will now give you a new pid because this is a new evaluation). 

In short, it should now be impossible to return to a previous text survey version, even if using the same email.

Additionally, timestamps are added to the creation of entries in the participant log now, as requested by Derek for easy cleanup of testing.