### PR TITLE
ITM 1071

### DIFF
--- a/dashboard-ui/src/components/Research/RQ2.jsx
+++ b/dashboard-ui/src/components/Research/RQ2.jsx
@@ -16,7 +16,8 @@ const ALLOWED_EVAL_OPTIONS = [
     { value: 4, label: 'Dry Run Evaluation' },
     { value: 5, label: 'Phase 1 Evaluation' },
     { value: 7, label: 'Phase II Experiment 1' },
-    { value: 8, label: 'Phase II June 2025 Collaboration'}
+    { value: 8, label: 'Phase II June 2025 Collaboration'},
+    { value: 9, label: 'Phase II July 2025 Collaboration'}
 ];
 
 export function RQ2() {

--- a/dashboard-ui/src/components/Research/tables/ph2_rq22-rq23.jsx
+++ b/dashboard-ui/src/components/Research/tables/ph2_rq22-rq23.jsx
@@ -27,6 +27,11 @@ const PH2_HEADERS = [
     'Baseline Server Session ID'
 ];
 
+const evalToName = {
+    8: 'June',
+    9: 'July'
+}
+
 export function PH2RQ2223({ evalNum }) {
     const { loading, error, data } = useQuery(getAdmData, {
         variables: { "evalNumber": evalNum }
@@ -49,6 +54,14 @@ export function PH2RQ2223({ evalNum }) {
 
     const openModal = () => setShowDefinitions(true);
     const closeModal = () => setShowDefinitions(false);
+
+    // reset all filters when eval num changes
+    React.useEffect(() => {
+        setAttributeFilters([])
+        setTargetFilters([])
+        setSetFilters([])
+        setTargetTypeFilters([])
+    }, [evalNum])
 
     React.useEffect(() => {
         if (data?.getAllHistoryByEvalNumber) {
@@ -102,8 +115,8 @@ export function PH2RQ2223({ evalNum }) {
                 // exclude full runs (not sets)
                 if (!setMatch) { continue; }
                 const scenarioSet = isRandom
-                        ? `P2June Dynamic Set ${setMatch[1]}`
-                        : `P2June Observation Set ${setMatch[1]}`;
+                        ? `P2${evalToName[evalNum]} Dynamic Set ${setMatch[1]}`
+                        : `P2${evalToName[evalNum]} Observation Set ${setMatch[1]}`;
 
 
                 for (const target of Object.keys(targets)) {
@@ -274,6 +287,7 @@ export function PH2RQ2223({ evalNum }) {
                     <Autocomplete
                         multiple
                         options={attributes}
+                        value={attributeFilters}
                         filterSelectedOptions
                         size="small"
                         renderInput={(params) => (
@@ -285,6 +299,7 @@ export function PH2RQ2223({ evalNum }) {
                     <Autocomplete
                         multiple
                         options={targets}
+                        value={targetFilters}
                         filterSelectedOptions
                         size="small"
                         renderInput={(params) => (
@@ -296,6 +311,7 @@ export function PH2RQ2223({ evalNum }) {
                     <Autocomplete
                         multiple
                         options={sets}
+                        value={setFilters}
                         filterSelectedOptions
                         size="small"
                         renderInput={(params) => (
@@ -307,6 +323,7 @@ export function PH2RQ2223({ evalNum }) {
                     <Autocomplete
                         multiple
                         options={targetType}
+                        value={targetTypeFilters}
                         filterSelectedOptions
                         size="small"
                         renderInput={(params) => (


### PR DESCRIPTION
Update to http://localhost:3000/research-results/rq2 to support the July ADM runs. 

You should be able to select July from the drop-down (leaving June as the default for now). Test that you can view all the July ADM runs and spot-check a few of the alignment scores using the `admTargetRuns` collection. Please also check that if you use a filter on July, and then switch back to June, the filters reset. 