### PR TITLE
ITM 1086: Eliminate Unnecessary Page Re-Renders In BlockedTable

### DIFF
--- a/dashboard-ui/src/components/Research/tables/BlockedTable.jsx
+++ b/dashboard-ui/src/components/Research/tables/BlockedTable.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { ResultsTable } from '../../SurveyResults/resultsTable';
 import gql from "graphql-tag";
 import { useQuery } from '@apollo/react-hooks';
@@ -39,27 +39,27 @@ export function BlockedTable({ evalNum }) {
         setIncludeJAN(event.target.checked);
     };
 
-    const updateEvalNums = useCallback((includeEval, evalObj) => {
-    if (includeEval) {
-      const newEvalNumbers = structuredClone(evalNumbers);
-      newEvalNumbers.push(evalObj);
-      setEvalNumbers(newEvalNumbers);
-    }
-    else {
-      const newEvalNumbers = structuredClone(evalNumbers);
-      let index = -1;
-      for (let i = 0; i < newEvalNumbers.length; i++) {
-        if (newEvalNumbers[i]['value'] === evalObj["value"]) {
-          index = i;
-          break;
+    const updateEvalNums = (includeEval, evalObj) => {
+        if (includeEval) {
+            const newEvalNumbers = structuredClone(evalNumbers);
+            newEvalNumbers.push(evalObj);
+            setEvalNumbers(newEvalNumbers);
         }
-      }
-      if (index > -1) {
-        newEvalNumbers.splice(index, 1);
-      }
-      setEvalNumbers(newEvalNumbers);
-    }
-  }, [evalNumbers]);
+        else {
+            const newEvalNumbers = structuredClone(evalNumbers);
+            let index = -1;
+            for (let i = 0; i < newEvalNumbers.length; i++) {
+                if (newEvalNumbers[i]['value'] === String(evalObj["value"])) {
+                    index = i;
+                    break;
+                }
+            }
+            if (index > -1) {
+                newEvalNumbers.splice(index, 1);
+            }
+            setEvalNumbers(newEvalNumbers);
+        }
+    };
 
     React.useEffect(() => {
         // reset toggles on render
@@ -70,11 +70,14 @@ export function BlockedTable({ evalNum }) {
 
     React.useEffect(() => {
         updateEvalNums(includeDRE, DRE);
-    }, [includeDRE, updateEvalNums]);
+    //updateEvalNums excluded to prevent infinite loop from constant function recreation
+    // eslint-disable-next-line
+    }, [includeDRE]);
 
     React.useEffect(() => {
         updateEvalNums(includeJAN, JAN);
-    }, [includeJAN, updateEvalNums]);
+    //updateEvalNums excluded to prevent infinite loop from constant function recreation
+    }, [includeJAN]);
 
     return (
         <>


### PR DESCRIPTION
**Original Ticket:** [Here](https://nextcentury.atlassian.net/browse/ITM-1086?atlOrigin=eyJpIjoiNDJjOTY1MjAxYTZmNDI3ZmEwMDZjMzAwZTY4MTY0Y2EiLCJwIjoiaiJ9)

## Description: 
The purpose of this ticket is to resolve a `Maximum update depth` warning discovered by @kaitlyn-sharo in the `BlockedTable.jsx` file. When completing [ITM-1014](https://github.com/NextCenturyCorporation/itm-evaluation-dashboard/pull/307), I eliminated a linter warning by memoizing the `updateEvalNums` function, using `evalNumbers` as a dependency, and then including `updateEvalNums` as a dependency in two `useEffect` hooks.. However, this was an incorrect dependency to include, as internally, `updateEvalNums` relies on `evalNumbers`. Changes to `evalNumbers` caused `updateEvalNums` to be re-created on each render, making the memoization pointless. This PR removes the unnecessary memoization and excludes `updateEvalNums` from dependency arrays to prevent infinite re-renders and resolve the original warning.

## How to Test
1. First, checkout the `development` branch or simply use `prod`. Navigate to the exploratory analysis page: http://localhost:3000/research-results/exploratory-analysis. 
2. Make sure that your console is open. From the dropdown at the top left of the page, select either `Dry Run Evaluation` or `Jan 2025 Evaluation`. Then, you should see the `Maximum update depth` warning appear. 
3. Now, checkout this branch and restart your Docker containers (just as a precaution). 
4. Repeat step 2. The warning should no longer be present. 
5. Scroll down to the `Delegation Data by Block` table on this page. 
6. Check that the correct data still renders in this table and that filtering still works. After applying some filters, ensure that both the `Download All Data` and `Download Filtered Data` buttons produce expected Excel downloads (compare to `prod`). 
7. (Optional) Inspect your docker logs to ensure that no new lint warnings were generated by this fix (the only lint warning should be a missing polyfill).  