### PR TITLE
Fixed delegator_mil in rq134 for phase 2

### DIFF
--- a/dashboard-ui/src/components/Research/utils.js
+++ b/dashboard-ui/src/components/Research/utils.js
@@ -338,7 +338,8 @@ export function getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dat
                     entryObj['Delegator_mil'] = roles?.includes('Military Background') || pid === '202409102' ? 'yes' : 'no';
                 }
                 else {
-                    entryObj['Delegator_mil'] = res.results?.['Post-Scenario Measures']?.questions?.["Served in Military"]?.['response'] == 'Never Served' ? 'no' : 'yes';
+                    const served = res.results?.['Post-Scenario Measures']?.questions?.["Served in Military"]?.['response'];
+                    entryObj['Delegator_mil'] = isDefined(served) ? served == 'Never Served' ? 'no' : 'yes' : null;
                 }
                 entryObj['Delegator_Role'] = roles ?? '-'
                 if (Array.isArray(entryObj['Delegator_Role'])) {


### PR DESCRIPTION
The Delegator_Mil column in the RQ134 table was being pulled incorrectly. I have changed it for Phase 2 so that it pulls the yes/no value from the "Served in Military" question. If the answer is "Never Served", it correlates to a "no" value in the table. Otherwise, the value is "yes". 

Spot-check June and July to see that this has updated properly, and check back at previous evals to make sure nothing broke there.