### PR TITLE
Itm 1092 delete pid

### DIFF
--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -305,7 +305,7 @@ export function App() {
             return <Redirect push to="/login" />;
         } else {
             if (isUserElevated(currentUser)) {
-                return <ParticipantProgressTable canViewProlific={currentUser.adeptUser || currentUser.admin} />
+                return <ParticipantProgressTable canViewProlific={currentUser.adeptUser || currentUser.admin} isAdmin={currentUser.admin} />
             } else {
                 return <Redirect push to="/" />;
             }

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -305,7 +305,7 @@ export function App() {
             return <Redirect push to="/login" />;
         } else {
             if (isUserElevated(currentUser)) {
-                return <ParticipantProgressTable canViewProlific={currentUser.adeptUser || currentUser.admin} isAdmin={currentUser.admin} />
+                return <ParticipantProgressTable canViewProlific={currentUser.adeptUser || currentUser.admin} isAdmin={currentUser.admin} currentUser={currentUser} />
             } else {
                 return <Redirect push to="/" />;
             }

--- a/dashboard-ui/src/components/Research/utils.js
+++ b/dashboard-ui/src/components/Research/utils.js
@@ -334,7 +334,12 @@ export function getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dat
                 const CURRENT_ROLE_QTEXT = evalNum >= 8 ? 'What is your current role' : 'What is your current role (choose all that apply):';
                 const roles = res.results?.['Post-Scenario Measures']?.questions?.[CURRENT_ROLE_QTEXT]?.['response'];
                 // override 102, who is military
-                entryObj['Delegator_mil'] = roles?.includes('Military Background') || pid === '202409102' ? 'yes' : 'no';
+                if (evalNum < 8) {
+                    entryObj['Delegator_mil'] = roles?.includes('Military Background') || pid === '202409102' ? 'yes' : 'no';
+                }
+                else {
+                    entryObj['Delegator_mil'] = res.results?.['Post-Scenario Measures']?.questions?.["Served in Military"]?.['response'] == 'Never Served' ? 'no' : 'yes';
+                }
                 entryObj['Delegator_Role'] = roles ?? '-'
                 if (Array.isArray(entryObj['Delegator_Role'])) {
                     entryObj['Delegator_Role'] = entryObj['Delegator_Role'].join('; ');

--- a/dashboard-ui/src/components/SurveyResults/resultsTable.css
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.css
@@ -334,6 +334,11 @@
     box-shadow: 24;
 }
 
+.delete-modal-box p {
+    text-align: center;
+}
+
+
 .deletion-header {
     text-align: center;
     border-bottom: 4px solid black;
@@ -348,13 +353,10 @@
 }
 
 .delete-table-container .itm-table td {
-    border: none;
-    border-right: 1px solid grey;
     padding: 12px 8px;
 }
 
-.delete-table-container .itm-table th td {
-    border: none;
+.delete-table-container .itm-table thead tr th {
     padding: 12px 8px !important;
 }
 
@@ -375,4 +377,23 @@
 .delete-column {
     min-width: 120px !important;
     width: 120px;
+}
+
+.type-to-delete {
+    display: flex;
+    flex-direction: column;
+    margin: auto;
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+}
+
+.delete-btn-group .downloadBtn:disabled {
+    color: white;
+    background-color: rgb(99, 99, 99);
+    opacity: 0.3 !important;
+    cursor: not-allowed;
+    transform: none;
+    pointer-events: none;
 }

--- a/dashboard-ui/src/components/SurveyResults/resultsTable.css
+++ b/dashboard-ui/src/components/SurveyResults/resultsTable.css
@@ -301,3 +301,78 @@
 .lowered-table {
     margin-top: 40px;
 }
+
+.delete-btn {
+    display: block;
+    margin: auto;
+    border: none;
+    background-color: transparent;
+    border-radius: 50%;
+    padding: 8px;
+}
+
+.delete-btn:hover {
+    background-color: rgba(167, 165, 165, 0.232);
+}
+
+.delete-btn:active {
+    background-color: rgba(110, 110, 110, 0.232);
+    color: rgb(188, 13, 13);
+}
+
+.delete-modal-box {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 50%;
+    min-width: 500px;
+    height: fit-content;
+    background-color: white;
+    border: 2px solid #000;
+    border-radius: 8px;
+    box-shadow: 24;
+}
+
+.deletion-header {
+    text-align: center;
+    border-bottom: 4px solid black;
+    padding: 16px;
+}
+
+.delete-table-container {
+    overflow: auto;
+    margin: 12px;
+    border: 3px solid black;
+    border-radius: 8px;
+}
+
+.delete-table-container .itm-table td {
+    border: none;
+    border-right: 1px solid grey;
+    padding: 12px 8px;
+}
+
+.delete-table-container .itm-table th td {
+    border: none;
+    padding: 12px 8px !important;
+}
+
+.delete-table-container .itm-table th {
+    padding: 0px;
+}
+
+.delete-btn-group {
+    display: flex;
+    justify-content: space-between;
+    margin: 12px;
+}
+
+.delete-btn-group button {
+    padding: 6px;
+}
+
+.delete-column {
+    min-width: 120px !important;
+    width: 120px;
+}

--- a/node-graphql/package.json
+++ b/node-graphql/package.json
@@ -20,6 +20,7 @@
     "express-graphql": "^0.12.0",
     "graphql": "^15.3.0",
     "graphql-query-complexity": "^1.0.0",
+    "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
     "mongodb": "^3.7.3",
     "mongoose": "^5.13.14",


### PR DESCRIPTION
The goal of this ticket is to allow ADMINS ONLY to delete participant data. Derek currently has a script that accomplishes this based on the date of testing, but this adds similar functionality to the UI.

The feature has been added to http://localhost:3000/participant-progress-table. 

Things to check:
- Non-admins should not see anything different. 
- Admins should now have an extra "Delete" column. 
- Delete functionality is only allowed for data that is at least 24 hours old (except sim data). The time is checked in the client code to show/hide the button, and also on the server side to prevent date manipulation. This check will make sure that we have the backed up data in case of an accidental deletion.
- You should need to type in the PID exactly as written in order to delete on the confirmation page
- Successful deletions should give a notification (bottom left corner), the table should refresh, and you should no longer see that data
- Text, Sim (raw and analyzed), Survey, and Participant Log data should all be deleted
- If anything goes wrong (play around with different ways to make this happen, like changing dates in mongo, or even changing the code to force an error on the client side or server side), an error message should appear in the bottom left corner that says the data was not deleted
- Nobody except for someone with a valid admin session should be able to access this new, very dangerous endpoint