### PR TITLE
Rq1 eval89 fixes

### DIFF
--- a/dashboard-ui/src/components/Research/utils.js
+++ b/dashboard-ui/src/components/Research/utils.js
@@ -486,7 +486,7 @@ export function getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dat
                     entryObj['Probe Set Observation'] = adjustScenarioNumber(
                         isMultiKdma ? adjustScenarioNumber(entryObj['Probe Set Assessment'], 3) : entryObj['Probe Set Assessment'], 3
                     );
-                    console.log(entryObj['Probe Set Observation'])
+                    
                     allProbeSetObservation.push(entryObj['Probe Set Observation'])
                     entryObj['Server Session ID (Delegator)'] = t === 'comparison' ? '-' : textResultsForPID[0]?.combinedSessionId;
                 }


### PR DESCRIPTION
[Ticket](https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?jql=assignee%20IN%20%2860ba425da547eb00686ee0ce%2C%20empty%29&selectedIssue=ITM-1111)
If you visit https://darpaitm.caci.com/research-results/rq1, you'll notice missing data in the `ADM|Target` column and the `Probe Set Observation` column (along with the accompanying dropdown). 

Go to http://localhost:3000/research-results/rq1, and those should now be populated. Let me know if anything else looks amiss and I will try to add a fix to it on this pr. 