### PR TITLE
Update endpoint name from dre to phase1

### DIFF
--- a/docker_setup/resources/nginx.conf
+++ b/docker_setup/resources/nginx.conf
@@ -169,7 +169,7 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
-    location /adept_dre/ {
+    location /adept_phase1/ {
      # proxy_pass CANNOT contain variable for this to work
       proxy_pass http://10.216.38.101:8087/;
       proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Already updated the server running at 8087 on production to be running at tag 3.9.9 instead of running a DRE version.

Will be hard to test this potentially only changing redirect URL name for Derek and UK collect.