### PR TITLE
ITM 1103: CACI Prolific Data Collection Testing Suite

### DIFF
--- a/dashboard-ui/.env
+++ b/dashboard-ui/.env
@@ -39,4 +39,4 @@ REACT_APP_SOARTECH_DRE_URL=https://darpaitm.caci.com/soartech_dre
 REACT_APP_EMAIL_SALT=j0Bpq6e1b0556pu935uBdu
 
 # changing this will automatically change the text version to a valid option
-REACT_APP_TEST_SURVEY_VERSION=5
+REACT_APP_TEST_SURVEY_VERSION=7

--- a/dashboard-ui/.env
+++ b/dashboard-ui/.env
@@ -39,4 +39,4 @@ REACT_APP_SOARTECH_DRE_URL=https://darpaitm.caci.com/soartech_dre
 REACT_APP_EMAIL_SALT=j0Bpq6e1b0556pu935uBdu
 
 # changing this will automatically change the text version to a valid option
-REACT_APP_TEST_SURVEY_VERSION=7
+REACT_APP_TEST_SURVEY_VERSION=5

--- a/dashboard-ui/src/__mocks__/testUtils.js
+++ b/dashboard-ui/src/__mocks__/testUtils.js
@@ -165,17 +165,26 @@ export async function startAdeptQualtrixSurvey(page) {
 }
 
 export async function startCaciProlificSurvey(page) {
+    const IS_PH1 = Number(process.env.REACT_APP_TEST_SURVEY_VERSION) <= 5;
     await page.goto(`${process.env.REACT_APP_TEST_URL}/remote-text-survey?caciProlific=true&PROLIFIC_PID=ALS_test1210b`);
     await page.waitForSelector('text/Consent Form', { timeout: 20000 });
     await page.$$eval('button', btns => {
         const b = Array.from(btns).find(x => x.innerText?.trim() === 'I Agree');
         b?.click();
     });
-    await page.waitForSelector('text/Instructions', { timeout: 20000 });
+    await page.waitForSelector('text/Instructions', { timeout: 30000 });
     await page.$$eval('button', btns => {
         const b = Array.from(btns).find(x => x.innerText?.trim() === 'Start');
         b?.click();
     });
+
+    if (IS_PH1) {
+        await page.waitForSelector('text/Page 1 of', { timeout: 30000 });
+        await page.waitForSelector('input[type="radio"]', { timeout: 30000 });
+    }
+    else {
+        await page.waitForSelector('text/Scenario Details', { timeout: 30000 });
+    }
 }
 
 export async function agreeToProlificConsent(page) {
@@ -216,13 +225,16 @@ export async function takePhase1TextScenario(page) {
     let scenarios = 0;
     while (scenarios < 5) {
         try {
-            await page.waitForSelector(`text/Page ${pageNum} of`, { timeout: 200 });
-        } catch (error) {
+            await page.waitForSelector(`text/Page ${pageNum} of`, { timeout: 2000 });
+        } 
+        catch (error) 
+        {
             if (error.name === 'TimeoutError') {
-                await page.waitForSelector(`text/Page 1 of`, { timeout: 100 });
+                await page.waitForSelector('text/Page 1 of', { timeout: 2000 });
                 scenarios += 1;
                 pageNum = 1;
-            } else {
+            } 
+            else  {
                 throw error;
             }
         }

--- a/dashboard-ui/src/__mocks__/testUtils.js
+++ b/dashboard-ui/src/__mocks__/testUtils.js
@@ -164,6 +164,31 @@ export async function startAdeptQualtrixSurvey(page) {
     await page.waitForSelector('text/Page 1 of', { timeout: 500 });
 }
 
+export async function startCaciProlificSurvey(page) {
+    await page.goto(`${process.env.REACT_APP_TEST_URL}/remote-text-survey?caciProlific=true&PROLIFIC_PID=ALS_test1210b`);
+    await page.waitForSelector('text/Consent Form', { timeout: 20000 });
+    await page.$$eval('button', btns => {
+        const b = Array.from(btns).find(x => x.innerText?.trim() === 'I Agree');
+        b?.click();
+    });
+    await page.waitForSelector('text/Instructions', { timeout: 20000 });
+    await page.$$eval('button', btns => {
+        const b = Array.from(btns).find(x => x.innerText?.trim() === 'Start');
+        b?.click();
+    });
+}
+
+export async function agreeToProlificConsent(page) {
+    try {
+        await page.waitForSelector('text/Consent Form', { timeout: 1000 });
+        await page.$$eval('button', btns => {
+            const b = Array.from(btns).find(x => x.innerText?.trim() === 'I Agree');
+            b?.click();
+        });
+    } catch (_) {
+    }
+}
+
 export async function pressAllKeys(page, uniqueExpectedText) {
     // https://pptr.dev/api/puppeteer.keyinput
     const keysToPress = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'Power', 'Eject', 'Abort', 'Help', 'Backspace', 'Numpad5', 'NumpadEnter',

--- a/dashboard-ui/src/__mocks__/testUtils.js
+++ b/dashboard-ui/src/__mocks__/testUtils.js
@@ -226,15 +226,12 @@ export async function takePhase1TextScenario(page) {
     while (scenarios < 5) {
         try {
             await page.waitForSelector(`text/Page ${pageNum} of`, { timeout: 2000 });
-        } 
-        catch (error) 
-        {
+        } catch (error) {
             if (error.name === 'TimeoutError') {
-                await page.waitForSelector('text/Page 1 of', { timeout: 2000 });
+                await page.waitForSelector(`text/Page 1 of`, { timeout: 2000 });
                 scenarios += 1;
                 pageNum = 1;
-            } 
-            else  {
+            } else {
                 throw error;
             }
         }

--- a/dashboard-ui/src/__tests__/CACIProlific.test.jsx
+++ b/dashboard-ui/src/__tests__/CACIProlific.test.jsx
@@ -1,0 +1,185 @@
+/**
+ * @jest-environment puppeteer
+ */
+
+import { pressAllKeys, takePhase1TextScenario, takePhase2TextScenario, startCaciProlificSurvey, agreeToProlificConsent } from "../__mocks__/testUtils";
+
+const IS_PH1 = Number(process.env.REACT_APP_TEST_SURVEY_VERSION) <= 5;
+const PROLIFIC_PID = "ALS_test1210b";
+const PROLIFIC_RETURN_URL = "https://app.prolific.com/submissions/complete?cc=C155IMPM";
+
+describe('Test CACI Prolific entry method', () => {
+    beforeEach(async () => {
+        page = await browser.newPage();
+    }, 30000);
+
+    it('/remote-text-survey?caciProlific=true shows consent and preserves PROLIFIC_PID', async () => {
+        await page.goto(`${process.env.REACT_APP_TEST_URL}/remote-text-survey?caciProlific=true&PROLIFIC_PID=${PROLIFIC_PID}`);
+        await page.waitForSelector('text/Consent Form', { timeout: 20000 });
+        await page.waitForSelector('text/I Agree', { timeout: 20000 });
+        await page.waitForSelector('text/I Do Not Agree', { timeout: 20000 });
+        await pressAllKeys(page, 'Consent Form');
+        await page.waitForSelector('text/Consent Form', { timeout: 2000 });
+        await page.$$eval('button', btns => {
+            const b = Array.from(btns).find(x => x.innerText?.trim() === 'I Agree');
+            b?.click();
+        });
+        await page.waitForSelector('text/Instructions', { timeout: 20000 });
+        await page.$$eval('button', btns => {
+            const b = Array.from(btns).find(x => x.innerText?.trim() === 'Start');
+            b?.click();
+        });
+        await page.waitForSelector(`text/${IS_PH1 ? 'Assess the shooter' : 'Scenario Details'}`, { timeout: 30000 });
+        const currentUrl = page.url();
+        expect(currentUrl.includes(`PROLIFIC_PID=${PROLIFIC_PID}`)).toBe(true);
+    }, 60000);
+
+    it('Clicking "I Do Not Agree" redirects to Prolific return URL', async () => {
+        await page.goto(`${process.env.REACT_APP_TEST_URL}/remote-text-survey?caciProlific=true&PROLIFIC_PID=${PROLIFIC_PID}`);
+        await page.waitForSelector('text/Consent Form', { timeout: 20000 });
+
+        const waitForReturnHit = page.waitForRequest(req => req.url() === PROLIFIC_RETURN_URL, { timeout: 20000 });
+        const clickDisagree = page.$$eval('button', btns => {
+          const b = Array.from(btns).find(x => x.innerText?.trim() === 'I Do Not Agree');
+          b?.click();
+        });
+        await Promise.all([waitForReturnHit, clickDisagree]);
+        
+        await page.waitForNavigation({ waitUntil: 'load', timeout: 20000 }).catch(() => {});
+        const finalUrl = page.url();
+        expect(
+          finalUrl.startsWith('https://app.prolific.com') ||
+          finalUrl.startsWith('https://auth.prolific.com')
+        ).toBe(true);
+    }, 30000);
+
+    it('any key combo during text scenario should have no effect on progress', async () => {
+        await startCaciProlificSurvey(page);
+        await pressAllKeys(page, IS_PH1 ? "Assess the shooter" : "Scenario Details");
+    }, 30000);
+
+    it('text-scenario through CACI Prolific should be navigable and end with survey', async () => {
+        await startCaciProlificSurvey(page);
+        if (IS_PH1) {
+            await takePhase1TextScenario(page);
+        } else {
+            await takePhase2TextScenario(page);
+        }
+        await page.waitForSelector('text/Please do not close your browser', { timeout: 500 });
+        await page.waitForSelector('text/In the final part of the study,', { timeout: 10000000 });
+        await pressAllKeys(page, 'In the final part of the study,');
+        // very long test because it connects to ST and ADEPT servers to send fake responses
+    }, 80000000);
+
+    it('any key combo during survey should have no effect on progress', async () => {
+        await page.goto(`${process.env.REACT_APP_TEST_URL}/remote-text-survey?caciProlific=true&startSurvey=true&PROLIFIC_PID=${PROLIFIC_PID}&pid=123`);
+        await agreeToProlificConsent(page);
+        await page.waitForSelector('text/In the final part of the study,', { timeout: 500 });
+        await pressAllKeys(page, 'In the final part of the study,');
+    }, 100000);
+
+    it('survey through CACI Prolific should be navigable', async () => {
+        await page.goto(`${process.env.REACT_APP_TEST_URL}/remote-text-survey?caciProlific=true&startSurvey=true&PROLIFIC_PID=${PROLIFIC_PID}&pid=123`);
+        await agreeToProlificConsent(page);
+        await page.waitForSelector('text/In the final part of the study,', { timeout: 500 });
+        await page.$$eval('input', buttons => {
+            Array.from(buttons).find(btn => btn.value == 'Next').click();
+        });
+
+        // phase 1 only
+        if (IS_PH1) {
+            await page.waitForSelector('text/Note that in some scenarios', { timeout: 50000 });
+            await page.$$eval('input', buttons => {
+                Array.from(buttons).find(btn => btn.value == 'Next').click();
+            });
+            await page.waitForSelector('text/Situation', { timeout: 500 });
+            let pageNum = 3;
+            let medics = 0;
+            while (medics < 3) {
+                await page.waitForSelector(`text/Page ${pageNum} of`, { timeout: 500 });
+                await page.focus('input[type="radio"]');
+                for (let i = 0; i < 4; i++) {
+                    await page.keyboard.press(' ');
+                    await page.keyboard.press('Tab');
+                }
+                await page.$$eval('input', buttons => {
+                    Array.from(buttons).find(btn => btn.value == 'Next').click();
+                });
+                medics += 1;
+                pageNum += 1;
+            }
+            // reached comparison page!
+            await page.waitForSelector('text/Medic-B21 vs Medic-V17', { timeout: 500 });
+            await page.waitForSelector('text/Medic-B16 vs Medic-B21', { timeout: 500 });
+            await page.focus('input[type="radio"]');
+            // two MC followed by short answer, twice
+            for (let i = 0; i < 2; i++) {
+                await page.keyboard.press(' ');
+                await page.keyboard.press('Tab');
+                await page.keyboard.press(' ');
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('m');
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+            }
+            await page.$$eval('input', buttons => {
+                Array.from(buttons).find(btn => btn.value == 'Next').click();
+            });
+        }
+        // reached post-scenario measures
+        await page.waitForSelector('text/What was the biggest influence on your delegation decision between different medics?', { timeout: 500 });
+        // answer short-text question
+        await page.keyboard.press('Tab');
+        await page.keyboard.press('m');
+        // answer initial radio questions
+        for (let i = 0; i < 9; i++) {
+            await page.keyboard.press('Tab');
+            await page.keyboard.press(' ');
+        }
+        // skip past roles
+        for (let i = 0; i < (IS_PH1 ? 8 : 9); i++) {
+            await page.keyboard.press('Tab');
+        }
+
+        if (!IS_PH1) {
+        // phase 2
+            await page.keyboard.press('m');
+            // answer the rest
+            for (let i = 0; i < 5; i++) {
+                await page.keyboard.press('Tab');
+                await page.keyboard.press(' ');
+            }
+            // skip past roles
+            for (let i = 0; i < 7; i++) {
+                await page.keyboard.press('Tab');
+            }
+            for (let i = 0; i < 2; i++) {
+                await page.keyboard.press('Tab');
+                await page.keyboard.press(' ');
+            }
+            await page.keyboard.press('m');
+            for (let i = 0; i < 2; i++) {
+                await page.keyboard.press('Tab');
+                await page.keyboard.press(' ');
+            }
+            // skip past environments
+            for (let i = 0; i < 7; i++) {
+                await page.keyboard.press('Tab');
+            }
+        }
+        for (let i = 0; i < 3; i++) {
+            await page.keyboard.press('Tab');
+            await page.keyboard.press(' ');
+        }
+        // don't leave to the external form, stay here!
+        page.on('dialog', async dialog => {
+            expect(dialog.message()).toContain('');
+            await dialog.dismiss();
+        });
+        await page.$$eval('input', buttons => {
+            Array.from(buttons).find(btn => btn.value == 'Complete').click();
+        });
+        await page.waitForSelector('text/Thank you for completing the survey', { timeout: 50000 });
+    }, 40000);
+
+});

--- a/dashboard-ui/src/__tests__/CACIProlific.test.jsx
+++ b/dashboard-ui/src/__tests__/CACIProlific.test.jsx
@@ -74,6 +74,11 @@ describe('Test CACI Prolific entry method', () => {
     it('any key combo during survey should have no effect on progress', async () => {
         await page.goto(`${process.env.REACT_APP_TEST_URL}/remote-text-survey?caciProlific=true&startSurvey=true&PROLIFIC_PID=${PROLIFIC_PID}&pid=123`);
         await agreeToProlificConsent(page);
+        const startSurveyUrl = page.url();
+        expect(startSurveyUrl.includes(`PROLIFIC_PID=${PROLIFIC_PID}`)).toBe(true);
+        const maybeInstructions = await page.$('text/Instructions');
+        expect(maybeInstructions).toBeNull();
+
         await page.waitForSelector('text/In the final part of the study,', { timeout: 500 });
         await pressAllKeys(page, 'In the final part of the study,');
     }, 100000);

--- a/dashboard-ui/src/__tests__/CACIProlific.test.jsx
+++ b/dashboard-ui/src/__tests__/CACIProlific.test.jsx
@@ -24,12 +24,18 @@ describe('Test CACI Prolific entry method', () => {
             const b = Array.from(btns).find(x => x.innerText?.trim() === 'I Agree');
             b?.click();
         });
-        await page.waitForSelector('text/Instructions', { timeout: 20000 });
+        await page.waitForSelector('text/Instructions', { timeout: 30000 });
         await page.$$eval('button', btns => {
             const b = Array.from(btns).find(x => x.innerText?.trim() === 'Start');
             b?.click();
         });
-        await page.waitForSelector(`text/${IS_PH1 ? 'Assess the shooter' : 'Scenario Details'}`, { timeout: 30000 });
+        if (IS_PH1) {
+            await page.waitForSelector('text/Page 1 of', { timeout: 30000 });
+            await page.waitForSelector('input[type="radio"]', { timeout: 30000 });
+        }
+        else {
+            await page.waitForSelector('text/Scenario Details', { timeout: 30000 });
+        }
         const currentUrl = page.url();
         expect(currentUrl.includes(`PROLIFIC_PID=${PROLIFIC_PID}`)).toBe(true);
     }, 60000);
@@ -55,7 +61,7 @@ describe('Test CACI Prolific entry method', () => {
 
     it('any key combo during text scenario should have no effect on progress', async () => {
         await startCaciProlificSurvey(page);
-        await pressAllKeys(page, IS_PH1 ? "Assess the shooter" : "Scenario Details");
+        await pressAllKeys(page, IS_PH1 ? "Page 1 of" : "Scenario Details");
     }, 30000);
 
     it('text-scenario through CACI Prolific should be navigable and end with survey', async () => {


### PR DESCRIPTION
**Original Ticket:** [Here](https://nextcentury.atlassian.net/browse/ITM-1103?atlOrigin=eyJpIjoiYjExMDMxMmNlOGI1NDkzYjgzODhmMjZkYjJhNTMxNTAiLCJwIjoiaiJ9)

## Description
This PR introduces a new test suite covering the CACI Prolific entry path to the text-based scenario survey. Previously, the existing `AdeptQualtrix.test.jsx` file in `/dashboard-ui/src/__tests__/AdeptQualtrix.test.jsx` tested the core functionality of the survey. However, it did not test the Prolific consent entry gate, which displays a consent form that the user must agree to before accessing the survey questions. This method of entry also changes `PID` logic, so that it is now maintained via a pass-through from the URL as opposed to being determined via online generation. This branch introduces `CACIProlific.test.jsx`, which mirrors the structure and flow of the existing `AdeptQualtrix.test.jsx` testing suite, however it adds coverage for the new consent gate. New tests in the suite verify that this consent form appears when `caciProlific=true`. It simulates clicking `Agree` to the form conditions (which proceeds either directly to scenarios when `startSurvey=true` or to the Instructions page if this is not the case. It also tests `Disagree` by ensuring redirection to the prolific return URL (`https://app.prolific.com/submissions/complete?cc=C155IMPM`). The testing suite developed walks through the full scenario flow and is compatible with both Phase 1 and Phase 2 survey versions. Finally, the test ensures that the same `PROLIFIC_PID` value initially generated is held throughout all steps of the survey. This provides comprehensive coverage to the Prolific entry gate that was previously not present. 

## Disclaimer
When testing my work locally, I noticed that Prolific redirects unauthenticated users from `app.prolific.com` to `auth.prolific.com`. To get around this and ensure that the redirection to the correct prolific return URL occurs, I added logic that asserts the outbound request is to the exact expected return URL before allowing landing on any other pages in the Prolific domain. This keeps the test deterministic and independent of changes made by Prolific.

## How To Test

1. From the root of the repository, run the terminal command `npm run setup-tests`. 
2. To save time and only run the new testing suite (instead of all testing suites in the test folder), first `cd dashboard-ui`. Then, run `npm test -- src/__tests__/CACIProlific.test.jsx`.
3. Wait for the test run to complete. The entire test suite should pass, displaying `6 passes, 6 total`. 
4. To verify the test suite is compatible with a Phase 1 survey version, change the value of the `REACT_APP_TEST_SURVEY_VERSION` variable in `.env` to 5 instead of 7 (following @kaitlyn-sharo's logic in #341). 
5. Re-run the command `npm test -- src/__tests__/CACIProlific.test.jsx`. All tests in the suite should still pass.
6. _(Bonus)_ Inspect the contents of the `CACIProlific.test.jsx` file. Ensure that the tests are equally as comprehensive as in the ADEPT Qualtrix suite and that the consent gate is tested thoroughly. 