### PR TITLE
ITM 1140

### DIFF
--- a/dashboard-ui/src/components/Research/utils.js
+++ b/dashboard-ui/src/components/Research/utils.js
@@ -478,8 +478,10 @@ export function getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dat
                             x['pid'] === pid &&
                             x['adm_scenario'] === page['scenarioIndex'] &&
                             x['adm_alignment_target'] === page['admTarget'] &&
+                            (evalNum !== 10 || x['text_scenario'].includes(entryObj['Attribute'])) &&
                             (page['scenarioIndex']?.includes('PS-AF') ? x['text_scenario']?.includes('PS-AF') : !x['text_scenario']?.includes('PS-AF'))
                         );
+                        console.log(comparison_entry)
                     }
                     let alignmentComparison;
                     // for the combined psaf block from eval 10 we need to collect the two separate comparisons

--- a/dashboard-ui/src/components/Research/utils.js
+++ b/dashboard-ui/src/components/Research/utils.js
@@ -472,7 +472,14 @@ export function getRQ134Data(evalNum, dataSurveyResults, dataParticipantLog, dat
                     if (evalNum < 8) {
                         comparison_entry = comparisons?.find((x) => x['ph1_server'] !== true && x['dre_server'] !== true && x['adm_type'] === t && x['pid'] === pid && getDelEnvMapping(res.results.surveyVersion)[entryObj['Scenario']].includes(x['adm_scenario']) && ((entry['TA2'] === 'Parallax' && x['adm_author'] === 'TAD') || (entry['TA2'] === 'Kitware' && x['adm_author'] === 'kitware')) && x['adm_scenario']?.toLowerCase().includes(entryObj['Attribute']?.toLowerCase()));
                     } else {
-                        comparison_entry = comparisons?.find((x) => (evalNum === 10 || x['adm_type'] === t) && x['pid'] === pid && x['adm_scenario'] === page['scenarioIndex'] && x['adm_alignment_target'] === page['admTarget']);
+                        // added in ternary to make sure single attribute and multi attribute comparisons are properly grabbed (eval 10) 
+                        comparison_entry = comparisons?.find((x) =>
+                            (evalNum === 10 || x['adm_type'] === t) &&
+                            x['pid'] === pid &&
+                            x['adm_scenario'] === page['scenarioIndex'] &&
+                            x['adm_alignment_target'] === page['admTarget'] &&
+                            (page['scenarioIndex']?.includes('PS-AF') ? x['text_scenario']?.includes('PS-AF') : !x['text_scenario']?.includes('PS-AF'))
+                        );
                     }
                     let alignmentComparison;
                     // for the combined psaf block from eval 10 we need to collect the two separate comparisons


### PR DESCRIPTION
[Ticket](https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?jql=assignee%20IN%20%2860ba425da547eb00686ee0ce%2C%20empty%29&selectedIssue=ITM-1140)

Some of the single attribute comparison scores in the RQ134 table for the September collaboration were populated with the wrong scores. The participants' scores on the PS-AF multi-attribute text scenario set were scored separately from their scores on the single-attribute text scenario sets. However, our `.find` method to grab the comparison score sometimes accidentally retrieved the comparison of that participant's multi-attribute assessment compared to the target ADM instead of the single attribute score compared to the target ADM.

I put in a console log (to be removed) to assist in confirming that the correct scores are being pulled. 

<img width="831" height="595" alt="Screenshot 2025-09-30 at 1 07 20 PM" src="https://github.com/user-attachments/assets/28d7f0b1-eb25-4dbf-a81e-b310a0f61f73" />

You should now see that the resulting documents come from the participant's single attribute text assessments, and not the multi-attribute set. You should not see any documents that have a `text_scenario` field of `Sept2025-PS-AF2-eval` or `Sept2025-PS-AF1-eval` unless, of course, it corresponds to a multi-attribute comparison: 
<img width="404" height="147" alt="Screenshot 2025-09-30 at 1 09 01 PM" src="https://github.com/user-attachments/assets/de99d66d-4169-491e-9469-32b1de41d1f3" />
