### PR TITLE
PS-AF Text Results Fix

### DIFF
--- a/dashboard-ui/src/components/App/setupUtils.js
+++ b/dashboard-ui/src/components/App/setupUtils.js
@@ -58,8 +58,7 @@ export function setupTextBasedConfig(data) {
     
     for (const config of data.getAllTextBasedConfigs) {
         let tempConfig = JSON.parse(JSON.stringify(config));
-        
-        if (hasTextBasedImages && tempConfig.eval !== 'mre-eval') {
+        if (hasTextBasedImages && tempConfig.eval !== 'mre-eval' && tempConfig.pages && Array.isArray(tempConfig.pages)) {
             for (const page of tempConfig.pages) {
                 for (const el of page.elements) {
                     if (Object.keys(el).includes("patients")) {

--- a/dashboard-ui/src/components/TextBasedResults/TextBasedResultsPage.jsx
+++ b/dashboard-ui/src/components/TextBasedResults/TextBasedResultsPage.jsx
@@ -314,7 +314,7 @@ function ParticipantView({ data, scenarioName, textBasedConfigs, selectedEval, p
 
         const allHeaders = [...fixedHeaders, ...dynamicHeaders];
         const allData = Array.from(participantDataMap.values())
-            .map(row => allHeaders.reduce((acc, header) => ({ ...acc, [header]: row[header] || '' }), {}))
+            .map(row => allHeaders.reduce((acc, header) => ({ ...acc, [header]: row[header] !== undefined ? row[header] : '' }), {}))
             .sort((a, b) => a['Participant ID'].localeCompare(b['Participant ID'], undefined, { numeric: true, sensitivity: 'base' }));
 
         const ws = XLSX.utils.json_to_sheet(allData, { header: allHeaders });

--- a/dashboard-ui/src/components/TextBasedResults/TextBasedResultsPage.jsx
+++ b/dashboard-ui/src/components/TextBasedResults/TextBasedResultsPage.jsx
@@ -293,9 +293,14 @@ function ParticipantView({ data, scenarioName, textBasedConfigs, selectedEval, p
         };
 
         const scenariosToProcess = allScenarios
-            ? scenarioOptions.filter(scenario =>
-                !attribute || new RegExp(`\\b${attribute}\\d*\\b`, 'i').test(scenario)
-            )
+            ? scenarioOptions.filter(scenario => {
+                if (!attribute) return true;
+
+                const match = scenario.match(/-(PS-AF|AF|MF|PS|SS)\d*-eval/i);
+                const scenarioAttr = match ? match[1] : null;
+
+                return scenarioAttr && scenarioAttr.toUpperCase() === attribute.toUpperCase();
+            })
             : [singleScenario];
 
         for (const scenario of scenariosToProcess) {

--- a/dashboard-ui/src/components/TextBasedResults/util.js
+++ b/dashboard-ui/src/components/TextBasedResults/util.js
@@ -92,4 +92,4 @@ export function shortenAnswer(answer) {
     }
 }
 
-export const p2Attributes = ['AF', 'MF', 'SS', 'PS']
+export const p2Attributes = [ 'PS-AF', 'AF', 'MF', 'SS', 'PS']


### PR DESCRIPTION
[Ticket](https://nextcentury.atlassian.net/jira/software/projects/ITM/boards/116?jql=assignee%20%3D%2060ba425da547eb00686ee0ce&selectedIssue=ITM-1141)

http://localhost:3000/text-based-results

The PS-AF text results section (under September collab) was not downloading correctly. The probe names in the column headers were also not properly adhering to the format we had for the other scenarios. You should now see table headers such as `Probe-PS-AF-207-Resp`.

Check the `Download All PS-AF Results` spreadsheet as well as `Download Scenario Results` spreadsheet. Both should now populate with all of the participant responses. The prior download should also correctly denote which of the two PS-AF sets the participant saw (this can be checked using the `participantLog` collection ex. `{ ParticipantID: 202509110 }`)