### PR TITLE
ITM-1234: Sticky evaluation selector

### DIFF
--- a/dashboard-ui/src/components/Research/ExploratoryAnalysis.jsx
+++ b/dashboard-ui/src/components/Research/ExploratoryAnalysis.jsx
@@ -11,16 +11,19 @@ import { HumanVariability } from './tables/humanVariability';
 import { BlockedTable } from './tables/BlockedTable';
 import { CalibrationData } from './tables/CalibrationData';
 import { PAGES, getEvalOptionsForPage } from './utils';
+import { useSelector, useDispatch } from 'react-redux'
+import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
 export function ExploratoryAnalysis() {
     const evalOptions = getEvalOptionsForPage(PAGES.EXPLORATORY_ANALYSIS);
-    const evalRQ1Options = getEvalOptionsForPage(PAGES.RQ1); 
+    const evalRQ1Options = getEvalOptionsForPage(PAGES.RQ1);
+    const dispatch = useDispatch()
+    const storedEval = useSelector(state => state.configs.selectedResearchEval) 
 
-    const [selectedEval, setSelectedEval] = React.useState(evalOptions[0].value);
+    const selectedEval = storedEval ?? evalOptions[0].value
     function selectEvaluation(target) {
-        setSelectedEval(target.value);
+        dispatch(setSelectedResearchEval(target.value))
     }
-
     // Extract all evaluation values that have an RQ1 page to conditionally render RQ4 content 
     const rq1Values = evalRQ1Options.map(option => option.value); 
     const hasRQ1Page = rq1Values.includes(selectedEval);

--- a/dashboard-ui/src/components/Research/RQ1.jsx
+++ b/dashboard-ui/src/components/Research/RQ1.jsx
@@ -7,18 +7,22 @@ import rq1CodePh1 from './rcode/code_for_dashboard_RQ1_ph1.R';
 import { Button, Modal } from 'react-bootstrap';
 import { RCodeModal } from "./rcode/RcodeModal";
 import { PAGES, getEvalOptionsForPage } from './utils';
+import { useSelector, useDispatch } from 'react-redux'
+import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
 export function RQ1() {
     const evalOptions = getEvalOptionsForPage(PAGES.RQ1);
+    const dispatch = useDispatch()
+    const storedEval = useSelector(state => state.configs.selectedResearchEval)
 
     const [rq1CodeShowing, setRQ1CodeShowing] = React.useState(false);
 
     const close1Code = () => {
         setRQ1CodeShowing(false);
     }
-    const [selectedEval, setSelectedEval] = React.useState(evalOptions[0].value);
+    const selectedEval = storedEval ?? evalOptions[0].value
     function selectEvaluation(target) {
-        setSelectedEval(target.value);
+        dispatch(setSelectedResearchEval(target.value))
     }
     return (<div className="researchQuestion">
         <div className="rq-selection-section">

--- a/dashboard-ui/src/components/Research/RQ2.jsx
+++ b/dashboard-ui/src/components/Research/RQ2.jsx
@@ -12,16 +12,20 @@ import { RCodeModal } from "./rcode/RcodeModal";
 import { MultiKDMA_RQ23 as MultiKdmaRq23 } from './tables/rq23_multiKDMA';
 import { PH2RQ2223 } from './tables/ph2_rq22-rq23';
 import { PAGES, getEvalOptionsForPage } from './utils';
+import { useSelector, useDispatch } from 'react-redux'
+import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
 export function RQ2() {
     const evalOptions = getEvalOptionsForPage(PAGES.RQ2);
+    const dispatch = useDispatch()
+    const storedEval = useSelector(state => state.configs.selectedResearchEval)
 
     const [rq21CodeShowing, setRQ21CodeShowing] = React.useState(false);
     const [rq2CodeShowing, setRQ2CodeShowing] = React.useState(false);
-    const [selectedEval, setSelectedEval] = React.useState(evalOptions[0].value);
+    const selectedEval = storedEval ?? evalOptions[0].value
 
     function selectEvaluation(target) {
-        setSelectedEval(target.value);
+        dispatch(setSelectedResearchEval(target.value))
     }
 
     const close21Code = () => {

--- a/dashboard-ui/src/components/Research/RQ3.jsx
+++ b/dashboard-ui/src/components/Research/RQ3.jsx
@@ -9,15 +9,19 @@ import rq32CodePh1 from './rcode/code_for_dashboard_RQ32_ph1.R';
 import rq31CodePh1 from './rcode/code_for_dashboard_RQ31_and_RQ33_ph1.R';
 import { Button, Modal } from 'react-bootstrap';
 import { PAGES, getEvalOptionsForPage } from './utils';
+import { useSelector, useDispatch } from 'react-redux'
+import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
 export function RQ3() {
     const evalOptions = getEvalOptionsForPage(PAGES.RQ3);
+    const dispatch = useDispatch()
+    const storedEval = useSelector(state => state.configs.selectedResearchEval)
 
     const [rq32CodeShowing, setRQ32CodeShowing] = React.useState(false);
     const [rq31CodeShowing, setRQ31CodeShowing] = React.useState(false);
-    const [selectedEval, setSelectedEval] = React.useState(evalOptions[0].value);
+    const selectedEval = storedEval ?? evalOptions[0].value
     function selectEvaluation(target) {
-        setSelectedEval(target.value);
+        dispatch(setSelectedResearchEval(target.value))
     }
 
     const close32Code = () => {

--- a/dashboard-ui/src/store/slices/configSlice.js
+++ b/dashboard-ui/src/store/slices/configSlice.js
@@ -8,6 +8,7 @@ const configSlice = createSlice({
         currentSurveyVersion: null,
         currentTextEval: null,
         currentStyle: null,
+        selectedResearchEval: null,
         evals: [],
         pidBounds: {
             lowPid: null,
@@ -41,10 +42,13 @@ const configSlice = createSlice({
         },
         setShowDemographics: (state, action) => {  
             state.showDemographics = action.payload;
+        },
+        setSelectedResearchEval: (state, action) => {
+            state.selectedResearchEval = action.payload
         }
     }
 });
 
-export const { addConfig, addTextBasedConfig, setCurrentSurveyVersion, setCurrentTextEval, setCurrentStyle, setEvals, setPidBounds, setShowDemographics } = configSlice.actions;
+export const { addConfig, addTextBasedConfig, setCurrentSurveyVersion, setCurrentTextEval, setCurrentStyle, setEvals, setPidBounds, setShowDemographics, setSelectedResearchEval } = configSlice.actions;
 export default configSlice.reducer;
 


### PR DESCRIPTION
The evaluation selector on pages RQ1, RQ2, RQ3, and Exploratory Analysis will now persist between those pages.

To test:

Navigate to a research page and select an evaluation from the drop down:
<img width="1903" height="694" alt="image" src="https://github.com/user-attachments/assets/c417c6c6-9f38-4499-8a04-fcdf54e62bad" />

Navigate to a new research page and confirm that the evaluation selector is still the evaulation you selected from the previous page, in this case RQ1 and RQ2 both have the June evaluations so the selection persists:
<img width="1914" height="668" alt="image" src="https://github.com/user-attachments/assets/522aafeb-b1eb-49a6-9253-2f95533a9f36" />

Also test selections that are not present in other pages to see if the selector defaults to the most current evaluation.

I did explore adding this functionality to other parts of the dashboard but that can be added on in the future if requested. For now this will only affect the Data Analysis grouping
