### PR TITLE
Itm 1319: Make email required for create account

### DIFF
--- a/dashboard-ui/src/components/Account/adminPage.jsx
+++ b/dashboard-ui/src/components/Account/adminPage.jsx
@@ -405,9 +405,10 @@ function ApprovalTable({ unapproved, updateUnapproved, caller }) {
                     </thead>
                     <tbody>
                         {unapproved.map((user) => {
+                            console.log(user)
                             return (
                                 <tr key={user._id}>
-                                    <td>{user.emails[0]?.address}</td>
+                                    <td>{user.emails?.[0]?.address}</td>
                                     <td>{user.username}</td>
                                     <td><Switch onChange={(e) => updateUserStatus(user._id, 'admin', e)} /></td>
                                     <td><Switch onChange={(e) => updateUserStatus(user._id, 'evaluator', e)} /></td>

--- a/dashboard-ui/src/components/Account/adminPage.jsx
+++ b/dashboard-ui/src/components/Account/adminPage.jsx
@@ -405,7 +405,6 @@ function ApprovalTable({ unapproved, updateUnapproved, caller }) {
                     </thead>
                     <tbody>
                         {unapproved.map((user) => {
-                            console.log(user)
                             return (
                                 <tr key={user._id}>
                                     <td>{user.emails?.[0]?.address}</td>

--- a/node-graphql/server.mongo.js
+++ b/node-graphql/server.mongo.js
@@ -38,7 +38,14 @@ const connection = mongoose.connect('mongodb://dashboard-mongo:27030/dashboard',
 
 const dashboardDB = new Mongo(mongoose.connection);
 
-const accountsPassword = new AccountsPassword({});
+const accountsPassword = new AccountsPassword({
+  validateNewUser: (user) => {
+    if (!user.email || !user.email.trim()) {
+      throw new Error('Email is required');
+    }
+    return user;
+  }
+});
 
 const accountsServer = new AccountsServer(
   {

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -1042,7 +1042,7 @@ const resolvers = {
           return (milliseconds / (1000 * 60 * 60)) >= 24;
         };
         const now = new Date();
-        const allOldEnough = true;
+        let allOldEnough = true;
 
         // check that pid was created at least 24 hours ago
         for (const doc of foundPlog) {

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -124,7 +124,7 @@ const resolvers = {
     checkUserExists: async (obj, args, context, infow) => {
       const userByEmail = await context.db.collection('users').findOne({
         $or: [
-          { "emails.address": { $regex: `^${args.email.toLowerCase().trim()}$`, $options: 'i' } },
+          { "emails.address": args.email.toLowerCase().trim() },
           { "username": { $regex: `^${args.username.toLowerCase().trim()}$`, $options: 'i' } }
         ]
       });


### PR DESCRIPTION
CACI did some pen testing and was able to create some accounts without email addresses. This caused the admin page to crash on production due to undefined references. This pr adds in some option chaining so the page doesn't crash (we can then delete these accounts from the production admin page). 

I also added in some server-side validation. We were only validating on the client side, which is presumably how they exploited the system.

Go to https://darpaitm.caci.com/admin and enter your password. The page will crash.

Go to http://localhost:3000/admin and enter your password. It will not. 