### PR TITLE
Itm 1320: Online-Only Experiment April 2026

### DIFF
--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -510,7 +510,7 @@ export function ParticipantProgressTable({ canViewProlific = false, isAdmin = fa
                 textThreshold = 5;
             }
 
-            const delThreshold = isUK ? 3 : (isPH2OrUK && dataSet['_evalNumber'] !== 10) ? 5 : 4;
+            const delThreshold = isUK ? 3 : (isPH2OrUK && ![10, 16].includes(dataSet['_evalNumber'])) ? 5 : 4;
             if ((header === 'Delegation' && val >= delThreshold) ||
                 (header === 'Text' && val == textThreshold) ||
                 (header === 'Sim Count' && (val === 4 || (isPH2OrUK && val === 2)))) {

--- a/dashboard-ui/src/components/OnlineOnly/OnlineOnly.jsx
+++ b/dashboard-ui/src/components/OnlineOnly/OnlineOnly.jsx
@@ -38,6 +38,23 @@ export default function StartOnline() {
 
     const createParticipantAndRedirect = async () => {
         const result = await refetch();
+        const currentSearchParams = new URLSearchParams(location.search);
+        const existingPid = currentSearchParams.get('pid');
+
+        // reached using survey link from progress table
+        if (existingPid) {
+            const matchedLog = result.data.getParticipantLog.find(
+                log => String(log['ParticipantID']) === existingPid
+            );
+            if (matchedLog) {
+                currentSearchParams.set('class', 'Online');
+                history.push({
+                    pathname: '/text-based',
+                    search: `?${currentSearchParams.toString()}`,
+                });
+                return;
+            }
+        }
         const evalNumber = evalNameToNumber[currentTextEval]
 
         const lowPid = pidBounds.lowPid;
@@ -49,8 +66,6 @@ export default function StartOnline() {
             x.ParticipantID >= lowPid && x.ParticipantID <= highPid
         ).map((x) => Number(x['ParticipantID'])), lowPid - 1) + 1;
         
-        // get correct plog data
-        const currentSearchParams = new URLSearchParams(location.search);
         const participantDataFunctions = {
             16: aprilParticipantData,
             15: febParticipantData,

--- a/dashboard-ui/src/components/Survey/dynamicPhase2.jsx
+++ b/dashboard-ui/src/components/Survey/dynamicPhase2.jsx
@@ -76,24 +76,6 @@ const DynamicPhase2 = ({ rows, scenarioDescription, supplies, options }) => {
         return currentOptions !== prevOptions;
     };
 
-    const renderSupplies = () => {
-        if (!supplies || supplies.length === 0) return null;
-
-        return (
-            <div className="supplies-section">
-                <h5 className="supplies-title">Supplies</h5>
-                <div className="supplies-grid">
-                    {supplies.map((supply, index) => (
-                        <div key={index} className="supply-item">
-                            <span className="supply-name">{supply.type}</span>
-                            <span className="supply-quantity">Qty: {supply.quantity}</span>
-                        </div>
-                    ))}
-                </div>
-            </div>
-        );
-    };
-
     const scenarioStripTexts = [
         'There are two patients, Patient A and Patient B, and you only have time to treat one of them.',
     ];
@@ -127,9 +109,6 @@ const DynamicPhase2 = ({ rows, scenarioDescription, supplies, options }) => {
     return (
         <Container className="py-4" style={{ maxWidth: '1200px', width: '100%' }}>
             {renderInstructions()}
-            {/*
-            {renderSupplies()}
-            */}
 
             <Table className="table-borderless decision-table">
                 <thead>
@@ -148,7 +127,7 @@ const DynamicPhase2 = ({ rows, scenarioDescription, supplies, options }) => {
                         const showGroupHeader = isNewGroup(index);
                         const groupPrompt = row.trailingKey ? trailingTextMap[row.trailingKey] : null;
 
-                        // 🔹 apply transformation here
+                        // apply transformation here
                         const cleanedRowText = transformRowText(row.strippedDescription, groupPrompt);
 
                         return (

--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -642,6 +642,7 @@ class SurveyPage extends Component {
             if (postScenarioPage) {
                 finalPages.push(postScenarioPage);
             }
+            console.log(finalPages)
             this.surveyConfigClone.pages = finalPages;
             this.setState({ orderLog: finalPages.map(page => page.name) });
 

--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -633,7 +633,7 @@ class SurveyPage extends Component {
             const getVersion = (type) => type.startsWith('MF') === isEven ? 'A' : 'B';
 
             const allBlocks = ['AF-PS', 'MF-PS', 'MF', 'AF']
-                .map(type => createScenarioBlockv11(type, allPages, participantTextResults, getVersion(type)))
+                .map(type => createScenarioBlockv11(type, allPages, participantTextResults, getVersion(type), this.state.onlineOnly))
                 .filter(Boolean);// null check
 
             const selectedPages = shuffle(allBlocks).flatMap(block => block.pages);

--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -642,7 +642,7 @@ class SurveyPage extends Component {
             if (postScenarioPage) {
                 finalPages.push(postScenarioPage);
             }
-            console.log(finalPages)
+
             this.surveyConfigClone.pages = finalPages;
             this.setState({ orderLog: finalPages.map(page => page.name) });
 

--- a/dashboard-ui/src/components/Survey/surveyUtils.js
+++ b/dashboard-ui/src/components/Survey/surveyUtils.js
@@ -2142,7 +2142,5 @@ const genComparisonPagev11 = (primary, secondary, leastAligned, isOracle = false
 
 const onlineOnlyTitles = {
     'A': 'If you had to triage a similar scenario with 18-20 patients, how would you allocate decision-making responsibilities with the medic above?',
-    'B': 'Waves of 8-10 patients are being discovered, requiring medical assistance. If you had to \
-            triage the next wave of patients, knowing there are more coming, and the medic above \
-            was available, how would you allocate responsibilities?'
+    'B': 'Waves of 8-10 patients are being discovered, requiring medical assistance. If you had to triage the next wave of patients, knowing there are more coming, and the medic above was available, how would you allocate responsibilities?'
 }

--- a/dashboard-ui/src/components/Survey/surveyUtils.js
+++ b/dashboard-ui/src/components/Survey/surveyUtils.js
@@ -1944,7 +1944,7 @@ const haveSameResponses = (page1, page2) => {
         Object.keys(responses1).every(k => responses1[k] === responses2[k]);
 };
 
-export const createScenarioBlockv11 = (scenarioType, allPages, textResults, delVersion) => {
+export const createScenarioBlockv11 = (scenarioType, allPages, textResults, delVersion, onlineOnly=false) => {
     const subpop = textResults.find(result => result.scenario_id === 'April2026-subpopulation')?.subPopResult;
     if (!subpop) { console.warn("Couldn't find subpopulation group in text result documents " + textResults); }
 
@@ -2030,11 +2030,21 @@ export const createScenarioBlockv11 = (scenarioType, allPages, textResults, delV
     }
 
     // enforce delVersion
+    // also updates question text if online only version
     const removeVersion = delVersion === 'A' ? 'Del Version B' : 'Del Version A';
+    const keepVersion = `Del Version ${delVersion}`;
+
     admPages.forEach(page => {
-        if (page?.elements) {
-            page.elements = page.elements.filter(el => !el.name?.includes(removeVersion));
-        }
+        if (!page?.elements) return;
+
+        page.elements = page.elements.filter(el => {
+            if (el.name?.includes(removeVersion)) return false;
+            if (onlineOnly && el.name?.includes(keepVersion)) {
+                el.title = onlineOnlyTitles[delVersion];
+                el.name = el.name.replace('(in-person)', '(online)');
+            }
+            return true;
+        });
     });
 
     return {
@@ -2128,4 +2138,11 @@ const genComparisonPagev11 = (primary, secondary, leastAligned, isOracle = false
     }
 
     return metadata;
+}
+
+const onlineOnlyTitles = {
+    'A': 'If you had to triage a similar scenario with 18-20 patients, how would you allocate decision-making responsibilities with the medic above?',
+    'B': 'Waves of 8-10 patients are being discovered, requiring medical assistance. If you had to \
+            triage the next wave of patients, knowing there are more coming, and the medic above \
+            was available, how would you allocate responsibilities?'
 }

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -227,6 +227,16 @@ class TextBasedScenariosPage extends Component {
             const configCopy = JSON.parse(JSON.stringify(demographicsConfig));
             configCopy.showTitle = false;
 
+            if (this.state.onlineOnly) {
+                configCopy.pages.forEach(page => {
+                    if (page.elements) {
+                        page.elements = page.elements.filter(el =>
+                            !el.name?.toLowerCase().includes('virtual reality')
+                        );
+                    }
+                });
+            }
+
             const surveyModel = new Model(configCopy);
             surveyModel.applyTheme(surveyTheme);
             surveyModel.onComplete.add(this.demographicsSurveyComplete);

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -227,16 +227,12 @@ class TextBasedScenariosPage extends Component {
             const configCopy = JSON.parse(JSON.stringify(demographicsConfig));
             configCopy.showTitle = false;
 
-            if (this.state.onlineOnly) {
-                configCopy.pages.forEach(page => {
-                    if (page.elements) {
-                        page.elements = page.elements.filter(el =>
-                            !el.name?.toLowerCase().includes('virtual reality')
-                        );
-                    }
-                });
+            if (this.state.onlineOnly && configCopy.pages?.elements) {
+                configCopy.pages.elements = configCopy.pages.elements.filter(el =>
+                    !el.name?.toLowerCase().includes('virtual reality')
+                );
             }
-
+        
             const surveyModel = new Model(configCopy);
             surveyModel.applyTheme(surveyTheme);
             surveyModel.onComplete.add(this.demographicsSurveyComplete);


### PR DESCRIPTION
Make sure your `.env` file is pointed at your local instance of the ADEPT server. 

This pr has slight changes to the survey and demographics questions for the online-only route of this experiment. 

http://localhost:3000/remote-text-survey?caciProlific=true&PROLIFIC_PID=ALS_test1210b

This link should take you to the consent form and then begin the text-based scenarios. Upon completing the text-based scenarios, you should be redirected to the delegation survey after your results have been processed by the ADEPT server. (Note: to speed this process up, we deleted many unnecessary targets from `data/alignment_target/feb2026` on production, but you do not need to do that.)

At this point, I would like you to close the tab and go to http://localhost:3000/participant-progress-table so we can test the survey link functionality. The idea being that if a participant closes out of a tab, or there is ever a timeout issue, we can send them this link to take them back directly to the delegation survey portion. Locate the row created from you completing the text-based scenarios and click `Copy Link`. Then enter this in the browser URL. You should be taken directly to the delegation survey. 
<img width="1329" height="72" alt="Screenshot 2026-04-17 at 2 15 02 PM" src="https://github.com/user-attachments/assets/2b553d21-1e35-46ef-8988-1ee26572c32c" />

I have left a console log containing all of the loaded pages so that the loading can be verified using their results in `userScenarioResults`. I will delete this before merging. Upon completion, the page should automatically redirect back to prolific. 