### PR TITLE
ITM-1347 Add server side filtering to OW Part 1

### DIFF
--- a/dashboard-ui/src/components/Research/tables/ph2_rq8_ow_part1.jsx
+++ b/dashboard-ui/src/components/Research/tables/ph2_rq8_ow_part1.jsx
@@ -11,8 +11,8 @@ import owPart1Defs from '../variables/Variable Definitions RQ8_OW_Part1.xlsx';
 
 
 const getAdmData = gql`
-    query getAdmHistoryByScenario($evalNumber: Float!, $scenarioIDs: [ID]){
-        getAdmHistoryByScenario(evalNumber: $evalNumber, scenarioIDs: $scenarioIDs)
+    query getAllOWData($evalNumber: Float!, $scenarioIDs: [ID]){
+        getAllOWData(evalNumber: $evalNumber, scenarioIDs: $scenarioIDs)
     }`;
 
 const OW_ADM_SESSIONS = {
@@ -53,13 +53,13 @@ export function PH2RQ8OWPart1() {
     const closeModal = () => setShowDefinitions(false);
 
     React.useEffect(() => {
-        if (!data8?.getAdmHistoryByScenario || !data15?.getAdmHistoryByScenario) return;
+        if (!data8?.getAllOWData || !data15?.getAllOWData) return;
         const allObjs = [];
         const allOwScenarios = [];
         const allTargets = [];
         const dataByEval = {
-            8: data8.getAdmHistoryByScenario,
-            15: data15.getAdmHistoryByScenario
+            8: data8.getAllOWData,
+            15: data15.getAllOWData
         };
         for (const currentEvalNum of OW_EVALS) {
             const rawData = dataByEval[currentEvalNum];

--- a/dashboard-ui/src/components/Research/tables/ph2_rq8_ow_part1.jsx
+++ b/dashboard-ui/src/components/Research/tables/ph2_rq8_ow_part1.jsx
@@ -11,8 +11,8 @@ import owPart1Defs from '../variables/Variable Definitions RQ8_OW_Part1.xlsx';
 
 
 const getAdmData = gql`
-    query getAllHistoryByEvalNumber($evalNumber: Float!){
-        getAllHistoryByEvalNumber(evalNumber: $evalNumber)
+    query getAdmHistoryByScenario($evalNumber: Float!, $scenarioIDs: [ID]){
+        getAdmHistoryByScenario(evalNumber: $evalNumber, scenarioIDs: $scenarioIDs)
     }`;
 
 const OW_ADM_SESSIONS = {
@@ -39,8 +39,8 @@ const getOWScenario = (scenarioId, evalNum) => {
 };
 
 export function PH2RQ8OWPart1() {
-    const { loading: loading8, error: error8, data: data8 } = useQuery(getAdmData, { variables: { evalNumber: 8 } });
-    const { loading: loading15, error: error15, data: data15 } = useQuery(getAdmData, { variables: { evalNumber: 15 } });
+    const { loading: loading8, error: error8, data: data8 } = useQuery(getAdmData, { variables: { evalNumber: 8, scenarioIDs: ["June2025-OW_desert", "June2025-OW_urban"] } });
+    const { loading: loading15, error: error15, data: data15 } = useQuery(getAdmData, { variables: { evalNumber: 15, scenarioIDs: ["Feb2026-OW_desert", "Feb2026-OW_urban"] } });
     const [formattedData, setFormattedData] = React.useState([]);
     const [filteredData, setFilteredData] = React.useState([]);
     const [showDefinitions, setShowDefinitions] = React.useState(false);
@@ -53,13 +53,13 @@ export function PH2RQ8OWPart1() {
     const closeModal = () => setShowDefinitions(false);
 
     React.useEffect(() => {
-        if (!data8?.getAllHistoryByEvalNumber || !data15?.getAllHistoryByEvalNumber) return;
+        if (!data8?.getAdmHistoryByScenario || !data15?.getAdmHistoryByScenario) return;
         const allObjs = [];
         const allOwScenarios = [];
         const allTargets = [];
         const dataByEval = {
-            8: data8.getAllHistoryByEvalNumber,
-            15: data15.getAllHistoryByEvalNumber
+            8: data8.getAdmHistoryByScenario,
+            15: data15.getAdmHistoryByScenario
         };
         for (const currentEvalNum of OW_EVALS) {
             const rawData = dataByEval[currentEvalNum];

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -28,6 +28,7 @@ const typeDefs = gql`
     getHistory(id: ID): JSON @complexity(value: 10)
     getAllHistory(id: ID): [JSON] @complexity(value: 150)
     getAllHistoryByEvalNumber(evalNumber: Float, showMainPage: Boolean): [JSON] @complexity(value: 75)
+    getAdmHistoryByScenario(evalNumber: Float, scenarioID: ID): [JSON] @complexity(value: 75)
     getGroupAdmAlignmentByEval(evalNumber: Float): [JSON] @complexity(value: 80)
     getAllEvalData: [JSON] @complexity(value: 10)
     getEvalIdsForAllHistory: [JSON] @complexity(value: 10)
@@ -733,6 +734,45 @@ const resolvers = {
       }
     }
   },
+    getAdmHistoryByScenario: async (obj, args, context, inflow) => {
+      const docs = await context.db.collection('admTargetRuns').find({ "evalNumber": args["evalNumber"], "evaluation.scenario_id": { $in: args["scenarioID"] } }, {
+        projection: {
+          "synthetic": 1,
+          "probe_ids": 1,
+          "probes": 1,
+          "scenario": 1,
+          "alignment_target": 1,
+          "evaluation": 1,
+          "results": 1,
+          "adm_name": 1,
+          "oracle_alignment": 1,
+          "history.parameters.adm_name": 1,
+          "history.response.id": 1,
+          "history.parameters.target_id": 1,
+          "history.response.kdma_values.value": 1,
+          "history.parameters.target_id": 1,
+          "history.response.score": 1,
+          "history.response.distance_based_score": 1,
+          "history.response.dre_alignment.score": 1,
+          "history.parameters.session_id": 1,
+          "history.parameters.dreSessionId": 1,
+          "history.command": 1,
+          "history.parameters.probe_id": 1
+        }
+      }).toArray();
+      return docs.map(doc => {
+        if (!Array.isArray(doc.probe_ids) || doc.probe_ids.length === 0) {
+          if (doc.probes?.length > 0) {
+              doc.probe_ids = doc.probes.map(p => p.probe_id);
+          } else {
+              doc.probe_ids = (doc.history || [])
+                  .filter(h => h.command === 'Respond to TA1 Probe')
+                  .map(h => h.parameters?.probe_id);
+          }
+      }
+        return doc;
+      });
+    },
   Mutation: {
     updateAdminUser: async (obj, args, context, inflow) => {
       const session = await context.db.collection('sessions').find({ "_id": new ObjectId(args['caller']?.['sessionId']) })?.project({ "userId": 1, "valid": 1 }).toArray().then(result => { return result[0] });

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -28,7 +28,7 @@ const typeDefs = gql`
     getHistory(id: ID): JSON @complexity(value: 10)
     getAllHistory(id: ID): [JSON] @complexity(value: 150)
     getAllHistoryByEvalNumber(evalNumber: Float, showMainPage: Boolean): [JSON] @complexity(value: 75)
-    getAdmHistoryByScenario(evalNumber: Float, scenarioID: ID): [JSON] @complexity(value: 75)
+    getAdmHistoryByScenario(evalNumber: Float, scenarioIDs: [ID]): [JSON] @complexity(value: 75)
     getGroupAdmAlignmentByEval(evalNumber: Float): [JSON] @complexity(value: 80)
     getAllEvalData: [JSON] @complexity(value: 10)
     getEvalIdsForAllHistory: [JSON] @complexity(value: 10)
@@ -732,10 +732,9 @@ const resolvers = {
       else {
         return await context.db.collection('tcccResults').find().toArray().then(result => { return result; });
       }
-    }
-  },
+    },
     getAdmHistoryByScenario: async (obj, args, context, inflow) => {
-      const docs = await context.db.collection('admTargetRuns').find({ "evalNumber": args["evalNumber"], "evaluation.scenario_id": { $in: args["scenarioID"] } }, {
+      const docs = await context.db.collection('admTargetRuns').find({ "evalNumber": args["evalNumber"], "evaluation.scenario_id": { $in: args["scenarioIDs"] } }, {
         projection: {
           "synthetic": 1,
           "probe_ids": 1,
@@ -772,7 +771,8 @@ const resolvers = {
       }
         return doc;
       });
-    },
+    }
+  },
   Mutation: {
     updateAdminUser: async (obj, args, context, inflow) => {
       const session = await context.db.collection('sessions').find({ "_id": new ObjectId(args['caller']?.['sessionId']) })?.project({ "userId": 1, "valid": 1 }).toArray().then(result => { return result[0] });

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -28,7 +28,7 @@ const typeDefs = gql`
     getHistory(id: ID): JSON @complexity(value: 10)
     getAllHistory(id: ID): [JSON] @complexity(value: 150)
     getAllHistoryByEvalNumber(evalNumber: Float, showMainPage: Boolean): [JSON] @complexity(value: 75)
-    getAdmHistoryByScenario(evalNumber: Float, scenarioIDs: [ID]): [JSON] @complexity(value: 75)
+    getAllOWData(evalNumber: Float, scenarioIDs: [ID]): [JSON] @complexity(value: 75)
     getGroupAdmAlignmentByEval(evalNumber: Float): [JSON] @complexity(value: 80)
     getAllEvalData: [JSON] @complexity(value: 10)
     getEvalIdsForAllHistory: [JSON] @complexity(value: 10)
@@ -733,44 +733,16 @@ const resolvers = {
         return await context.db.collection('tcccResults').find().toArray().then(result => { return result; });
       }
     },
-    getAdmHistoryByScenario: async (obj, args, context, inflow) => {
+    getAllOWData: async (obj, args, context, inflow) => {
       const docs = await context.db.collection('admTargetRuns').find({ "evalNumber": args["evalNumber"], "evaluation.scenario_id": { $in: args["scenarioIDs"] } }, {
         projection: {
-          "synthetic": 1,
-          "probe_ids": 1,
-          "probes": 1,
-          "scenario": 1,
-          "alignment_target": 1,
           "evaluation": 1,
           "results": 1,
           "adm_name": 1,
-          "oracle_alignment": 1,
-          "history.parameters.adm_name": 1,
-          "history.response.id": 1,
-          "history.parameters.target_id": 1,
-          "history.response.kdma_values.value": 1,
-          "history.parameters.target_id": 1,
-          "history.response.score": 1,
-          "history.response.distance_based_score": 1,
-          "history.response.dre_alignment.score": 1,
-          "history.parameters.session_id": 1,
-          "history.parameters.dreSessionId": 1,
-          "history.command": 1,
-          "history.parameters.probe_id": 1
         }
       }).toArray();
-      return docs.map(doc => {
-        if (!Array.isArray(doc.probe_ids) || doc.probe_ids.length === 0) {
-          if (doc.probes?.length > 0) {
-              doc.probe_ids = doc.probes.map(p => p.probe_id);
-          } else {
-              doc.probe_ids = (doc.history || [])
-                  .filter(h => h.command === 'Respond to TA1 Probe')
-                  .map(h => h.parameters?.probe_id);
-          }
-      }
-        return doc;
-      });
+      
+      return docs
     }
   },
   Mutation: {


### PR DESCRIPTION
This PR speeds up the load time for the Open World Part 1 table in RQ8

Rebuild Graphql

- Go to http://localhost:3000/research-results/exploratory-analysis and https://darpaitm.caci.com/research-results/exploratory-analysis
- Make sure you have April selected from the dropdown
- Scroll to the Open World Part 1 table. It should load noticeably faster compared to prod

Double check that all 64 rows are still showing and the download functionality is still working.