### PR TITLE
ITM-1257 Revisit Page Stickiness

### DIFF
--- a/dashboard-ui/src/components/Account/editEvals.jsx
+++ b/dashboard-ui/src/components/Account/editEvals.jsx
@@ -34,8 +34,7 @@ const DELETE_EVAL = gql`
 
 const pagePaths = [
     '/', '/text-based-results', '/humanSimParticipant', '/humanProbeData',
-    '/human-results', '/results', '/adm-results', '/adm-probe-responses',
-    '/rq1', '/rq2', '/rq3', '/exploratory-analysis'
+    '/human-results', '/results', '/adm-results', '/adm-probe-responses'
 ];
 
 export function EditEvals({ caller }) {
@@ -159,9 +158,10 @@ export function EditEvals({ caller }) {
             "evalNumber": parseInt(evalNumber),
             "evalName": evalName,
             "pages": {
-                "rq1": selectedPages.includes('/rq1'),
-                "rq2": selectedPages.includes('/rq2'),
-                "rq3": selectedPages.includes('/rq3'),
+                // Setting these to be true as a place holder until all toggles are removed
+                "rq1": true, 
+                "rq2": true,
+                "rq3": true,
                 "exploratoryAnalysis": selectedPages.includes('/exploratory-analysis'),
                 "admProbeResponses": selectedPages.includes('/adm-probe-responses'),
                 "admAlignment": selectedPages.includes('/adm-results'),
@@ -247,18 +247,6 @@ export function EditEvals({ caller }) {
                                 <th className='switch-header' title='adm probe responses'>
                                     /adm-probe-responses
                                 </th>
-                                <th className='switch-header' title='rq1'>
-                                    /rq1
-                                </th>
-                                <th className='switch-header' title='rq2'>
-                                    /rq2
-                                </th>
-                                <th className='switch-header' title='rq3'>
-                                    /rq3
-                                </th>
-                                <th className='switch-header' title='exploratory analysis'>
-                                    /exploratory-analysis
-                                </th>
                                 <th className='action-header' title='only deletes the entry from the evalData collection'>
                                     Delete
                                 </th>
@@ -278,10 +266,6 @@ export function EditEvals({ caller }) {
                                         <td><Switch color='primary' checked={evaluation.pages.admResults} onChange={(e) => updateEvalPagePermissions(evaluation._id, 'admResults', e)} /></td>
                                         <td><Switch color='primary' checked={evaluation.pages.admAlignment} onChange={(e) => updateEvalPagePermissions(evaluation._id, 'admAlignment', e)} /></td>
                                         <td><Switch color='primary' checked={evaluation.pages.admProbeResponses} onChange={(e) => updateEvalPagePermissions(evaluation._id, 'admProbeResponses', e)} /></td>
-                                        <td><Switch color='primary' checked={evaluation.pages.rq1} onChange={(e) => updateEvalPagePermissions(evaluation._id, 'rq1', e)} /></td>
-                                        <td><Switch color='primary' checked={evaluation.pages.rq2} onChange={(e) => updateEvalPagePermissions(evaluation._id, 'rq2', e)} /></td>
-                                        <td><Switch color='primary' checked={evaluation.pages.rq3} onChange={(e) => updateEvalPagePermissions(evaluation._id, 'rq3', e)} /></td>
-                                        <td><Switch color='primary' checked={evaluation.pages.exploratoryAnalysis} onChange={(e) => updateEvalPagePermissions(evaluation._id, 'exploratoryAnalysis', e)} /></td>
                                         <td><IconButton title='Delete' onClick={() => startDeleteProcess(evaluation)} children={<DeleteIcon className='delete-eval-btn' />} /></td>
                                     </tr>);
                             })}
@@ -358,34 +342,6 @@ export function EditEvals({ caller }) {
                                 </td>
                                 <td className="table-value">
                                     <Switch color='primary' checked={modalEval.pages?.admProbeResponses} onChange={(e) => updateEvalPagePermissions(modalEval._id, 'admProbeResponses', e)} />
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="table-label">
-                                    /rq1
-                                </td>
-                                <td className="table-value">
-                                    <Switch color='primary' checked={modalEval.pages?.rq1} onChange={(e) => updateEvalPagePermissions(modalEval._id, 'rq1', e)} />
-                                </td>
-                                <td className="table-label">
-                                    /rq2
-                                </td>
-                                <td className="table-value">
-                                    <Switch color='primary' checked={modalEval.pages?.rq2} onChange={(e) => updateEvalPagePermissions(modalEval._id, 'rq2', e)} />
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="table-label">
-                                    /rq3
-                                </td>
-                                <td className="table-value">
-                                    <Switch color='primary' checked={modalEval.pages?.rq3} onChange={(e) => updateEvalPagePermissions(modalEval._id, 'rq3', e)} />
-                                </td>
-                                <td className="table-label">
-                                    /exploratory-analysis
-                                </td>
-                                <td className="table-value">
-                                    <Switch color='primary' checked={modalEval.pages?.exploratoryAnalysis} onChange={(e) => updateEvalPagePermissions(modalEval._id, 'exploratoryAnalysis', e)} />
                                 </td>
                             </tr>
                         </tbody>

--- a/dashboard-ui/src/components/Research/ExploratoryAnalysis.jsx
+++ b/dashboard-ui/src/components/Research/ExploratoryAnalysis.jsx
@@ -13,14 +13,18 @@ import { HumanVariability } from './tables/humanVariability';
 import { BlockedTable } from './tables/BlockedTable';
 import { CalibrationData } from './tables/CalibrationData';
 import { PAGES, getAllEvals, getEvalOptionsForPage } from './utils';
+import { useSelector, useDispatch } from 'react-redux'
+import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
 export function ExploratoryAnalysis() {
     const evalOptions = getAllEvals();
-    const evalRQ1Options = getEvalOptionsForPage(PAGES.RQ1); 
+    const evalRQ1Options = getEvalOptionsForPage(PAGES.RQ1);
+    const dispatch = useDispatch()
+    const storedEval = useSelector(state => state.configs.selectedResearchEval)  
 
-    const [selectedEval, setSelectedEval] = React.useState(evalOptions[0].value);
+    const selectedEval = storedEval ?? evalOptions[0].value;
     function selectEvaluation(target) {
-        setSelectedEval(target.value);
+        dispatch(setSelectedResearchEval(target.value))
     }
 
     // Extract all evaluation values that have an RQ1 page to conditionally render RQ4 content 

--- a/dashboard-ui/src/components/Research/ExploratoryAnalysis.jsx
+++ b/dashboard-ui/src/components/Research/ExploratoryAnalysis.jsx
@@ -12,10 +12,10 @@ import { RQ5_PH1 } from './tables/rq5_ph1';
 import { HumanVariability } from './tables/humanVariability';
 import { BlockedTable } from './tables/BlockedTable';
 import { CalibrationData } from './tables/CalibrationData';
-import { PAGES, getEvalOptionsForPage } from './utils';
+import { PAGES, getAllEvals, getEvalOptionsForPage } from './utils';
 
 export function ExploratoryAnalysis() {
-    const evalOptions = getEvalOptionsForPage(PAGES.EXPLORATORY_ANALYSIS);
+    const evalOptions = getAllEvals();
     const evalRQ1Options = getEvalOptionsForPage(PAGES.RQ1); 
 
     const [selectedEval, setSelectedEval] = React.useState(evalOptions[0].value);
@@ -157,7 +157,7 @@ export function ExploratoryAnalysis() {
         </div>
 
         <div className="section-container">
-            {RQ8Component ? <RQ8Component evalNum={selectedEval} /> : selectedEval < 8 ? <RQ8 evalNum={selectedEval} /> : <PH2RQ8 evalNum={selectedEval} />}
+            {RQ8Component ? <RQ8Component evalNum={selectedEval} /> : selectedEval < 8 ? <RQ8 evalNum={selectedEval} /> : <PH2RQ8 evalNum={selectedEval}/>}
         </div>
 
         {selectedEval === 16 &&

--- a/dashboard-ui/src/components/Research/RQ1.jsx
+++ b/dashboard-ui/src/components/Research/RQ1.jsx
@@ -7,18 +7,22 @@ import rq1CodePh1 from './rcode/code_for_dashboard_RQ1_ph1.R';
 import { Button, Modal } from 'react-bootstrap';
 import { RCodeModal } from "./rcode/RcodeModal";
 import { getAllEvals } from './utils';
+import { useSelector, useDispatch } from 'react-redux'
+import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
 export function RQ1() {
     const evalOptions = getAllEvals();
+    const dispatch = useDispatch()
+    const storedEval = useSelector(state => state.configs.selectedResearchEval)
 
     const [rq1CodeShowing, setRQ1CodeShowing] = React.useState(false);
 
     const close1Code = () => {
         setRQ1CodeShowing(false);
     }
-    const [selectedEval, setSelectedEval] = React.useState(evalOptions[0].value);
+     const selectedEval = storedEval ?? evalOptions[0].value
     function selectEvaluation(target) {
-        setSelectedEval(target.value);
+        dispatch(setSelectedResearchEval(target.value))
     }
     return (<div className="researchQuestion">
         <div className="rq-selection-section">

--- a/dashboard-ui/src/components/Research/RQ1.jsx
+++ b/dashboard-ui/src/components/Research/RQ1.jsx
@@ -6,10 +6,10 @@ import rq1CodeDre from './rcode/code_for_dashboard_RQ1_dre.R';
 import rq1CodePh1 from './rcode/code_for_dashboard_RQ1_ph1.R';
 import { Button, Modal } from 'react-bootstrap';
 import { RCodeModal } from "./rcode/RcodeModal";
-import { PAGES, getEvalOptionsForPage } from './utils';
+import { getAllEvals } from './utils';
 
 export function RQ1() {
-    const evalOptions = getEvalOptionsForPage(PAGES.RQ1);
+    const evalOptions = getAllEvals();
 
     const [rq1CodeShowing, setRQ1CodeShowing] = React.useState(false);
 

--- a/dashboard-ui/src/components/Research/RQ2.jsx
+++ b/dashboard-ui/src/components/Research/RQ2.jsx
@@ -11,10 +11,10 @@ import { Button, Modal } from 'react-bootstrap';
 import { RCodeModal } from "./rcode/RcodeModal";
 import { MultiKDMA_RQ23 as MultiKdmaRq23 } from './tables/rq23_multiKDMA';
 import { PH2RQ2223 } from './tables/ph2_rq22-rq23';
-import { PAGES, getEvalOptionsForPage } from './utils';
+import { getAllEvals} from './utils';
 
 export function RQ2() {
-    const evalOptions = getEvalOptionsForPage(PAGES.RQ2);
+    const evalOptions = getAllEvals();
 
     const [rq21CodeShowing, setRQ21CodeShowing] = React.useState(false);
     const [rq2CodeShowing, setRQ2CodeShowing] = React.useState(false);

--- a/dashboard-ui/src/components/Research/RQ2.jsx
+++ b/dashboard-ui/src/components/Research/RQ2.jsx
@@ -12,16 +12,20 @@ import { RCodeModal } from "./rcode/RcodeModal";
 import { MultiKDMA_RQ23 as MultiKdmaRq23 } from './tables/rq23_multiKDMA';
 import { PH2RQ2223 } from './tables/ph2_rq22-rq23';
 import { getAllEvals} from './utils';
+import { useSelector, useDispatch } from 'react-redux'
+import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
 export function RQ2() {
     const evalOptions = getAllEvals();
+    const dispatch = useDispatch()
+    const storedEval = useSelector(state => state.configs.selectedResearchEval)
 
     const [rq21CodeShowing, setRQ21CodeShowing] = React.useState(false);
     const [rq2CodeShowing, setRQ2CodeShowing] = React.useState(false);
-    const [selectedEval, setSelectedEval] = React.useState(evalOptions[0].value);
+    const selectedEval = storedEval ?? evalOptions[0].value
 
     function selectEvaluation(target) {
-        setSelectedEval(target.value);
+        dispatch(setSelectedResearchEval(target.value))
     }
 
     const close21Code = () => {

--- a/dashboard-ui/src/components/Research/RQ3.jsx
+++ b/dashboard-ui/src/components/Research/RQ3.jsx
@@ -8,10 +8,10 @@ import rq31CodeDre from './rcode/code_for_dashboard_RQ31_and_RQ33_dre.R';
 import rq32CodePh1 from './rcode/code_for_dashboard_RQ32_ph1.R';
 import rq31CodePh1 from './rcode/code_for_dashboard_RQ31_and_RQ33_ph1.R';
 import { Button, Modal } from 'react-bootstrap';
-import { PAGES, getEvalOptionsForPage } from './utils';
+import { getAllEvals} from './utils';
 
 export function RQ3() {
-    const evalOptions = getEvalOptionsForPage(PAGES.RQ3);
+    const evalOptions = getAllEvals();
 
     const [rq32CodeShowing, setRQ32CodeShowing] = React.useState(false);
     const [rq31CodeShowing, setRQ31CodeShowing] = React.useState(false);

--- a/dashboard-ui/src/components/Research/RQ3.jsx
+++ b/dashboard-ui/src/components/Research/RQ3.jsx
@@ -9,15 +9,19 @@ import rq32CodePh1 from './rcode/code_for_dashboard_RQ32_ph1.R';
 import rq31CodePh1 from './rcode/code_for_dashboard_RQ31_and_RQ33_ph1.R';
 import { Button, Modal } from 'react-bootstrap';
 import { getAllEvals} from './utils';
+import { useSelector, useDispatch } from 'react-redux'
+import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
 export function RQ3() {
     const evalOptions = getAllEvals();
+    const dispatch = useDispatch()
+    const storedEval = useSelector(state => state.configs.selectedResearchEval)
 
     const [rq32CodeShowing, setRQ32CodeShowing] = React.useState(false);
     const [rq31CodeShowing, setRQ31CodeShowing] = React.useState(false);
-    const [selectedEval, setSelectedEval] = React.useState(evalOptions[0].value);
+    const selectedEval = storedEval ?? evalOptions[0].value
     function selectEvaluation(target) {
-        setSelectedEval(target.value);
+        dispatch(setSelectedResearchEval(target.value))
     }
 
     const close32Code = () => {

--- a/dashboard-ui/src/components/Research/tables/ph2_rq22-rq23.jsx
+++ b/dashboard-ui/src/components/Research/tables/ph2_rq22-rq23.jsx
@@ -457,7 +457,7 @@ export function PH2RQ2223({ evalNum }) {
                         Showing {filteredData.length} of {formattedData.length} rows based on filters
                     </p>
             }
-            {formattedData.length === 0 ? <p>This table is not available for the selected evaluation</p> :
+            {formattedData.length === 0 ? <p>This table is not available for the selected evaluation.</p> :
             <>
             <section className='tableHeader'>
                 <div className="filters">

--- a/dashboard-ui/src/components/Research/tables/ph2_rq22-rq23.jsx
+++ b/dashboard-ui/src/components/Research/tables/ph2_rq22-rq23.jsx
@@ -29,6 +29,7 @@ export function PH2RQ2223({ evalNum }) {
 
     const [formattedData, setFormattedData] = React.useState([]);
     const [showDefinitions, setShowDefinitions] = React.useState(false);
+    const dataRef = React.useRef(null);
 
     const [attributes, setAttributes] = React.useState([]);
     const [admNames, setAdmNames] = React.useState([]);
@@ -116,7 +117,6 @@ export function PH2RQ2223({ evalNum }) {
         setSetFilters([])
         setTargetTypeFilters([])
         setAdmNamesFilters([])
-        setFormattedData([])
     }, [evalNum])
 
     React.useEffect(() => {
@@ -412,10 +412,9 @@ export function PH2RQ2223({ evalNum }) {
                 return a.Trial_ID - b.Trial_ID;
             });
 
-            if (allObjs.length > 0) {
-                setFormattedData(allObjs);
-                setFilteredData(allObjs);
-            } 
+            setFormattedData(allObjs);
+            setFilteredData(allObjs);
+            
 
             setAdmNames(Array.from(new Set(allAdmNames)));
             setAttributes(Array.from(new Set(allAttributes)));
@@ -438,7 +437,7 @@ export function PH2RQ2223({ evalNum }) {
         }
     }, [formattedData, attributeFilters, targetFilters, setFilters, targetTypeFilters, setConstructionFilters, admNamesFilters]);
 
-    if (loading) return <p>Loading...</p>;
+    if (loading || (data?.getAllHistoryByEvalNumber?.length > 0 && formattedData.length === 0)) return <p>Loading...</p>;
     if (error) return <p>Error: {error.message}</p>;
 
     //eval 15 at least one filter before rendering rows due to dataset size

--- a/dashboard-ui/src/components/Research/tables/ph2_rq22-rq23.jsx
+++ b/dashboard-ui/src/components/Research/tables/ph2_rq22-rq23.jsx
@@ -116,6 +116,7 @@ export function PH2RQ2223({ evalNum }) {
         setSetFilters([])
         setTargetTypeFilters([])
         setAdmNamesFilters([])
+        setFormattedData([])
     }, [evalNum])
 
     React.useEffect(() => {
@@ -414,10 +415,7 @@ export function PH2RQ2223({ evalNum }) {
             if (allObjs.length > 0) {
                 setFormattedData(allObjs);
                 setFilteredData(allObjs);
-            } else {
-                setFormattedData([{ 'Trial_ID': '-' }]);
-                setFilteredData([{ 'Trial_ID': '-' }]);
-            }
+            } 
 
             setAdmNames(Array.from(new Set(allAdmNames)));
             setAttributes(Array.from(new Set(allAttributes)));
@@ -459,7 +457,8 @@ export function PH2RQ2223({ evalNum }) {
                         Showing {filteredData.length} of {formattedData.length} rows based on filters
                     </p>
             }
-
+            {formattedData.length === 0 ? <p>This table is not available for the selected evaluation</p> :
+            <>
             <section className='tableHeader'>
                 <div className="filters">
                     <Autocomplete
@@ -568,6 +567,8 @@ export function PH2RQ2223({ evalNum }) {
                     </tbody>
                 </table>
             </div>
+            </>
+            }
 
             <Modal className='table-modal' open={showDefinitions} onClose={closeModal}>
                 <div className='modal-body'>

--- a/dashboard-ui/src/components/Research/tables/ph2_rq8.jsx
+++ b/dashboard-ui/src/components/Research/tables/ph2_rq8.jsx
@@ -420,7 +420,7 @@ export function PH2RQ8({ evalNum }) {
                     Showing {filteredData.length} of {formattedData.length} rows based on filters
                 </p>
             )}
-            {formattedData.length === 0 ? <p>This table is not available for the selected evaluation</p> :
+            {formattedData.length === 0 ? <p>This table is not available for the selected evaluation.</p> :
             <>
             <section className="tableHeader">
                 <div className="filters"></div>

--- a/dashboard-ui/src/components/Research/tables/ph2_rq8.jsx
+++ b/dashboard-ui/src/components/Research/tables/ph2_rq8.jsx
@@ -52,6 +52,7 @@ export function PH2RQ8({ evalNum }) {
     const [showDefinitions, setShowDefinitions] = React.useState(false);
     const [definitionFields, setDefinitionFields] = React.useState([]);
     const [HEADERS, setHeaders] = React.useState([]);
+    const [processedForEval, setProcessedForEval] = React.useState(null);
 
     const mode = React.useMemo(() => {
         return FEB26_EVALS.includes(evalNum) ? "feb26" : "legacy";
@@ -380,6 +381,7 @@ export function PH2RQ8({ evalNum }) {
         setHeaders(filteredHeaders);
         setFormattedData(filteredObjs);
         setFilteredData(filteredObjs);
+        setProcessedForEval(evalNum);
     }, [
         dataSim,
         dataTextResults,
@@ -408,7 +410,7 @@ export function PH2RQ8({ evalNum }) {
         setShowDefinitions(false);
     };
 
-    if (loadingSim || loadingTextResults || loadingParticipantLog) return <p>Loading...</p>;
+    if (loadingSim || loadingTextResults || loadingParticipantLog || (formattedData.length === 0 && processedForEval !== evalNum)) return <p>Loading...</p>;
     if (errorSim || errorTextResults || errorParticipantLog) return <p>Error :</p>;
 
     return (
@@ -420,7 +422,7 @@ export function PH2RQ8({ evalNum }) {
                     Showing {filteredData.length} of {formattedData.length} rows based on filters
                 </p>
             )}
-            {formattedData.length === 0 ? <p>This table is not available for the selected evaluation.</p> :
+            {formattedData.length === 0 && processedForEval === evalNum ? <p>This table is not available for the selected evaluation.</p>: formattedData.length > 0 ?            
             <>
             <section className="tableHeader">
                 <div className="filters"></div>
@@ -456,8 +458,8 @@ export function PH2RQ8({ evalNum }) {
                 </table>
             </div>
             </>
+            : null
             }
-
             <Modal className="table-modal" open={showDefinitions} onClose={closeModal}>
                 <div className="modal-body">
                     <span className="close-icon" onClick={closeModal}>

--- a/dashboard-ui/src/components/Research/tables/ph2_rq8.jsx
+++ b/dashboard-ui/src/components/Research/tables/ph2_rq8.jsx
@@ -420,7 +420,8 @@ export function PH2RQ8({ evalNum }) {
                     Showing {filteredData.length} of {formattedData.length} rows based on filters
                 </p>
             )}
-
+            {formattedData.length === 0 ? <p>This table is not available for the selected evaluation</p> :
+            <>
             <section className="tableHeader">
                 <div className="filters"></div>
                 <DownloadButtons
@@ -454,6 +455,8 @@ export function PH2RQ8({ evalNum }) {
                     </tbody>
                 </table>
             </div>
+            </>
+            }
 
             <Modal className="table-modal" open={showDefinitions} onClose={closeModal}>
                 <div className="modal-body">

--- a/dashboard-ui/src/components/Research/tables/ph2_rq8_apr26.jsx
+++ b/dashboard-ui/src/components/Research/tables/ph2_rq8_apr26.jsx
@@ -44,6 +44,7 @@ export function PH2RQ8Apr26({ evalNum }) {
     const [showDefinitions, setShowDefinitions] = React.useState(false);
     const [definitionFields, setDefinitionFields] = React.useState([]);
     const [HEADERS, setHeaders] = React.useState([]);
+    const [processedForEval, setProcessedForEval] = React.useState(null);
 
     const definitionFile = ph2Apr26DefinitionXLFile
 
@@ -315,6 +316,7 @@ export function PH2RQ8Apr26({ evalNum }) {
         setHeaders(filteredHeaders);
         setFormattedData(filteredObjs);
         setFilteredData(filteredObjs);
+        setProcessedForEval(evalNum);
     }, [
         dataSim,
         dataTextResults,
@@ -338,7 +340,7 @@ export function PH2RQ8Apr26({ evalNum }) {
         setShowDefinitions(false);
     };
 
-    if (loadingSim || loadingTextResults || loadingParticipantLog) return <p>Loading...</p>;
+    if (loadingSim || loadingTextResults || loadingParticipantLog || (formattedData.length === 0 && processedForEval !== evalNum)) return <p>Loading...</p>;
     if (errorSim || errorTextResults || errorParticipantLog) return <p>Error :</p>;
 
     return (
@@ -351,7 +353,7 @@ export function PH2RQ8Apr26({ evalNum }) {
                 </p>
             )}
 
-            {formattedData.length === 0 ? <p>This table is not available for the selected evaluation.</p> : 
+            {formattedData.length === 0 && processedForEval === evalNum ? <p>This table is not available for the selected evaluation.</p>: formattedData.length > 0 ? 
             <>
             <section className="tableHeader">
                 <div className="filters"></div>
@@ -387,6 +389,7 @@ export function PH2RQ8Apr26({ evalNum }) {
                 </table>
             </div>
             </>
+            : null
             }
 
             <Modal className="table-modal" open={showDefinitions} onClose={closeModal}>

--- a/dashboard-ui/src/components/Research/tables/ph2_rq8_apr26.jsx
+++ b/dashboard-ui/src/components/Research/tables/ph2_rq8_apr26.jsx
@@ -351,6 +351,8 @@ export function PH2RQ8Apr26({ evalNum }) {
                 </p>
             )}
 
+            {formattedData.length === 0 ? <p>This table is not available for the selected evaluation</p> : 
+            <>
             <section className="tableHeader">
                 <div className="filters"></div>
                 <DownloadButtons
@@ -384,6 +386,8 @@ export function PH2RQ8Apr26({ evalNum }) {
                     </tbody>
                 </table>
             </div>
+            </>
+            }
 
             <Modal className="table-modal" open={showDefinitions} onClose={closeModal}>
                 <div className="modal-body">

--- a/dashboard-ui/src/components/Research/tables/ph2_rq8_apr26.jsx
+++ b/dashboard-ui/src/components/Research/tables/ph2_rq8_apr26.jsx
@@ -351,7 +351,7 @@ export function PH2RQ8Apr26({ evalNum }) {
                 </p>
             )}
 
-            {formattedData.length === 0 ? <p>This table is not available for the selected evaluation</p> : 
+            {formattedData.length === 0 ? <p>This table is not available for the selected evaluation.</p> : 
             <>
             <section className="tableHeader">
                 <div className="filters"></div>

--- a/dashboard-ui/src/components/Research/tables/rq134.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq134.jsx
@@ -546,6 +546,8 @@ export function RQ134({ evalNum, tableTitle }) {
                 <span className='reset-btn' onClick={clearFilters}>(Reset Filters)</span>
             </p>
         }
+        {formattedData.length === 0 ? <p>This table is not available for the selected evaluation</p> :
+        <>
         <section className='tableHeader'>
             <div className='complexHeader'>
                 <div className="too-many-filters">
@@ -764,6 +766,8 @@ export function RQ134({ evalNum, tableTitle }) {
                 </tbody>
             </table>
         </div>
+        </>
+        }
         <Modal className='table-modal' open={showDefinitions} onClose={closeModal}>
             <div className='modal-body'>
                 <span className='close-icon' onClick={closeModal}><CloseIcon /></span>

--- a/dashboard-ui/src/components/Research/tables/rq134.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq134.jsx
@@ -111,6 +111,7 @@ export function RQ134({ evalNum, tableTitle }) {
     // searching rows
     const [searchPid, setSearchPid] = React.useState('');
     const [headers, setHeaders] = React.useState([]);
+    const [processedForEval, setProcessedForEval] = React.useState(null);
 
     // Set evals to be rendered by number
     const evalNumbers = React.useMemo(() => {
@@ -350,6 +351,7 @@ export function RQ134({ evalNum, tableTitle }) {
             setProbeSetAssessments(Array.from(new Set(data.allProbeSetAssessment)))
             setProbeSetObservations(Array.from(new Set(data.allProbeSetObservation)))
             setTargets(Array.from(new Set(data.allTargets)));
+            setProcessedForEval(evalNum);
         }
     }, [
         dataParticipantLog,
@@ -378,6 +380,19 @@ export function RQ134({ evalNum, tableTitle }) {
         dataMedics,
         dataDemo
     ]);
+
+    const allFetched = fetchedSurveyEvals.includes(evalNum) &&
+                   fetchedScenarioEvals.includes(evalNum) &&
+                   fetchedComparisonEvals.includes(evalNum);
+
+    const allLoaded = !loadingParticipantLog && !loadingSurveyResults && !loadingTextResults &&
+                  !loadingADMs && !loadingMedics && !loadingComparisonData && !loadingSim;
+
+    React.useEffect(() =>{
+        if (allFetched && allLoaded && processedForEval !== evalNum) {
+            setProcessedForEval(evalNum)
+        }
+    }, [allFetched, allLoaded, evalNum, processedForEval])
 
     const includeExtraData = (data, evalToAdd, simData, admsToUse) => {
         const addedData = getRQ134Data(evalToAdd, surveyData, dataParticipantLog, textResultsData, admsToUse, comparisonData, simData, evalToAdd == 4);
@@ -517,7 +532,7 @@ export function RQ134({ evalNum, tableTitle }) {
         return headers.filter(x => !columnsToHide.includes(x) && (shouldShowTruncationError || x !== 'Truncation Error'));
     };
 
-    if (loadingParticipantLog || loadingSurveyResults || loadingTextResults || loadingADMs || loadingMedics || loadingComparisonData || loadingSim) return <p>Loading...</p>;
+    if (loadingParticipantLog || loadingSurveyResults || loadingTextResults || loadingADMs || loadingMedics || loadingComparisonData || loadingSim || formattedData.length === 0 && processedForEval !== evalNum) return <p>Loading...</p>;
     if (errorParticipantLog || errorSurveyResults || errorTextResults || errorADMs || errorMedics || errorComparisonData || errorSim) return <p>Error :</p>;
 
     return (<>
@@ -546,7 +561,7 @@ export function RQ134({ evalNum, tableTitle }) {
                 <span className='reset-btn' onClick={clearFilters}>(Reset Filters)</span>
             </p>
         }
-        {formattedData.length === 0 ? <p>This table is not available for the selected evaluation.</p> :
+        {formattedData.length === 0 && processedForEval === evalNum ? <p>This table is not available for the selected evaluation.</p>: formattedData.length > 0 ?
         <>
         <section className='tableHeader'>
             <div className='complexHeader'>
@@ -767,6 +782,7 @@ export function RQ134({ evalNum, tableTitle }) {
             </table>
         </div>
         </>
+        :null
         }
         <Modal className='table-modal' open={showDefinitions} onClose={closeModal}>
             <div className='modal-body'>
@@ -776,7 +792,6 @@ export function RQ134({ evalNum, tableTitle }) {
         </Modal>
     </>);
 }
-
 const DEFINITION_FILE_MAP = {
     16: aprilDefinitionXLFile,
     15: febDefinitionXLFile,

--- a/dashboard-ui/src/components/Research/tables/rq134.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq134.jsx
@@ -546,7 +546,7 @@ export function RQ134({ evalNum, tableTitle }) {
                 <span className='reset-btn' onClick={clearFilters}>(Reset Filters)</span>
             </p>
         }
-        {formattedData.length === 0 ? <p>This table is not available for the selected evaluation</p> :
+        {formattedData.length === 0 ? <p>This table is not available for the selected evaluation.</p> :
         <>
         <section className='tableHeader'>
             <div className='complexHeader'>

--- a/dashboard-ui/src/components/Research/tables/rq21.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq21.jsx
@@ -154,20 +154,13 @@ export function RQ21({ evalNum }) {
                 setFormattedData(allObjs);
                 setFilteredData(allObjs);
             }
-            else {
-                setFormattedData([{ 'TA1_Name': null }]);
-                setFilteredData([{ 'TA1_Name': '-' }])
-            }
+
             setTA1s(Array.from(new Set(allTA1s)));
             setTA2s(Array.from(new Set(allTA2s)));
             setAttributes(Array.from(new Set(allAttributes)));
             setScenarios(Array.from(new Set(allScenarios)));
             setGroupTargets(Array.from(new Set(allGroupTargets)));
             setDecisionMakers(Array.from(new Set(allDecisionMakers)));
-        }
-        else {
-            setFormattedData([{ 'TA1_Name': '-' }]);
-            setFilteredData([{ 'TA1_Name': '-' }])
         }
     }, [dataAdms, dataTextResults, evalNum]);
 
@@ -198,6 +191,8 @@ export function RQ21({ evalNum }) {
 
     return (<>
         {filteredData.length < formattedData.length && <p className='filteredText'>Showing {filteredData.length} of {formattedData.length} rows based on filters</p>}
+        {formattedData.length === 0 ? <p>This table is not available for the selected evaluation</p> :
+        <>
         <section className='tableHeader'>
             <div className="filters">
                 <Autocomplete
@@ -312,6 +307,8 @@ export function RQ21({ evalNum }) {
                 </tbody>
             </table>
         </div>
+        </>
+        }
         <Modal className='table-modal' open={showDefinitions} onClose={closeModal}>
             <div className='modal-body'>
                 <span className='close-icon' onClick={closeModal}><CloseIcon /></span>

--- a/dashboard-ui/src/components/Research/tables/rq21.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq21.jsx
@@ -191,7 +191,7 @@ export function RQ21({ evalNum }) {
 
     return (<>
         {filteredData.length < formattedData.length && <p className='filteredText'>Showing {filteredData.length} of {formattedData.length} rows based on filters</p>}
-        {formattedData.length === 0 ? <p>This table is not available for the selected evaluation</p> :
+        {formattedData.length === 0 ? <p>This table is not available for the selected evaluation.</p> :
         <>
         <section className='tableHeader'>
             <div className="filters">

--- a/dashboard-ui/src/components/Research/tables/rq21.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq21.jsx
@@ -42,6 +42,7 @@ export function RQ21({ evalNum }) {
     const [groupTargetFilters, setGroupTargetFilters] = React.useState([]);
     const [decisionMakerFilters, setDecisionMakerFilters] = React.useState([]);
     const [filteredData, setFilteredData] = React.useState([]);
+    const [processedForEval, setProcessedForEval] = React.useState(null);
 
 
     React.useEffect(() => {
@@ -150,13 +151,12 @@ export function RQ21({ evalNum }) {
             textObjs.sort((a, b) => a['Decision_Maker'] - b['Decision_Maker']);
             allObjs = allObjs.concat(textObjs);
 
-            if (allObjs.length > 0) {
-                setFormattedData(allObjs);
-                setFilteredData(allObjs);
-            }
+            setFormattedData(allObjs);
+            setFilteredData(allObjs);
 
             setTA1s(Array.from(new Set(allTA1s)));
             setTA2s(Array.from(new Set(allTA2s)));
+            setProcessedForEval(evalNum);
             setAttributes(Array.from(new Set(allAttributes)));
             setScenarios(Array.from(new Set(allScenarios)));
             setGroupTargets(Array.from(new Set(allGroupTargets)));
@@ -186,12 +186,12 @@ export function RQ21({ evalNum }) {
         }
     }, [formattedData, ta1Filters, ta2Filters, scenarioFilters, attributeFilters, groupTargetFilters, decisionMakerFilters]);
 
-    if (loadingAdms || loadingTextResults) return <p>Loading...</p>;
+    if (loadingAdms || loadingTextResults || (formattedData.length === 0 && processedForEval !== evalNum)) return <p>Loading...</p>;
     if (errorAdms || errorTextResults) return <p>Error :</p>;
 
     return (<>
         {filteredData.length < formattedData.length && <p className='filteredText'>Showing {filteredData.length} of {formattedData.length} rows based on filters</p>}
-        {formattedData.length === 0 ? <p>This table is not available for the selected evaluation.</p> :
+        {formattedData.length === 0 && processedForEval === evalNum ? <p>This table is not available for the selected evaluation.</p>: formattedData.length > 0 ?
         <>
         <section className='tableHeader'>
             <div className="filters">
@@ -308,6 +308,7 @@ export function RQ21({ evalNum }) {
             </table>
         </div>
         </>
+        : null
         }
         <Modal className='table-modal' open={showDefinitions} onClose={closeModal}>
             <div className='modal-body'>

--- a/dashboard-ui/src/components/Research/tables/rq22-rq23.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq22-rq23.jsx
@@ -200,7 +200,7 @@ export function RQ2223({ evalNum }) {
 
     return (<>
         {filteredData.length < formattedData.length && <p className='filteredText'>Showing {filteredData.length} of {formattedData.length} rows based on filters</p>}
-        {formattedData.length === 0 ? <p>This table is not available for the selected evaluation</p> :
+        {formattedData.length === 0 ? <p>This table is not available for the selected evaluation.</p> :
         <>
         <section className='tableHeader'>
             <div className="filters">

--- a/dashboard-ui/src/components/Research/tables/rq22-rq23.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq22-rq23.jsx
@@ -172,10 +172,7 @@ export function RQ2223({ evalNum }) {
                 setFormattedData(allObjs);
                 setFilteredData(allObjs);
             }
-            else {
-                setFormattedData([{ 'Trial_ID': '-' }]);
-                setFilteredData([{ 'Trial_ID': '-' }]);
-            }
+
             setTA1s(Array.from(new Set(allTA1s)));
             setTA2s(Array.from(new Set(allTA2s)));
             setAttributes(Array.from(new Set(allAttributes)));
@@ -203,6 +200,8 @@ export function RQ2223({ evalNum }) {
 
     return (<>
         {filteredData.length < formattedData.length && <p className='filteredText'>Showing {filteredData.length} of {formattedData.length} rows based on filters</p>}
+        {formattedData.length === 0 ? <p>This table is not available for the selected evaluation</p> :
+        <>
         <section className='tableHeader'>
             <div className="filters">
                 <Autocomplete
@@ -317,6 +316,8 @@ export function RQ2223({ evalNum }) {
                 </tbody>
             </table>
         </div>
+        </>
+        }
         <Modal className='table-modal' open={showDefinitions} onClose={closeModal}>
             <div className='modal-body'>
                 <span className='close-icon' onClick={closeModal}><CloseIcon /></span>

--- a/dashboard-ui/src/components/Research/tables/rq22-rq23.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq22-rq23.jsx
@@ -26,6 +26,7 @@ export function RQ2223({ evalNum }) {
     });
     const [formattedData, setFormattedData] = React.useState([]);
     const [showDefinitions, setShowDefinitions] = React.useState(false);
+    const [processedForEval, setProcessedForEval] = React.useState(null);
     // all options for filters
     const [ta1s, setTA1s] = React.useState([]);
     const [ta2s, setTA2s] = React.useState([]);
@@ -167,17 +168,16 @@ export function RQ2223({ evalNum }) {
                 // If attribute is equal, compare Trial_ID
                 return a.Trial_ID - b.Trial_ID;
             });
-
-            if (allObjs.length > 0) {
-                setFormattedData(allObjs);
-                setFilteredData(allObjs);
-            }
-
+    
+            setFormattedData(allObjs);
+            setFilteredData(allObjs);
+            
             setTA1s(Array.from(new Set(allTA1s)));
             setTA2s(Array.from(new Set(allTA2s)));
             setAttributes(Array.from(new Set(allAttributes)));
             setScenarios(Array.from(new Set(allScenarios)));
             setTargets(Array.from(new Set(allTargets)));
+            setProcessedForEval(evalNum);
         }
     }, [data, evalNum]);
 
@@ -195,12 +195,12 @@ export function RQ2223({ evalNum }) {
     }, [formattedData, ta1Filters, ta2Filters, scenarioFilters, targetFilters, attributeFilters, targetTypeFilters]);
 
 
-    if (loading) return <p>Loading...</p>;
+    if (loading || (formattedData.length === 0 && processedForEval !== evalNum)) return <p>Loading...</p>;
     if (error) return <p>Error :</p>;
 
     return (<>
         {filteredData.length < formattedData.length && <p className='filteredText'>Showing {filteredData.length} of {formattedData.length} rows based on filters</p>}
-        {formattedData.length === 0 ? <p>This table is not available for the selected evaluation.</p> :
+        {formattedData.length === 0 && processedForEval === evalNum ? <p>This table is not available for the selected evaluation.</p>: formattedData.length > 0 ?
         <>
         <section className='tableHeader'>
             <div className="filters">
@@ -317,6 +317,7 @@ export function RQ2223({ evalNum }) {
             </table>
         </div>
         </>
+        : null
         }
         <Modal className='table-modal' open={showDefinitions} onClose={closeModal}>
             <div className='modal-body'>

--- a/dashboard-ui/src/components/Research/tables/rq23_multiKDMA.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq23_multiKDMA.jsx
@@ -92,6 +92,7 @@ export function MultiKDMA_RQ23({ evalNum = 7 }) {
     const [targetTypeFilters, setTargetTypeFilters] = React.useState([]);
     const [onlyShowCompletedSurveys, setOnlyShowCompletedSurveys] = React.useState(false);
     const [pidsWithCompleteSurveys, setPidsWithCompleteSurveys] = React.useState([]);
+    const [processedForEval, setProcessedForEval] = React.useState(null);
 
     React.useEffect(() => {
         setAdmNameFilters([]); setScenarioFilters([]); setTargetTypeFilters([]);
@@ -123,8 +124,9 @@ export function MultiKDMA_RQ23({ evalNum = 7 }) {
         }, []);
 
         allObjs.sort((a, b) => a['ADM Name'].localeCompare(b['ADM Name']) || String(a['PID']).localeCompare(String(b['PID'])));
-        setFormattedData(allObjs.length ? allObjs : [{ 'ADM Name': '-' }]);
-        setFilteredData(allObjs.length ? allObjs : [{ 'ADM Name': '-' }]);
+        setFormattedData(allObjs);
+        setFilteredData(allObjs);
+        setProcessedForEval(evalNum);
         setAdmNames([...new Set(allAdmNames)]);
     }, [data, dataEval11, dataSurvey, dataLog, dataText, evalNum, config.fieldMap]);
 
@@ -141,7 +143,7 @@ export function MultiKDMA_RQ23({ evalNum = 7 }) {
     const isLoading = (evalNum === 7 ? loading : loadingEval11) || loadingLog || loadingSurvey || loadingText;
     const hasError = (evalNum === 7 ? error : errorEval11) || errorLog || errorSurvey || errorText;
 
-    if (isLoading) return <p>Loading...</p>;
+    if (isLoading || (formattedData.length === 0 && processedForEval !== evalNum)) return <p>Loading...</p>;
     if (hasError) return <p>Error :</p>;
 
     return (<>
@@ -149,6 +151,8 @@ export function MultiKDMA_RQ23({ evalNum = 7 }) {
             <div><FormControlLabel control={<Checkbox value={onlyShowCompletedSurveys} onChange={e => setOnlyShowCompletedSurveys(e.target.checked)} />} label="Only Show Participants with Survey Data" /></div>
         </h2>
         {filteredData.length < formattedData.length && <p className='filteredText'>Showing {filteredData.length} of {formattedData.length} rows based on filters</p>}
+        {formattedData.length === 0 && processedForEval === evalNum ? <p>This table is not available for the selected evaluation.</p>: formattedData.length > 0 ?
+        <>
         <section className='tableHeader'>
             <div className="filters">
                 <Autocomplete style={{ minWidth: '300px' }} multiple options={admNames} filterSelectedOptions size="small"
@@ -166,6 +170,9 @@ export function MultiKDMA_RQ23({ evalNum = 7 }) {
                 <tbody>{filteredData.map((row, i) => <tr key={`${row['ADM Name']}-${row['PID']}-${i}`}>{HEADERS.map(h => <td key={h}>{row[h] ?? '-'}</td>)}</tr>)}</tbody>
             </table>
         </div>
+        </>
+        : null
+    }
         <Modal className='table-modal' open={showDefinitions} onClose={() => setShowDefinitions(false)}>
             <div className='modal-body'>
                 <span className='close-icon' onClick={() => setShowDefinitions(false)}><CloseIcon /></span>

--- a/dashboard-ui/src/components/Research/tables/rq5.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq5.jsx
@@ -59,6 +59,7 @@ export function RQ5({ evalNum }) {
     const [filteredData, setFilteredData] = React.useState([]);
     const [includeDRE, setIncludeDRE] = React.useState(false);
     const [includeJAN, setIncludeJAN] = React.useState(false);
+    const [processedForEval, setProcessedForEval] = React.useState(null);
 
     React.useEffect(() => {
         // reset toggles on render
@@ -200,6 +201,7 @@ export function RQ5({ evalNum }) {
             });
             setFormattedData(allObjs);
             setFilteredData(allObjs);
+            setProcessedForEval(evalNum);
             setTA1s(Array.from(new Set(allTA1s)));
             setTA2s(Array.from(new Set(allTA2s)));
             setAttributes(Array.from(new Set(allAttributes)));
@@ -278,7 +280,7 @@ export function RQ5({ evalNum }) {
         }
     }
 
-    if (loadingParticipantLog || loadingTextResults || loadingComparisonData) return <p>Loading...</p>;
+    if (loadingParticipantLog || loadingTextResults || loadingComparisonData || (formattedData.length === 0 && processedForEval !== evalNum)) return <p>Loading...</p>;
     if (errorParticipantLog || errorTextResults || errorComparisonData) return <p>Error :</p>;
 
     return (<>
@@ -290,6 +292,8 @@ export function RQ5({ evalNum }) {
                 </div>}
         </h2>
         {filteredData.length < formattedData.length && <p className='filteredText'>Showing {filteredData.length} of {formattedData.length} rows based on filters</p>}
+        {formattedData.length === 0 && processedForEval === evalNum ? <p>This table is not available for the selected evaluation.</p>: formattedData.length > 0 ?
+        <>
         <section className='tableHeader'>
             <div className="filters">
                 <Autocomplete
@@ -389,6 +393,9 @@ export function RQ5({ evalNum }) {
                 </tbody>
             </table>
         </div>
+        </>
+        : null
+    }
         <Modal className='table-modal' open={showDefinitions} onClose={closeModal}>
             <div className='modal-body'>
                 <span className='close-icon' onClick={closeModal}><CloseIcon /></span>

--- a/dashboard-ui/src/components/Research/tables/rq5_ph1.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq5_ph1.jsx
@@ -62,6 +62,7 @@ export function RQ5_PH1({ evalNum }) {
     const [attributeFilters, setAttributeFilters] = React.useState([]);
     const [targetFilters, setTargetFilters] = React.useState([]);
     const [filteredData, setFilteredData] = React.useState([]);
+    const [processedForEval, setProcessedForEval] = React.useState(null);
 
     React.useEffect(() => {
         if (dataParticipantLog?.getParticipantLog && dataTextResults?.getAllScenarioResults && comparisonData?.getHumanToADMComparison && comparisonData?.getADMTextProbeMatches) {
@@ -227,6 +228,7 @@ export function RQ5_PH1({ evalNum }) {
             });
             setFormattedData(allObjs);
             setFilteredData(allObjs);
+            setProcessedForEval(evalNum);
             setTA1s(Array.from(new Set(allTA1s)));
             setAttributes(Array.from(new Set(allAttributes)));
             setScenarios(Array.from(new Set(allScenarios)));
@@ -269,12 +271,14 @@ export function RQ5_PH1({ evalNum }) {
         }
     }
 
-    if (loadingParticipantLog || loadingTextResults || loadingComparisonData) return <p>Loading...</p>;
+    if (loadingParticipantLog || loadingTextResults || loadingComparisonData || (formattedData.length === 0 && processedForEval !== evalNum)) return <p>Loading...</p>;
     if (errorParticipantLog || errorTextResults || errorComparisonData) return <p>Error :</p>;
 
     return (<>
         <h2 className='rq134-header'>RQ5 Data</h2>
         {filteredData.length < formattedData.length && <p className='filteredText'>Showing {filteredData.length} of {formattedData.length} rows based on filters</p>}
+        {formattedData.length === 0 && processedForEval === evalNum ? <p>This table is not available for the selected evaluation.</p>: formattedData.length > 0 ?
+        <>
         <section className='tableHeader'>
             <div className="filters">
                 <Autocomplete
@@ -360,6 +364,9 @@ export function RQ5_PH1({ evalNum }) {
                 </tbody>
             </table>
         </div>
+        </>
+        : null
+    }
         <Modal className='table-modal' open={showDefinitions} onClose={closeModal}>
             <div className='modal-body'>
                 <span className='close-icon' onClick={closeModal}><CloseIcon /></span>

--- a/dashboard-ui/src/components/Research/tables/rq6.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq6.jsx
@@ -47,6 +47,7 @@ export function RQ6({ evalNum }) {
     const [filteredData, setFilteredData] = React.useState([]);
     const [includeDRE, setIncludeDRE] = React.useState(false);
     const [includeJAN, setIncludeJAN] = React.useState(false);
+    const [processedForEval, setProcessedForEval] = React.useState(null);
 
     React.useEffect(() => {
         // reset toggles on render
@@ -152,6 +153,7 @@ export function RQ6({ evalNum }) {
             });
             setFormattedData(nonEmpty);
             setFilteredData(nonEmpty);
+            setProcessedForEval(evalNum);
             setTA1s(Array.from(new Set(allTA1s)));
             setAttributes(Array.from(new Set(allAttributes)));
             setScenarios(Array.from(new Set(allScenarios)));
@@ -185,7 +187,7 @@ export function RQ6({ evalNum }) {
         }
     }, [formattedData, ta1Filters, scenarioFilters, attributeFilters]);
 
-    if (loadingParticipantLog || loadingTextResults || loadingSim) return <p>Loading...</p>;
+    if (loadingParticipantLog || loadingTextResults || loadingSim || (formattedData.length === 0 && processedForEval !== evalNum)) return <p>Loading...</p>;
     if (errorParticipantLog || errorTextResults || errorSim) return <p>Error :</p>;
 
     return (<>
@@ -197,6 +199,8 @@ export function RQ6({ evalNum }) {
                 </div>}
         </h2>
         {filteredData.length < formattedData.length && <p className='filteredText'>Showing {filteredData.length} of {formattedData.length} rows based on filters</p>}
+        {formattedData.length === 0 && processedForEval === evalNum ? <p>This table is not available for the selected evaluation.</p>: formattedData.length > 0 ?
+        <>
         <section className='tableHeader'>
             <div className="filters">
                 <Autocomplete
@@ -268,6 +272,9 @@ export function RQ6({ evalNum }) {
                 </tbody>
             </table>
         </div>
+        </>
+        : null
+    }
         <Modal className='table-modal' open={showDefinitions} onClose={closeModal}>
             <div className='modal-body'>
                 <span className='close-icon' onClick={closeModal}><CloseIcon /></span>

--- a/dashboard-ui/src/components/Research/tables/rq8.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq8.jsx
@@ -57,6 +57,7 @@ export function RQ8({ evalNum }) {
     const [filteredData, setFilteredData] = React.useState([]);
     const [includeDRE, setIncludeDRE] = React.useState(false);
     const [includeJAN, setIncludeJAN] = React.useState(false);
+    const [processedForEval, setProcessedForEval] = React.useState(null);
 
     React.useEffect(() => {
         // reset toggles on render
@@ -211,6 +212,7 @@ export function RQ8({ evalNum }) {
             });
             setFormattedData(allObjs);
             setFilteredData(allObjs);
+            setProcessedForEval(evalNum);
             setTA1s(Array.from(new Set(allTA1s)));
             setAttributes(Array.from(new Set(allAttributes)));
             setScenarios(Array.from(new Set(allScenarios)));
@@ -242,7 +244,7 @@ export function RQ8({ evalNum }) {
         ));
     }, [ta1Filters, scenarioFilters, attributeFilters, formattedData]);
 
-    if (loadingSim || loadingTextResults || loadingParticipantLog) return <p>Loading...</p>;
+    if (loadingSim || loadingTextResults || loadingParticipantLog || (formattedData.length === 0 && processedForEval !== evalNum)) return <p>Loading...</p>;
     if (errorSim || errorTextResults || errorParticipantLog) return <p>Error :</p>;
 
     return (<>
@@ -254,6 +256,8 @@ export function RQ8({ evalNum }) {
                 </div>}
         </h2>
         {filteredData.length < formattedData.length && <p className='filteredText'>Showing {filteredData.length} of {formattedData.length} rows based on filters</p>}
+        {formattedData.length === 0 && processedForEval === evalNum ? <p>This table is not available for the selected evaluation.</p>: formattedData.length > 0 ?
+        <>
         <section className='tableHeader'>
             <div className="filters">
                 <Autocomplete
@@ -325,6 +329,9 @@ export function RQ8({ evalNum }) {
                 </tbody>
             </table>
         </div>
+        </>
+        : null
+    }
         <Modal className='table-modal' open={showDefinitions} onClose={closeModal}>
             <div className='modal-body'>
                 <span className='close-icon' onClick={closeModal}><CloseIcon /></span>

--- a/dashboard-ui/src/components/Research/utils.js
+++ b/dashboard-ui/src/components/Research/utils.js
@@ -1072,6 +1072,15 @@ export function getEvalOptionsForPage(page) {
     return dropdownOptions;
 }
 
+export function getAllEvals() {
+    const dropdownOptions = [];
+    for (const evalData of store.getState()?.configs?.evals) {
+        dropdownOptions.push({ value: evalData.evalNumber, label: evalData.evalName });
+    }
+    dropdownOptions.reverse();
+    return dropdownOptions;
+}
+
 function matchesAttribute(attr, target) {
     const hasAF = target.includes('AF');
     const hasMF = target.includes('MF');

--- a/dashboard-ui/src/store/slices/configSlice.js
+++ b/dashboard-ui/src/store/slices/configSlice.js
@@ -8,6 +8,7 @@ const configSlice = createSlice({
         currentSurveyVersion: null,
         currentTextEval: null,
         currentStyle: null,
+        selectedResearchEval: null,
         evals: [],
         pidBounds: {
             lowPid: null,
@@ -41,10 +42,13 @@ const configSlice = createSlice({
         },
         setShowDemographics: (state, action) => {  
             state.showDemographics = action.payload;
+        },
+        setSelectedResearchEval: (state, action) => {
+            state.selectedResearchEval = action.payload
         }
     }
 });
 
-export const { addConfig, addTextBasedConfig, setCurrentSurveyVersion, setCurrentTextEval, setCurrentStyle, setEvals, setPidBounds, setShowDemographics } = configSlice.actions;
+export const { addConfig, addTextBasedConfig, setCurrentSurveyVersion, setCurrentTextEval, setCurrentStyle, setEvals, setPidBounds, setShowDemographics, setSelectedResearchEval } = configSlice.actions;
 export default configSlice.reducer;
 


### PR DESCRIPTION
Previously, eval dropdowns on each data analysis page (RQ1, RQ2, RQ3, ExploratoryAnalysis) were driven by admin toggles, a new eval had to be manually toggled on per page before it appeared in the dropdown. This PR replaces that behavior with a query-driven approach where all evals always appear in every dropdown. Individual tables now handle the case where no data exists for the selected eval by showing "This table is not available for the selected evaluation."

To Test: 

Verify all dropdowns (RQ1, RQ2, RQ3, ExploratoryAnalysis) show all evals
Select an eval with no data for a table — confirm "This table is not available for the selected evaluation" message appears
Select an eval with data, confirm table renders correctly
Switch between evals, confirm no stale data flash

I wasn't sure whether to include the `Blocked Table` and `Calibration Data` table in the checks so I left it for now.