### PR TITLE
ITM-1365 Reorganize Exploratory Analysis Page

### DIFF
--- a/dashboard-ui/src/components/Account/adminPage.jsx
+++ b/dashboard-ui/src/components/Account/adminPage.jsx
@@ -79,9 +79,15 @@ const UPDATE_TA3_USER = gql`
     }
 `;
 
+const UPDATE_EXTERNAL_SIM_RESEARCHER = gql`
+    mutation updateExternalSimResearcher($caller: JSON!, $username: String!, $isExternalSimResearcher: Boolean!) {
+        updateExternalSimResearcher(caller: $caller, username: $username, isExternalSimResearcher: $isExternalSimResearcher)
+    }
+`;
+
 const UPDATE_USER_APPROVAL = gql`
-    mutation updateUserApproval($caller: JSON!, $username: String!, $isApproved: Boolean!, $isRejected: Boolean!, $isAdmin: Boolean!, $isEvaluator: Boolean!, $isExperimenter: Boolean!, $isAdeptUser: Boolean!, $isTa3User: Boolean!) {
-        updateUserApproval(caller: $caller, username: $username, isApproved: $isApproved, isRejected: $isRejected, isAdmin: $isAdmin, isEvaluator: $isEvaluator, isExperimenter: $isExperimenter, isAdeptUser: $isAdeptUser, isTa3User: $isTa3User)
+    mutation updateUserApproval($caller: JSON!, $username: String!, $isApproved: Boolean!, $isRejected: Boolean!, $isAdmin: Boolean!, $isEvaluator: Boolean!, $isExperimenter: Boolean!, $isAdeptUser: Boolean!, $isTa3User: Boolean!, $isExternalSimResearcher: Boolean!) {
+        updateUserApproval(caller: $caller, username: $username, isApproved: $isApproved, isRejected: $isRejected, isAdmin: $isAdmin, isEvaluator: $isEvaluator, isExperimenter: $isExperimenter, isAdeptUser: $isAdeptUser, isTa3User: $isTa3User, isExternalSimResearcher: $isExternalSimResearcher)
     }
 `;
 
@@ -355,6 +361,7 @@ function ApprovalTable({ unapproved, updateUnapproved, caller }) {
                 isExperimenter: user.experimenter ?? false,
                 isAdeptUser: user.adeptUser ?? false,
                 isTa3User: user.ta3User ?? false,
+                isExternalSimResearcher: user.externalSimResearcher ?? false,
                 isRejected: false
             }
         });
@@ -376,6 +383,7 @@ function ApprovalTable({ unapproved, updateUnapproved, caller }) {
                 isExperimenter: false,
                 isAdeptUser: false,
                 isTa3User: false,
+                isExternalSimResearcher: user.externalSimResearcher ?? false,
                 isRejected: true
             }
         });
@@ -409,6 +417,9 @@ function ApprovalTable({ unapproved, updateUnapproved, caller }) {
                             <th className='switch-header'>
                                 TA3
                             </th>
+                            <th className='switch-header'>
+                                ExternalSimResearcher
+                            </th>
                             <th className='action-header'>
                                 Action
                             </th>
@@ -425,6 +436,7 @@ function ApprovalTable({ unapproved, updateUnapproved, caller }) {
                                     <td><Switch onChange={(e) => updateUserStatus(user._id, 'experimenter', e)} /></td>
                                     <td><Switch onChange={(e) => updateUserStatus(user._id, 'adeptUser', e)} /></td>
                                     <td><Switch onChange={(e) => updateUserStatus(user._id, 'ta3User', e)} /></td>
+                                    <td><Switch onChange={(e) => updateUserStatus(user._id, 'externalSimResearcher', e)} /></td>
                                     <td>
                                         <IconButton title='Approve' onClick={() => approveUser(user._id)} children={<CheckCircleIcon className='green-btn' />} />
                                         <IconButton title='Deny' onClick={() => denyUser(user._id)} children={<CancelIcon className='red-btn' />} /></td>
@@ -1040,13 +1052,14 @@ function AdminPage({ currentUser, updateUserHandler }) {
                             if (loading) return <div className="loading">Loading ...</div>;
                             if (error) return <div className="error">Error: {error.message}</div>;
 
-                            const nonSelected = { 'admin': [], 'evaluators': [], 'experimenters': [], 'adept': [], 'ta3': [] };
+                            const nonSelected = { 'admin': [], 'evaluators': [], 'experimenters': [], 'adept': [], 'ta3': [], 'externalSimResearcher': [] };
 
                             let adminSelectedOptions = [];
                             let evaluatorSelectedOptions = [];
                             let experimenterSelectedOptions = [];
                             let adeptSelectedOptions = [];
                             let ta3SelectedOptions = [];
+                            let externalSimResearcherSelectedOptions = [];
 
                             const users = data[getUsersQueryName].filter((x) => x.approved);
                             for (let i = 0; i < users.length; i++) {
@@ -1072,6 +1085,9 @@ function AdminPage({ currentUser, updateUserHandler }) {
                                 if (users[i].ta3User) {
                                     ta3SelectedOptions.push(users[i].username);
                                 }
+                                if (users[i].externalSimResearcher) {
+                                    externalSimResearcherSelectedOptions.push(users[i].username);
+                                }
                             }
 
                             return (
@@ -1081,6 +1097,7 @@ function AdminPage({ currentUser, updateUserHandler }) {
                                     <InputBox options={nonSelected['experimenters']} selectedOptions={experimenterSelectedOptions} mutation={UPDATE_EXPERIMENTER_USER} param={'isExperimenter'} header={'Experimenters'} caller={{ username: currentUser.username, sessionId }} errorCallback={notAdmin} />
                                     <InputBox options={nonSelected['ta3']} selectedOptions={ta3SelectedOptions} mutation={UPDATE_TA3_USER} param={'isTa3User'} header={'TA3'} caller={{ username: currentUser.username, sessionId }} errorCallback={notAdmin} />
                                     <InputBox options={nonSelected['adept']} selectedOptions={adeptSelectedOptions} mutation={UPDATE_ADEPT_USER} param={'isAdeptUser'} header={'ADEPT Users'} caller={{ username: currentUser.username, sessionId }} errorCallback={notAdmin} />
+                                    <InputBox options={nonSelected['externalSimResearcher']} selectedOptions={externalSimResearcherSelectedOptions} mutation={UPDATE_EXTERNAL_SIM_RESEARCHER} param={'isExternalSimResearcher'} header={'External Sim Researcher'} caller={{ username: currentUser.username, sessionId }} errorCallback={notAdmin} />
                                 </>
                             );
                         }}

--- a/dashboard-ui/src/components/App/Header.jsx
+++ b/dashboard-ui/src/components/App/Header.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isUserElevated, isUserTa3 } from '.';
+import { isUserElevated, isUserTa3, isUserExternalSimResearcher } from '.';
 import brandImage from '../../img/itm-logo.png';
 import userImage from '../../img/account_icon.png';
 import NavDropdown from 'react-bootstrap/NavDropdown';
@@ -61,27 +61,45 @@ export function Header({ currentUser, logout }) {
                             ADM Probe Responses
                         </NavDropdown.Item>
                     </NavDropdown>
-                    <NavDropdown title="Data Analysis">
-                        <NavDropdown.Item as={Link} className="dropdown-item" to="/research-results/rq1">
+                </>
+            )}
+            {(isUserElevated(currentUser) || isUserExternalSimResearcher(currentUser)) && (
+                <>
+                <NavDropdown title="Data Analysis">
+                        {isUserElevated(currentUser) && (
+                            <NavDropdown.Item as={Link} className="dropdown-item" to="/research-results/rq1">
                             RQ1
-                        </NavDropdown.Item>
-                        <NavDropdown.Item as={Link} className="dropdown-item" to="/research-results/rq2">
+                            </NavDropdown.Item>
+                        )}
+                        {isUserElevated(currentUser) && (
+                            <NavDropdown.Item as={Link} className="dropdown-item" to="/research-results/rq2">
                             RQ2
-                        </NavDropdown.Item>
-                        <NavDropdown.Item as={Link} className="dropdown-item" to="/research-results/rq3">
+                            </NavDropdown.Item>
+                        )}
+                        {isUserElevated(currentUser) && (
+                            <NavDropdown.Item as={Link} className="dropdown-item" to="/research-results/rq3">
                             RQ3
-                        </NavDropdown.Item>
-                        <NavDropdown.Item as={Link} className="dropdown-item" to="/research-results/exploratory-analysis">
-                            Exploratory Analysis
-                        </NavDropdown.Item>
-                        {isUserTa3(currentUser) && (
+                            </NavDropdown.Item>
+                        )}
+                        {(isUserElevated(currentUser) || isUserExternalSimResearcher(currentUser)) && (
+                            <NavDropdown.Item as={Link} className="dropdown-item" to="/research-results/open-world">
+                            Open World
+                            </NavDropdown.Item>
+                        )}
+                        {isUserElevated(currentUser) && (
+                            <NavDropdown.Item as={Link} className="dropdown-item" to="/research-results/open-world-adms">
+                            Open World ADMs
+                            </NavDropdown.Item>
+                        )}
+                        {(isUserTa3(currentUser) || isUserExternalSimResearcher(currentUser)) && (
                             <NavDropdown.Item as={Link} className="dropdown-item" to="/research-results/tccc">
                                         TCCC
                                     </NavDropdown.Item>
                             )}
                     </NavDropdown>
                 </>
-            )}
+            )
+        }
         </ul>
         <ul className="navbar-nav ml-auto">
             <li className="login-user">

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -26,8 +26,9 @@ import HumanResults from '../HumanResults/humanResults';
 import { RQ1 } from '../Research/RQ1';
 import { RQ2 } from '../Research/RQ2';
 import { RQ3 } from '../Research/RQ3';
-import { ExploratoryAnalysis } from '../Research/ExploratoryAnalysis';
+import { OpenWorld } from '../Research/OpenWorld';
 import { TcccAnalysis } from '../Research/TcccAnalysis';
+import { OpenWorldADMs } from '../Research/OpenWorldADMs';
 import { PidLookup } from '../Account/pidLookup';
 import StartOnline from '../OnlineOnly/OnlineOnly';
 import { ParticipantProgressTable } from '../Account/participantProgress';
@@ -118,6 +119,10 @@ export function isUserElevated(currentUser) {
 
 export function isUserTa3(currentUser) {
     return currentUser?.ta3User || currentUser?.admin
+}
+
+export function isUserExternalSimResearcher(currentUser) {
+    return currentUser?.externalSimResearcher || currentUser?.admin
 }
 
 export function App() {
@@ -523,8 +528,9 @@ export function App() {
                         {isUserElevated(currentUser) && <Route exact path="/research-results/rq1" component={RQ1} />}
                         {isUserElevated(currentUser) && <Route exact path="/research-results/rq2" component={RQ2} />}
                         {isUserElevated(currentUser) && <Route exact path="/research-results/rq3" component={RQ3} />}
-                        {isUserElevated(currentUser) && <Route exact path="/research-results/exploratory-analysis" component={ExploratoryAnalysis} />}
-                        {isUserTa3(currentUser) && <Route exact path="/research-results/tccc" component={TcccAnalysis} />}
+                        {(isUserElevated(currentUser) || isUserExternalSimResearcher(currentUser)) && <Route exact path="/research-results/open-world" component={OpenWorld} />}
+                        {(isUserTa3(currentUser) || isUserExternalSimResearcher(currentUser)) && <Route exact path="/research-results/tccc" component={TcccAnalysis} />}
+                        {isUserElevated(currentUser) && <Route exact path="/research-results/open-world-adms" component={OpenWorldADMs} />}
                         {/* Redirection logic: If user is not logged in, send to /login. 
                             If user is not approved, send to /awaitingApproval.
                             Otherwise, send to homepage */}

--- a/dashboard-ui/src/components/Research/OpenWorld.jsx
+++ b/dashboard-ui/src/components/Research/OpenWorld.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import { RQ134 } from "./tables/rq134";
 import './dre-rq.css';
 import { RQ5 } from "./tables/rq5";
 import { RQ8 } from "./tables/rq8";
 import { PH2RQ8 } from "./tables/ph2_rq8";
 import { PH2RQ8Apr26} from "./tables/ph2_rq8_apr26";
-import { PH2RQ8OWPart1 } from "./tables/ph2_rq8_ow_part1";
 import { RQ6 } from "./tables/rq6";
 import Select from 'react-select';
 import { RQ5_PH1 } from './tables/rq5_ph1';
@@ -16,7 +14,7 @@ import { PAGES, getAllEvals, getEvalOptionsForPage } from './utils';
 import { useSelector, useDispatch } from 'react-redux'
 import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
-export function ExploratoryAnalysis() {
+export function OpenWorld() {
     const evalOptions = getAllEvals();
     const evalRQ1Options = getEvalOptionsForPage(PAGES.RQ1);
     const dispatch = useDispatch()
@@ -51,40 +49,6 @@ export function ExploratoryAnalysis() {
                 <HumanVariability evalNum={selectedEval} />
             </div>
         }
-        {(hasRQ1Page && selectedEval !== 15) && ( 
-            <>
-            <div className="section-container">
-            <h2>RQ4: Does alignment score predict perceived alignment?</h2>
-            <p className='indented'>
-                <b>H<sub>1</sub></b> = Alignment score calculated between the responses of one human on attribute-driven
-                decision making and responses of an observed decision maker should predict that human's ratings of self-reported
-                alignment on the observed decision maker
-            </p>
-            <p className='indented'>
-                <b>H<sub>0</sub></b> = Alignment score does not predict self-reported alignment ratings
-            </p>
-            <p>We test this hypothesis by calculating the alignment score between decisions of a human
-                decision maker and the decisions of an observed decision maker and then regressing it
-                onto the self-reported alignment ratings given to the observed decision maker by the human.
-            </p>
-            <p>
-                <b>Independent variable (calculated):</b> Alignment score <br />
-                <b>Dependent variable:</b> Self-reported alignment rating on each observed DM
-            </p>
-        </div>
-        
-        <div className="section-container">
-            <RQ134 evalNum={selectedEval} tableTitle={'RQ4 Data'} />
-            <p>
-                <b>Variables used from dataset:</b>
-            </p>
-            <ul>
-                <li>Participant ID</li>
-                <li>Alignment Score (Delegator | Observed_ADM (target))</li>
-                <li>SRAlign_Rating</li>
-            </ul>
-        </div>
-        </>)}
 
         {selectedEval < 8 &&
             <>
@@ -163,13 +127,6 @@ export function ExploratoryAnalysis() {
         <div className="section-container">
             {RQ8Component ? <RQ8Component evalNum={selectedEval} /> : selectedEval < 8 ? <RQ8 evalNum={selectedEval} /> : <PH2RQ8 evalNum={selectedEval}/>}
         </div>
-
-        {selectedEval === 16 &&
-            <div className="section-container">
-                <h2>Open World Part 1</h2>
-                <PH2RQ8OWPart1 />
-            </div>
-        }
 
         {selectedEval !== 15 && selectedEval !== 16 && ( 
             <>

--- a/dashboard-ui/src/components/Research/OpenWorldADMs.jsx
+++ b/dashboard-ui/src/components/Research/OpenWorldADMs.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import './dre-rq.css';
+import { PH2RQ8OWPart1 } from "./tables/ph2_rq8_ow_part1";
+
+export function OpenWorldADMs() {
+
+    return (
+    <div className="section-container">
+                    <h2>Open World Part 1</h2>
+                    <PH2RQ8OWPart1 />
+                </div>
+    )            
+}

--- a/dashboard-ui/src/services/accountsService.js
+++ b/dashboard-ui/src/services/accountsService.js
@@ -34,6 +34,7 @@ const accountsGraphQL = new GraphQLClient({
       experimenter
       adeptUser
       ta3User
+      externalSimResearcher
       approved
       rejected
     }

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -18,6 +18,7 @@ const typeDefs = gql`
     experimenter: Boolean
     adeptUser: Boolean
     ta3User: Boolean
+    externalSimResearcher: Boolean
     approved: Boolean
     rejected: Boolean
   }
@@ -90,7 +91,8 @@ const typeDefs = gql`
     updateExperimenterUser(caller: JSON, username: String, isExperimenter: Boolean): JSON,
     updateAdeptUser(caller: JSON, username: String, isAdeptUser: Boolean): JSON,
     updateTa3User(caller: JSON, username: String, isTa3User: Boolean): JSON,
-    updateUserApproval(caller: JSON, username: String, isApproved: Boolean, isRejected: Boolean, isAdmin: Boolean, isEvaluator: Boolean, isExperimenter: Boolean, isAdeptUser: Boolean, isTa3User: Boolean): JSON,
+    updateExternalSimResearcher(caller: JSON, username: String, isExternalSimResearcher: Boolean): JSON,
+    updateUserApproval(caller: JSON, username: String, isApproved: Boolean, isRejected: Boolean, isAdmin: Boolean, isEvaluator: Boolean, isExperimenter: Boolean, isAdeptUser: Boolean, isTa3User: Boolean, isExternalSimResearcher: Boolean): JSON,
     updateEvalData(caller: JSON, dataToUpdate: JSON): JSON,
     addNewEval(caller: JSON, newEval: JSON): JSON,
     deleteEval(caller: JSON, evalId: String): JSON,
@@ -821,6 +823,21 @@ const resolvers = {
         });
       }
     },
+    updateExternalSimResearcher: async (obj, args, context, inflow) => {
+      const session = await context.db.collection('sessions').find({ "_id": new ObjectId(args['caller']?.['sessionId']) })?.project({ "userId": 1, "valid": 1 }).toArray().then(result => { return result[0] });
+      const user = await context.db.collection('users').find({ "username": args['caller']?.['username'] })?.project({ "_id": 1, "username": 1, "admin": 1 }).toArray().then(result => { return result[0] });
+      if (session?.valid && (session?.userId == user?._id) && user?.admin) {
+        return await context.db.collection('users').update(
+          { "username": args["username"] },
+          { $set: { "externalSimResearcher": args["isExternalSimResearcher"] } }
+        );
+      }
+      else {
+        throw new GraphQLError('Users outside of the admin group cannot update External Sim Researcher status.', {
+          extensions: { code: '404' }
+        });
+      }
+    },
     updateUserApproval: async (obj, args, context, inflow) => {
       const session = await context.db.collection('sessions').find({ "_id": new ObjectId(args['caller']?.['sessionId']) })?.project({ "userId": 1, "valid": 1 }).toArray().then(result => { return result[0] });
       const user = await context.db.collection('users').find({ "username": args['caller']?.['username'] })?.project({ "_id": 1, "username": 1, "admin": 1 }).toArray().then(result => { return result[0] });
@@ -835,6 +852,7 @@ const resolvers = {
               "experimenter": args["isExperimenter"],
               "evaluator": args["isEvaluator"],
               "ta3User": args["isTa3User"],
+              "externalSimResearcher": args["isExternalSimResearcher"],
               "admin": args["isAdmin"]
             }
           }


### PR DESCRIPTION
This PR reorganizes the Exploratory Analysis Page and Adds a new role to the admin page.

Changes:

1. Exploratory Analysis renamed to Open World
2. Open World ADM data previously in the Exploratory Analysis page has been moved to its own page called Open World ADMs
3. RQ4 is removed from the newly named Open World page.
4. The new `External Sim Researcher` role is created and only has access to the Open World and TCCC pages.

To check:

- Review the data Analysis tab to check that the correct names are being shown
- Check the Open World page and check to see if RQ4 has been completely removed
- View the Open World ADMs page to check for the Open World table.
- Create a new user and grant it the `External Sim Researcher` Role on the admin page. Log in with that user and see if you are only able to see the Open World and TCCC tabs in the Data Analysis tab.
