### PR TITLE
ITM 1353: June 2026 Del Loading Logic

### DIFF
--- a/dashboard-ui/src/components/Survey/dynamicPhase2.jsx
+++ b/dashboard-ui/src/components/Survey/dynamicPhase2.jsx
@@ -3,12 +3,10 @@ import { Table, Container } from 'react-bootstrap';
 import '../../css/dynamicPhase2.css';
 
 const trailingTextMap = {
-    'You are currently in a location with cover. Do you move to treat the casualty now, or wait in your current location?':
-        'You are currently in a location with cover. Do you move to treat the casualty now, or wait in your current location?',
-    'Which patient do you treat?':
-        'There are two patients, Patient A and Patient B, and you only have time to treat one of them. Which patient do you treat?',
-    'Do you stay with your current patient, or do you leave?':
-        'You arrive at the scene where you know there may be multiple casualties. Do you stay with your current patient, or do you leave?',
+    'You are currently in a location with cover. Do you move to treat the casualty now, or wait in your current location?': 'You are currently in a location with cover. Do you move to treat the casualty now, or wait in your current location?',
+    'Which patient do you treat?': 'There are two patients, Patient A and Patient B, and you only have time to treat one of them. Which patient do you treat?',
+    'Do you stay with your current patient, or do you leave?': 'You arrive at the scene where you know there may be multiple casualties. Do you stay with your current patient, or do you leave?',
+    'Do you move to treat one of the casualties now, or wait in your current location?': 'Do you move to treat one of the casualties now, or wait in your current location?'
 };
 
 const TARGET_PROMPT = 'You are currently in a location with cover. Do you move to treat the casualty now, or wait in your current location?';

--- a/dashboard-ui/src/components/Survey/dynamicPhase2.jsx
+++ b/dashboard-ui/src/components/Survey/dynamicPhase2.jsx
@@ -11,6 +11,15 @@ const trailingTextMap = {
 
 const TARGET_PROMPT = 'You are currently in a location with cover. Do you move to treat the casualty now, or wait in your current location?';
 const WARFIGHTER_TEXT = 'They are a warfighter in the same military unit as you.';
+const TREAT_PATIENT_KEY = 'Which patient do you treat?';
+const TRINARY_TREAT_PROMPT = 'There are three patients, Patient A, Patient B, and Patient C, and you only have time to treat one of them. Which patient do you treat?';
+
+const getGroupPrompt = (trailingKey, opts) => {
+    if (trailingKey === TREAT_PATIENT_KEY && opts && opts.length >= 3) {
+        return TRINARY_TREAT_PROMPT;
+    }
+    return trailingTextMap[trailingKey];
+};
 
 const transformRowText = (text, groupPrompt) => {
     if (groupPrompt === TARGET_PROMPT) {
@@ -141,7 +150,7 @@ const DynamicPhase2 = ({ rows, scenarioDescription, supplies, options }) => {
                     {orderedRows.map((row, index) => {
                         const optionsToUse = row.options || options;
                         const showGroupHeader = isNewGroup(index);
-                        const groupPrompt = row.trailingKey ? trailingTextMap[row.trailingKey] : null;
+                        const groupPrompt = row.trailingKey ? getGroupPrompt(row.trailingKey, optionsToUse) : null;
                         const cleanedRowText = transformRowText(row.strippedDescription, groupPrompt);
 
                         // fewer choices than the table's max (keeps grid aligned).

--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -230,13 +230,16 @@ class SurveyPage extends Component {
                 .filter(Boolean);
             finalize(shuffle(allBlocks));
         } else if (version === "12.0") {
+            const isEven = parseInt(this.state.pid, 10) % 2 === 0;
+            const group1 = new Set(['PS-tri', 'AF-bi']);
+            const getVersion = (attr, type) => group1.has(`${attr}-${type}`) === isEven ? 'A' : 'B';
             const blockTypes = shuffle([
                 { attr: 'AF', type: 'tri' }, { attr: 'AF', type: 'bi' },
                 { attr: 'PS', type: 'tri' }, { attr: 'PS', type: 'bi' },
                 { attr: 'AF-SS', type: '2D' },
             ]);
             const allBlocks = blockTypes
-                .map(blockType => createScenarioBlockv12(blockType, allPages, participantTextResults))
+                .map(blockType => createScenarioBlockv12(blockType, allPages, participantTextResults, getVersion(blockType.attr, blockType.type)))
                 .filter(Boolean);
             finalize(allBlocks);
         }

--- a/dashboard-ui/src/components/Survey/survey.jsx
+++ b/dashboard-ui/src/components/Survey/survey.jsx
@@ -186,6 +186,7 @@ class SurveyPage extends Component {
             const finalPages = [...introPages, ...blocks.flatMap(getPages)];
             if (postScenarioPage) finalPages.push(postScenarioPage);
             this.surveyConfigClone.pages = finalPages;
+            console.log(finalPages)
             this.setState({ orderLog: finalPages.map(page => page.name) });
         };
 

--- a/dashboard-ui/src/components/Survey/surveyUtils.js
+++ b/dashboard-ui/src/components/Survey/surveyUtils.js
@@ -2132,9 +2132,7 @@ export const createScenarioBlockv12 = (scenarioType, allPages, textResults) => {
     const ordered = (entry?.response || []).filter(o => keyMatches(Object.keys(o)[0]));
     if (!ordered.length) { console.warn(`No alignment targets for v12 block ${blockKey}`); return null; }
 
-    const mostAlignedTarget = Object.keys(ordered[0])[0];
-    const leastAlignedTarget = Object.keys(ordered.at(-1))[0];
-
+    const pageForEntry = o => findPage(Object.keys(o)[0]);
     const findPage = (target, baseline = false) => allPages.find(page =>
         config.indexMatch(page.scenarioIndex) &&
         (baseline
@@ -2142,12 +2140,35 @@ export const createScenarioBlockv12 = (scenarioType, allPages, textResults) => {
             : (!page.admName?.includes('Baseline') && page.target === target))
     );
 
-    const alignedAdm = findPage(mostAlignedTarget);
+    // baseline is always the baseline
     const baselineAdm = findPage(null, true);
-    const misalignedAdm = includeMisaligned ? findPage(leastAlignedTarget) : null;
+    if (!baselineAdm) { console.warn(`Missing baseline ADM page for v12 block ${blockKey}`); return null; }
 
-    if (!alignedAdm || !baselineAdm || (includeMisaligned && !misalignedAdm)) {
-        console.warn(`Missing ADM pages for v12 block ${blockKey} - aligned:${!!alignedAdm} baseline:${!!baselineAdm} misaligned:${!!misalignedAdm}`);
+    // most aligned: walk down from the top until we find one that doesn't
+    // behave identically to the baseline
+    let alignedAdm = null;
+    for (const o of ordered) {
+        const candidate = pageForEntry(o);
+        if (candidate && !haveSameResponses(candidate, baselineAdm)) { alignedAdm = candidate; break; }
+    }
+
+    // least aligned: walk up from the bottom until we find one that doesn't
+    // overlap with either the most aligned or the baseline
+    let misalignedAdm = null;
+    if (includeMisaligned) {
+        for (let i = ordered.length - 1; i >= 0; i--) {
+            const candidate = pageForEntry(ordered[i]);
+            if (candidate &&
+                !haveSameResponses(candidate, alignedAdm) &&
+                !haveSameResponses(candidate, baselineAdm)) {
+                misalignedAdm = candidate;
+                break;
+            }
+        }
+    }
+
+    if (!alignedAdm || (includeMisaligned && !misalignedAdm)) {
+        console.warn(`Missing ADM pages for v12 block ${blockKey} - aligned:${!!alignedAdm} misaligned:${!!misalignedAdm}`);
         return null;
     }
 

--- a/dashboard-ui/src/components/Survey/surveyUtils.js
+++ b/dashboard-ui/src/components/Survey/surveyUtils.js
@@ -2101,9 +2101,68 @@ const onlineOnlyTitles = {
 }
 
 export const createScenarioBlockv12 = (scenarioType, allPages, textResults) => {
+    const { attr, type } = scenarioType;
+    const blockKey = `${attr}-${type}`;
 
-}
+    const configs = {
+        'AF-tri':   { scenarioId: 'June2026-AF-assess-trinary', field: 'combinedMostLeastAligned', include: ['AF'], exclude: ['MF', 'PS', 'SS'], indexMatch: idx => idx?.includes('AF') && idx?.includes('trinary') },
+        'AF-bi':    { scenarioId: 'June2026-AF-assess',         field: 'combinedMostLeastAligned', include: ['AF'], exclude: ['MF', 'PS', 'SS'], indexMatch: idx => idx?.includes('AF') && !idx?.includes('trinary') && !idx?.includes('SS') },
+        'PS-tri':   { scenarioId: 'June2026-PS-assess-trinary', field: 'combinedMostLeastAligned', include: ['PS'], exclude: ['MF', 'AF', 'SS'], indexMatch: idx => idx?.includes('PS') && idx?.includes('trinary') },
+        'PS-bi':    { scenarioId: 'June2026-PS-assess',         field: 'combinedMostLeastAligned', include: ['PS'], exclude: ['MF', 'AF', 'SS'], indexMatch: idx => idx?.includes('PS') && !idx?.includes('trinary') },
+        'AF-SS-2D': { scenarioId: 'June2026-AF-assess',         field: 'AF-SS_mostLeastAligned',   include: ['AF', 'SS'], exclude: ['MF', 'PS'], indexMatch: idx => idx?.includes('AF') && idx?.includes('SS') },
+    };
 
-const genComparisonPagev12 = (aligned, baseline, misaligned) => {
+    const config = configs[blockKey];
+    if (!config) { console.warn(`Unknown v12 block: ${blockKey}`); return null; }
 
-}
+    // AF-SS loads aligned + baseline only
+    const includeMisaligned = attr !== 'AF-SS';
+
+    const doc = textResults.find(r => r.scenario_id === config.scenarioId);
+    if (!doc) { console.warn(`No text document ${config.scenarioId} for v12 block ${blockKey}`); return null; }
+
+    const entry = doc[config.field]?.find(o => o.target === null) ?? doc[config.field]?.[0];
+
+    const isGroupKey = key => key.split('-').pop().includes('_');
+    const keyMatches = key =>
+        !isGroupKey(key) &&
+        config.include.every(c => key.includes(c)) &&
+        config.exclude.every(c => !key.includes(c));
+
+    const ordered = (entry?.response || []).filter(o => keyMatches(Object.keys(o)[0]));
+    if (!ordered.length) { console.warn(`No alignment targets for v12 block ${blockKey}`); return null; }
+
+    const mostAlignedTarget = Object.keys(ordered[0])[0];
+    const leastAlignedTarget = Object.keys(ordered.at(-1))[0];
+
+    const findPage = (target, baseline = false) => allPages.find(page =>
+        config.indexMatch(page.scenarioIndex) &&
+        (baseline
+            ? page.admName?.includes('Baseline')
+            : (!page.admName?.includes('Baseline') && page.target === target))
+    );
+
+    const alignedAdm = findPage(mostAlignedTarget);
+    const baselineAdm = findPage(null, true);
+    const misalignedAdm = includeMisaligned ? findPage(leastAlignedTarget) : null;
+
+    if (!alignedAdm || !baselineAdm || (includeMisaligned && !misalignedAdm)) {
+        console.warn(`Missing ADM pages for v12 block ${blockKey} - aligned:${!!alignedAdm} baseline:${!!baselineAdm} misaligned:${!!misalignedAdm}`);
+        return null;
+    }
+
+    Object.assign(alignedAdm, { alignment: 'aligned', admChoiceProcess: 'most aligned' });
+    baselineAdm.alignment = 'baseline';
+    if (misalignedAdm) Object.assign(misalignedAdm, { alignment: 'misaligned', admChoiceProcess: 'least aligned' });
+
+    const admPages = [alignedAdm, baselineAdm, ...(misalignedAdm ? [misalignedAdm] : [])];
+
+    return {
+        type: blockKey,
+        pages: [...shuffle(admPages), genComparisonPagev12(alignedAdm, baselineAdm, misalignedAdm)]
+    };
+};
+
+// same logic as version 10
+const genComparisonPagev12 = (aligned, baseline, misaligned) =>
+    genComparisonPagev10(aligned, baseline, misaligned);

--- a/dashboard-ui/src/components/Survey/surveyUtils.js
+++ b/dashboard-ui/src/components/Survey/surveyUtils.js
@@ -2100,7 +2100,7 @@ const onlineOnlyTitles = {
     'B': 'Waves of 8-10 patients are being discovered, requiring medical assistance. If you had to triage the next wave of patients, knowing there are more coming, and the medic above was available, how would you allocate responsibilities?'
 }
 
-export const createScenarioBlockv12 = (scenarioType, allPages, textResults) => {
+export const createScenarioBlockv12 = (scenarioType, allPages, textResults, delVersion) => {
     const { attr, type } = scenarioType;
     const blockKey = `${attr}-${type}`;
 
@@ -2178,8 +2178,16 @@ export const createScenarioBlockv12 = (scenarioType, allPages, textResults) => {
 
     const admPages = [alignedAdm, baselineAdm, ...(misalignedAdm ? [misalignedAdm] : [])];
 
+    // enforce delVersion
+    const removeVersion = delVersion === 'A' ? 'Del Version B' : 'Del Version A';
+    admPages.forEach(page => {
+        if (!page?.elements) return;
+        page.elements = page.elements.filter(el => !el.name?.includes(removeVersion));
+    });
+
     return {
         type: blockKey,
+        delVersion,
         pages: [...shuffle(admPages), genComparisonPagev12(alignedAdm, baselineAdm, misalignedAdm)]
     };
 };


### PR DESCRIPTION
Run [Ingest Pr](https://github.com/NextCenturyCorporation/itm-ingest/pull/229) first

If you already have some test text-based scenario data from my [previous pr](https://github.com/NextCenturyCorporation/itm-evaluation-dashboard/pull/474), you can skip right to taking the delegation survey using that participant ID. If not, follow the instructions in that pr to get some test data.

Make sure your survey version is set to `12.0` on http://localhost:3000/admin. Go to http://localhost:3000/survey and enter the participant ID from your text-based scenario data. 

I have left in a console log to help confirm that the survey has loaded correctly
<img width="816" height="304" alt="Screenshot 2026-06-05 at 11 55 55 AM" src="https://github.com/user-attachments/assets/9056a506-656e-48b6-91e7-2dbda7f5ac8a" />

The survey should contain all of the blocks listed in the diagram below (order randomized)
<img width="1200" height="675" alt="image (2)" src="https://github.com/user-attachments/assets/12f697c2-926c-4400-b142-761f2d08450a" />

You can confirm that the correct targets were loaded by using the console log in tandem with the `userScenarioResults` collection. For example, we can see from the console log that `Jun2026-PS-trinomial-8` was loaded as the most-aligned target for that scenario. If we check our text-based results, we will see that `Jun2026-PS-trinomial-8` is listed as the most aligned PS-tri target in our `combinedMostLeastAligned` array (returned from ADEPT server). 
<img width="723" height="510" alt="Screenshot 2026-06-05 at 12 07 23 PM" src="https://github.com/user-attachments/assets/9851d52e-bda9-4021-9fdf-3b0aef74524d" />

When you complete the survey, make sure that your results upload properly to `surveyResults`