### PR TITLE
ITM-1371 Data Analysis Reorg

### DIFF
--- a/dashboard-ui/src/components/Account/editEvals.jsx
+++ b/dashboard-ui/src/components/Account/editEvals.jsx
@@ -162,7 +162,7 @@ export function EditEvals({ caller }) {
                 "rq1": true, 
                 "rq2": true,
                 "rq3": true,
-                "exploratoryAnalysis": selectedPages.includes('/exploratory-analysis'),
+                "exploratoryAnalysis": true,
                 "admProbeResponses": selectedPages.includes('/adm-probe-responses'),
                 "admAlignment": selectedPages.includes('/adm-results'),
                 "admResults": selectedPages.includes('/results'),

--- a/dashboard-ui/src/components/App/Header.jsx
+++ b/dashboard-ui/src/components/App/Header.jsx
@@ -91,6 +91,11 @@ export function Header({ currentUser, logout }) {
                             Open World ADMs
                             </NavDropdown.Item>
                         )}
+                        {isUserElevated(currentUser) && (
+                            <NavDropdown.Item as={Link} className="dropdown-item" to="/research-results/exploratory-analysis">
+                            Exploratory Analysis
+                            </NavDropdown.Item>
+                        )}
                         {(isUserElevated(currentUser) || isUserExternalSimResearcher(currentUser)) && (
                             <NavDropdown.Item as={Link} className="dropdown-item" to="/research-results/participant-demographics">
                                 Participant Demographics

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -30,6 +30,7 @@ import { OpenWorld } from '../Research/OpenWorld';
 import { TcccAnalysis } from '../Research/TcccAnalysis';
 import { OpenWorldADMs } from '../Research/OpenWorldADMs';
 import { ParticipantDemographics } from '../Research/ParticipantDemographics';
+import { ExploratoryAnalysis } from '../Research/ExploratoryAnalysis'  
 import { PidLookup } from '../Account/pidLookup';
 import StartOnline from '../OnlineOnly/OnlineOnly';
 import { ParticipantProgressTable } from '../Account/participantProgress';
@@ -530,6 +531,7 @@ export function App() {
                         {isUserElevated(currentUser) && <Route exact path="/research-results/rq1" component={RQ1} />}
                         {isUserElevated(currentUser) && <Route exact path="/research-results/rq2" component={RQ2} />}
                         {isUserElevated(currentUser) && <Route exact path="/research-results/rq3" component={RQ3} />}
+                        {isUserElevated(currentUser) && <Route exact path="/research-results/exploratory-analysis" component={ExploratoryAnalysis} />}
                         {(isUserElevated(currentUser) || isUserExternalSimResearcher(currentUser)) && <Route exact path="/research-results/open-world" component={OpenWorld} />}
                         {(isUserElevated(currentUser) || isUserExternalSimResearcher(currentUser)) && <Route exact path="/research-results/participant-demographics" component={ParticipantDemographics} />}
                         {(isUserTa3(currentUser) || isUserExternalSimResearcher(currentUser)) && <Route exact path="/research-results/tccc" component={TcccAnalysis} />}

--- a/dashboard-ui/src/components/Research/ExploratoryAnalysis.jsx
+++ b/dashboard-ui/src/components/Research/ExploratoryAnalysis.jsx
@@ -5,20 +5,19 @@ import { RQ6 } from "./tables/rq6";
 import Select from 'react-select';
 import { RQ5_PH1 } from './tables/rq5_ph1';
 import { HumanVariability } from './tables/humanVariability';
-import { BlockedTable } from './tables/BlockedTable';
 import { CalibrationData } from './tables/CalibrationData';
 import { getAllEvals } from './utils';
 import { useSelector, useDispatch } from 'react-redux'
 import { setSelectedResearchEval } from '../../store/slices/configSlice';
-import { Alert } from "@mui/material";
 
 
 export function ExploratoryAnalysis() {
+    const noDataList = [8, 9, 10, 11, 12, 14, 15, 16, 17]
     const evalOptions = getAllEvals();
     const dispatch = useDispatch()
     const storedEval = useSelector(state => state.configs.selectedResearchEval)  
     const selectedEval = storedEval ?? evalOptions[0].value;
-    const hasData = selectedEval !== 15 && selectedEval !== 16 && selectedEval !== 17
+    const hasData = !noDataList.includes(selectedEval)
     function selectEvaluation(target) {
         dispatch(setSelectedResearchEval(target.value))
     }
@@ -106,9 +105,6 @@ export function ExploratoryAnalysis() {
 
         {selectedEval !== 15 && selectedEval !== 16 && ( 
             <>
-                <div className="section-container">
-                    <BlockedTable evalNum={selectedEval} />
-                </div>
                 {selectedEval > 4 && selectedEval < 8 &&
                     <div className="section-container">
                         <CalibrationData evalNum={selectedEval} />
@@ -117,9 +113,9 @@ export function ExploratoryAnalysis() {
             </>
         )}
         </>
-        : <Alert 
-        style={{marginTop: '10px'}}
-        severity="info">No data available</Alert>
+        : <p
+        style={{marginTop: '10px', marginLeft: '30px'}}
+        >No data available for the selected evaluation.</p>
     }
     </div>);
 }

--- a/dashboard-ui/src/components/Research/ExploratoryAnalysis.jsx
+++ b/dashboard-ui/src/components/Research/ExploratoryAnalysis.jsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import './dre-rq.css';
+import { RQ5 } from "./tables/rq5";
+import { RQ6 } from "./tables/rq6";
+import Select from 'react-select';
+import { RQ5_PH1 } from './tables/rq5_ph1';
+import { HumanVariability } from './tables/humanVariability';
+import { BlockedTable } from './tables/BlockedTable';
+import { CalibrationData } from './tables/CalibrationData';
+import { getAllEvals } from './utils';
+import { useSelector, useDispatch } from 'react-redux'
+import { setSelectedResearchEval } from '../../store/slices/configSlice';
+import { Alert } from "@mui/material";
+
+
+export function ExploratoryAnalysis() {
+    const evalOptions = getAllEvals();
+    const dispatch = useDispatch()
+    const storedEval = useSelector(state => state.configs.selectedResearchEval)  
+    const selectedEval = storedEval ?? evalOptions[0].value;
+    const hasData = selectedEval !== 15 && selectedEval !== 16 && selectedEval !== 17
+    function selectEvaluation(target) {
+        dispatch(setSelectedResearchEval(target.value))
+    }
+
+    return (<div className="researchQuestion">
+        <div className="rq-selection-section">
+            <Select
+                onChange={selectEvaluation}
+                options={evalOptions}
+                defaultValue={evalOptions[0]}
+                placeholder="Select Evaluation"
+                value={evalOptions.find(option => option.value === selectedEval)}
+                styles={{
+                    // Fixes the overlapping problem of the component
+                    menu: provided => ({ ...provided, zIndex: 9999 })
+                }}
+            />
+        </div>
+        {hasData ?
+        <>
+        {selectedEval === 13 &&
+            <div className="section-container">
+                <HumanVariability evalNum={selectedEval} />
+            </div>
+        }
+
+        {selectedEval < 8 &&
+            <>
+                <div className="section-container">
+                    <h2>RQ5: To what extent does alignment score predict identical behavior at the probe level in patterns of real human behavior?</h2>
+                    <p className='indented'>
+                        <b>H<sub>1</sub></b> = Alignment scores as calculated by the TA1s will be positively related to the % of exact matches in probe responses
+                    </p>
+                    <p className='indented'>
+                        <b>H<sub>0</sub></b> = Alignment scores as calculated by the TA1s will not be positively related to the % of exact matches in probe responses
+                    </p>
+                    <p>For each pair of DMs (human and ADM) that completed the same scenario, we will calculate the percentage of probes answered exactly the same and
+                        look at the correlation between the alignment score and the percentage of probes answered the same as an indicator of how the relationship
+                        between alignment score, as calculated at a scenario level by the characterization teams, and the behavioral responses of the human and ADM.
+                    </p>
+                    <p className='indented'>
+                        <b>H<sub>1</sub></b> = Alignment scores to group targets, as calculated by the TA1s, will be positively related to the % of exact matches
+                        in probe responses among group members
+                    </p>
+                    <p className='indented'>
+                        <b>H<sub>0</sub></b> = Alignment scores to group targets, as calculated by the TA1s, will not be positively related to the % of exact matches
+                        in probe responses among group members
+                    </p>
+                    <p>Similarly, we can also examine the correlation between alignment score to a group target and the % of probes answered the same as group members
+                        as an indicator of the relationship between alignment score and behavioral response. We can calculate, for each probe, the probe agreement
+                        between an individual and a group as the percentage of group individuals who answered the question in the same way
+                    </p>
+                    <p>
+                        <b>Dependent variables:</b> Alignment score and % matching probe responses
+                    </p>
+                </div>
+                <div className="section-container">
+                    {selectedEval === 5 ?
+                        <RQ5_PH1 evalNum={selectedEval} /> :
+                        <RQ5 evalNum={selectedEval} />}
+
+
+                </div>
+
+
+                <div className="section-container">
+                    <h2>RQ6: Does attribute assessment in different formats produce the same results?</h2>
+                    <p className='indented'>
+                        <b>H<sub>1</sub></b> = The human delegator probe responses in the text scenarios should be highly aligned to the same delegator’s probe responses in the simulated scenario.
+                    </p>
+                    <p className='indented'>
+                        <b>H<sub>0</sub></b> = The human delegator probe responses in the text scenarios should not be aligned to the same delegator’s probe responses in the simulated scenario.
+                    </p>
+                </div>
+                <div className="section-container">
+                    <RQ6 evalNum={selectedEval} />
+                </div>
+
+                <div className="section-container">
+                    <h2>RQ7: Exploratory: How do the attributes interact?</h2>
+                    <p>TBD</p>
+                </div>
+            </>
+        }
+
+        {selectedEval !== 15 && selectedEval !== 16 && ( 
+            <>
+                <div className="section-container">
+                    <BlockedTable evalNum={selectedEval} />
+                </div>
+                {selectedEval > 4 && selectedEval < 8 &&
+                    <div className="section-container">
+                        <CalibrationData evalNum={selectedEval} />
+                    </div>
+                }
+            </>
+        )}
+        </>
+        : <Alert 
+        style={{marginTop: '10px'}}
+        severity="info">No data available</Alert>
+    }
+    </div>);
+}

--- a/dashboard-ui/src/components/Research/OpenWorld.jsx
+++ b/dashboard-ui/src/components/Research/OpenWorld.jsx
@@ -1,113 +1,44 @@
 import React from 'react';
 import './dre-rq.css';
-import { RQ5 } from "./tables/rq5";
 import { RQ8 } from "./tables/rq8";
 import { PH2RQ8 } from "./tables/ph2_rq8";
 import { PH2RQ8Apr26} from "./tables/ph2_rq8_apr26";
-import { RQ6 } from "./tables/rq6";
 import Select from 'react-select';
-import { RQ5_PH1 } from './tables/rq5_ph1';
-import { HumanVariability } from './tables/humanVariability';
-import { BlockedTable } from './tables/BlockedTable';
-import { CalibrationData } from './tables/CalibrationData';
-import { PAGES, getAllEvals, getEvalOptionsForPage } from './utils';
+import { getAllEvals } from './utils';
 import { useSelector, useDispatch } from 'react-redux'
 import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
 export function OpenWorld() {
+    const evalAllowList = [4, 5, 6, 8, 9, 10, 12, 15, 16, 17]
     const evalOptions = getAllEvals();
-    const evalRQ1Options = getEvalOptionsForPage(PAGES.RQ1);
     const dispatch = useDispatch()
-    const storedEval = useSelector(state => state.configs.selectedResearchEval)  
+    const storedEval = useSelector(state => state.configs.selectedResearchEval)
+    
+    const filteredEvals = evalOptions.filter(x => 
+        evalAllowList.includes(x.value)
+    )
 
-    const selectedEval = storedEval ?? evalOptions[0].value;
+    const selectedEval = evalAllowList.includes(storedEval) ? storedEval : filteredEvals[0].value
     function selectEvaluation(target) {
         dispatch(setSelectedResearchEval(target.value))
     }
 
-    // Extract all evaluation values that have an RQ1 page to conditionally render RQ4 content 
-    const rq1Values = evalRQ1Options.map(option => option.value); 
-    const hasRQ1Page = rq1Values.includes(selectedEval);
     const rq8Map = { 16: PH2RQ8Apr26 };
     const RQ8Component = rq8Map[selectedEval]
     return (<div className="researchQuestion">
         <div className="rq-selection-section">
             <Select
                 onChange={selectEvaluation}
-                options={evalOptions}
-                defaultValue={evalOptions[0]}
+                options={filteredEvals}
+                defaultValue={filteredEvals[0]}
                 placeholder="Select Evaluation"
-                value={evalOptions.find(option => option.value === selectedEval)}
+                value={filteredEvals.find(option => option.value === selectedEval)}
                 styles={{
                     // Fixes the overlapping problem of the component
                     menu: provided => ({ ...provided, zIndex: 9999 })
                 }}
             />
         </div>
-        {selectedEval === 13 &&
-            <div className="section-container">
-                <HumanVariability evalNum={selectedEval} />
-            </div>
-        }
-
-        {selectedEval < 8 &&
-            <>
-                <div className="section-container">
-                    <h2>RQ5: To what extent does alignment score predict identical behavior at the probe level in patterns of real human behavior?</h2>
-                    <p className='indented'>
-                        <b>H<sub>1</sub></b> = Alignment scores as calculated by the TA1s will be positively related to the % of exact matches in probe responses
-                    </p>
-                    <p className='indented'>
-                        <b>H<sub>0</sub></b> = Alignment scores as calculated by the TA1s will not be positively related to the % of exact matches in probe responses
-                    </p>
-                    <p>For each pair of DMs (human and ADM) that completed the same scenario, we will calculate the percentage of probes answered exactly the same and
-                        look at the correlation between the alignment score and the percentage of probes answered the same as an indicator of how the relationship
-                        between alignment score, as calculated at a scenario level by the characterization teams, and the behavioral responses of the human and ADM.
-                    </p>
-                    <p className='indented'>
-                        <b>H<sub>1</sub></b> = Alignment scores to group targets, as calculated by the TA1s, will be positively related to the % of exact matches
-                        in probe responses among group members
-                    </p>
-                    <p className='indented'>
-                        <b>H<sub>0</sub></b> = Alignment scores to group targets, as calculated by the TA1s, will not be positively related to the % of exact matches
-                        in probe responses among group members
-                    </p>
-                    <p>Similarly, we can also examine the correlation between alignment score to a group target and the % of probes answered the same as group members
-                        as an indicator of the relationship between alignment score and behavioral response. We can calculate, for each probe, the probe agreement
-                        between an individual and a group as the percentage of group individuals who answered the question in the same way
-                    </p>
-                    <p>
-                        <b>Dependent variables:</b> Alignment score and % matching probe responses
-                    </p>
-                </div>
-                <div className="section-container">
-                    {selectedEval === 5 ?
-                        <RQ5_PH1 evalNum={selectedEval} /> :
-                        <RQ5 evalNum={selectedEval} />}
-
-
-                </div>
-
-
-                <div className="section-container">
-                    <h2>RQ6: Does attribute assessment in different formats produce the same results?</h2>
-                    <p className='indented'>
-                        <b>H<sub>1</sub></b> = The human delegator probe responses in the text scenarios should be highly aligned to the same delegator’s probe responses in the simulated scenario.
-                    </p>
-                    <p className='indented'>
-                        <b>H<sub>0</sub></b> = The human delegator probe responses in the text scenarios should not be aligned to the same delegator’s probe responses in the simulated scenario.
-                    </p>
-                </div>
-                <div className="section-container">
-                    <RQ6 evalNum={selectedEval} />
-                </div>
-
-                <div className="section-container">
-                    <h2>RQ7: Exploratory: How do the attributes interact?</h2>
-                    <p>TBD</p>
-                </div>
-            </>
-        }
 
         <div className="section-container">
             <h2>RQ8: Exploratory: How do the assessed attributes predict behavior in open triage scenarios?</h2>
@@ -127,19 +58,6 @@ export function OpenWorld() {
         <div className="section-container">
             {RQ8Component ? <RQ8Component evalNum={selectedEval} /> : selectedEval < 8 ? <RQ8 evalNum={selectedEval} /> : <PH2RQ8 evalNum={selectedEval}/>}
         </div>
-
-        {selectedEval !== 15 && selectedEval !== 16 && ( 
-            <>
-                <div className="section-container">
-                    <BlockedTable evalNum={selectedEval} />
-                </div>
-                {selectedEval > 4 && selectedEval < 8 &&
-                    <div className="section-container">
-                        <CalibrationData evalNum={selectedEval} />
-                    </div>
-                }
-            </>
-        )}
 
     </div>);
 }


### PR DESCRIPTION
Summary of Changes:
- Moved all non-RQ8 research content (RQ5, RQ6, RQ7, HumanVariability, BlockedTable, CalibrationData) from Open World into a new Exploratory Analysis page
- Open World now shows only RQ8, with the eval dropdown filtered to only include evals that have open world data (evals 4–6, 8–10, 12, 15–17)
- Exploratory Analysis shows a "No data available" message for evals without misc dataset content (evals 15, 16, 17 and any future evals)

Grab latest db backup from S3

Review http://localhost:3000/research-results/exploratory-analysis and http://localhost:3000/research-results/open-world and check that no RQ8 data is in exploratory analysis and no other datasets besides rq8 are in the Open World page. 

The dropdown for Openworld should only show evaluations that have RQ8 data.

Because the dropdown for Openworld only shows certain evals, the eval sticky selector will default to the current evaluation on the Open World page if the user views an evaluation on another Data Analysis that isn't included in Open World and switches to the Open World Page

June 2026 Evaluation is pending the RQ8 data which is why it shows up in the Open World Dropdown
