### PR TITLE
ITM-1410: Progress Table Eval Name Bug

### DIFF
--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -14,7 +14,7 @@ import { setScenarioCompletion, SCENARIO_HEADERS, checkAlignmentStatus } from ".
 import { accountsClient } from "../../services/accountsService";
 import AdmInfoModal from "./admInfoModal";
 import RepairAlignmentModal from "./repairAlignmentModal";
-
+import { evalNameToNumber } from "../OnlineOnly/config";
 
 const GET_PARTICIPANT_LOG = gql`
     query GetParticipantLog {
@@ -69,6 +69,11 @@ const computeDelThreshold = (evalNumber, isUK, isPH2OrUK) => {
     if (isPH2OrUK && !DEL_THRESHOLD_4_EVALS.has(evalNumber)) return 5;
     return 4;
 };
+
+// basically reverses the evalNameToNumber dict
+const numberToEvalName = Object.fromEntries(
+    Object.entries(evalNameToNumber).map(([name, num]) => [num, name])
+);
 
 
 const formatDateTime = (date) => {
@@ -415,6 +420,12 @@ export function ParticipantProgressTable({ canViewProlific = false, isAdmin = fa
                         obj['_phase'] = 1;
                         obj['_evalNumber'] = 1;
                     }
+                }
+
+                // for eval numbers not in the map (e.g. legacy Phase 1 records).
+                const canonicalEvalName = numberToEvalName[obj['_evalNumber']];
+                if (canonicalEvalName) {
+                    obj['Evaluation'] = canonicalEvalName.replace(/Phase 2\s*/g, '');
                 }
 
                 // set scenario completions using utility function


### PR DESCRIPTION
http://localhost:3000/participant-progress-table
Eval names displayed are now derived from their eval numbers so that if we have any discrepancies from the various data files, they will still be properly consolidated under one evaluation in the dropdown. 

Prod:
<img width="189" height="271" alt="Screenshot 2026-07-09 at 5 54 58 PM" src="https://github.com/user-attachments/assets/513a098d-79ba-4207-b960-b0d91ecee87b" />

Feature Branch:
<img width="205" height="251" alt="Screenshot 2026-07-09 at 5 54 41 PM" src="https://github.com/user-attachments/assets/2bfb99ed-1c20-4cdd-a7a8-eb9883dfe93a" />
