### PR TITLE
Itm 1394: Text Scenarios Guard & Resume Partially Completed Run

### DIFF
--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -60,7 +60,7 @@ const TEXT_THRESHOLD_BY_EVAL = { 13: 12, 17: 6 };
 // Phase 2 evals that use a delegation threshold of 4 instead of 5
 const DEL_THRESHOLD_4_EVALS = new Set([10, 16]);
 
-const computeTextThreshold = (evalNumber, isPH2OrUK) =>
+export const computeTextThreshold = (evalNumber, isPH2OrUK) =>
     TEXT_THRESHOLD_BY_EVAL[evalNumber] ?? (isPH2OrUK ? 4 : 5);
 
 const computeDelThreshold = (evalNumber, isUK, isPH2OrUK) => {

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -40,7 +40,7 @@ import { phase1ParticipantData, juneJulyParticipantData, evalNameToNumber, septe
 import { useSelector } from 'react-redux';
 import { checkAlignmentStatus } from '../Account/progressUtils';
 import { computeTextThreshold } from '../Account/participantProgress';
-import { alreadyCompleteModal } from '../TextBasedResults/alreadyCompleteModal'
+import { alreadyCompleteModal } from '../TextBasedScenarios/alreadyCompleteModal'
 // CSS and Image Stuff 
 import '../../css/app.css';
 import 'rc-slider/assets/index.css';
@@ -367,14 +367,14 @@ export function App() {
         const foundParticipant = dbPLog.data.getParticipantLog.find((x) => x.hashedEmail === hashedEmail && x.evalNum == evalNum);
 
         if (foundParticipant) {
-            const pid = foundParticipant['ParticipantID'];
+            const participantId = foundParticipant['ParticipantID'];
             if (foundParticipant['textEntryCount'] >= computeTextThreshold(evalNum, true)) {
                 setAlreadyComplete({
-                    open=true,
-                    pid=pid
+                    open:true,
+                    pid:participantId
                 })
             } else {
-                history.push("/text-based?pid=" + pid);
+                history.push("/text-based?pid=" + participantId);
             }
             return;
         } else {
@@ -566,7 +566,7 @@ export function App() {
                 <AlreadyCompleteModal
                     open={alreadyComplete.open}
                     onClose={closePopup}
-                    pid={alreadyComplete.pid}
+                    participantId={alreadyComplete.pid}
                 />
 
                 <div className="itm-footer">

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -38,9 +38,7 @@ import { WaitingPage } from '../Account/waitingPage';
 import { Header } from './Header';
 import { phase1ParticipantData, juneJulyParticipantData, evalNameToNumber, septemberParticipantData, ukParticipantData, octoberParticipantData, febParticipantData, aprilParticipantData, juneParticipantData } from '../OnlineOnly/config';
 import { useSelector } from 'react-redux';
-import { checkAlignmentStatus } from '../Account/progressUtils';
 import { computeTextThreshold } from '../Account/participantProgress';
-import { alreadyCompleteModal } from '../TextBasedScenarios/alreadyCompleteModal'
 // CSS and Image Stuff 
 import '../../css/app.css';
 import 'rc-slider/assets/index.css';

--- a/dashboard-ui/src/components/App/index.jsx
+++ b/dashboard-ui/src/components/App/index.jsx
@@ -38,7 +38,9 @@ import { WaitingPage } from '../Account/waitingPage';
 import { Header } from './Header';
 import { phase1ParticipantData, juneJulyParticipantData, evalNameToNumber, septemberParticipantData, ukParticipantData, octoberParticipantData, febParticipantData, aprilParticipantData, juneParticipantData } from '../OnlineOnly/config';
 import { useSelector } from 'react-redux';
-
+import { checkAlignmentStatus } from '../Account/progressUtils';
+import { computeTextThreshold } from '../Account/participantProgress';
+import { alreadyCompleteModal } from '../TextBasedResults/alreadyCompleteModal'
 // CSS and Image Stuff 
 import '../../css/app.css';
 import 'rc-slider/assets/index.css';
@@ -47,6 +49,7 @@ import 'material-design-icons/iconfont/material-icons.css';
 import 'react-dropdown/style.css';
 import 'react-dual-listbox/lib/react-dual-listbox.css';
 import store from '../../store/store';
+import AlreadyCompleteModal from '../TextBasedScenarios/alreadyCompleteModal';
 
 const GET_SHOW_DEMOGRAPHICS = gql`
     query GetShowDemographics {
@@ -148,6 +151,15 @@ export function App() {
     const [isDemographicsDataLoaded, setIsDemographicsDataLoaded] = React.useState(false);
     const [surveyConfigsLoaded, setSurveyConfigsLoaded] = React.useState(false);
     const [textConfigsLoaded, setTextConfigsLoaded] = React.useState(false);
+    // modal for warning a participant they already compelted the text based portion of the experiment
+    const [alreadyComplete, setAlreadyComplete] = React.useState({
+        open: false,
+        pid: null
+    })
+
+    const closePopup = () => {
+        setAlreadyComplete({ open: false, pid: null });
+    };
 
     // grab upper and lower bounds for new participant pids from mongo and set them in redux
     const { data: pidBoundsData } = useQuery(GET_PID_BOUNDS, {
@@ -356,7 +368,14 @@ export function App() {
 
         if (foundParticipant) {
             const pid = foundParticipant['ParticipantID'];
-            history.push("/text-based?pid=" + pid);
+            if (foundParticipant['textEntryCount'] >= computeTextThreshold(evalNum, true)) {
+                setAlreadyComplete({
+                    open=true,
+                    pid=pid
+                })
+            } else {
+                history.push("/text-based?pid=" + pid);
+            }
             return;
         } else {
             let newPid = Math.max(...dbPLog.data.getParticipantLog.filter((x) =>
@@ -544,6 +563,11 @@ export function App() {
 
                     </Switch>
                 </div>
+                <AlreadyCompleteModal
+                    open={alreadyComplete.open}
+                    onClose={closePopup}
+                    pid={alreadyComplete.pid}
+                />
 
                 <div className="itm-footer">
                     <div className="footer-text">This research was developed with funding from the Defense Advanced Research Projects Agency (DARPA). The views, opinions and/or findings expressed are those of the author and should not be interpreted as representing the official views or policies of the Department of Defense or the U.S. Government.</div>

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -23,6 +23,11 @@ import { Phase2Text } from './phase2Text';
 import { useHistory } from 'react-router-dom';
 import ScenarioProgress from './scenarioProgress';
 
+const UPSERT_SCENARIO_RESULT = gql`
+    mutation upsertScenarioResult($result: JSON) {
+        upsertScenarioResult(result: $result)
+    }`;
+
 const UPLOAD_DEMOGRAPHICS = gql`
   mutation UploadDemographics($surveyId: String, $results: JSON) {
     uploadDemographics(surveyId: $surveyId, results: $results)
@@ -49,6 +54,10 @@ const UPDATE_PARTICIPANT_LOG = gql`
         updateParticipantLog(pid: $pid, updates: $updates) 
     }`;
 
+const GET_COMPLETED_SCENARIOS = gql`
+    query GetCompletedTextScenarios($pid: String) {
+        getCompletedTextScenarios(pid: $pid)
+    }`;
 
 export function TextBasedScenariosPageWrapper(props) {
     const currentTextEval = useSelector(state => state.configs.currentTextEval)
@@ -56,6 +65,14 @@ export function TextBasedScenariosPageWrapper(props) {
     const textBasedConfigs = useSelector(state => state.configs.textBasedConfigs);
     const { loading: participantLogLoading, error: participantLogError, data: participantLogData } = useQuery(GET_PARTICIPANT_LOG,
         { fetchPolicy: 'no-cache' });
+    
+    // finding participant data if this is resuming a partial run
+    const pid = new URLSearchParams(window.location.search).get('pid');
+    const { data: completedData } = useQuery(GET_COMPLETED_SCENARIOS, {
+        variables: { pid },
+        skip: !pid,
+        fetchPolicy: 'no-cache'
+    });
 
     // server side time stamps
     const [getServerTimestamp] = useMutation(GET_SERVER_TIMESTAMP);
@@ -70,6 +87,7 @@ export function TextBasedScenariosPageWrapper(props) {
         participantLogs={participantLogData}
         getServerTimestamp={getServerTimestamp}
         showDemographics={showDemographics}
+        completedScenarioIds={completedData?.getCompletedTextScenarios || []}
     />;
 }
 
@@ -86,8 +104,6 @@ class TextBasedScenariosPage extends Component {
             sanitizedData: null,
             matchedParticipantLog: null,
             allScenariosCompleted: false,
-            sim1: null,
-            sim2: null,
             isUploadButtonEnabled: false,
             adeptSessionsCompleted: 0,
             combinedSessionId: '',
@@ -114,6 +130,7 @@ class TextBasedScenariosPage extends Component {
                 'MF-PS': [],
             },
             eval16SubPopResult: null,
+            resumedSubpop: false
         };
 
         this.surveyData = {};
@@ -122,6 +139,7 @@ class TextBasedScenariosPage extends Component {
         this.uploadButtonRef = React.createRef();
         this.uploadButtonRefDemographics = React.createRef();
         this.uploadButtonRefPLog = React.createRef();
+        this.upsertButtonRef = React.createRef();
         this.shouldBlockNavigation = true;
     }
 
@@ -168,17 +186,32 @@ class TextBasedScenariosPage extends Component {
         }
 
         if (!matchedLog) {
-            // If no match found, create default scenario set
-            const scenarioSet = Math.floor(Math.random() * 2) + 1;
-            matchedLog = {
-                'AF-text-scenario': scenarioSet,
-                'MF-text-scenario': scenarioSet,
-                'PS-text-scenario': scenarioSet,
-                'SS-text-scenario': scenarioSet
-            };
+            // This should not be possible
+            console.error("Error grabbing participant data")
+            history.push('/login')
         }
 
-        const scenarios = this.scenariosFromLog(matchedLog);
+        const allScenarios = this.scenariosFromLog(matchedLog);
+
+        // logic for resuming a partial run. filter out completed scenarios to avoid duplicates
+        const completedIds = this.props.completedScenarioIds || [];
+        const scenarios = completedIds.length > 0
+            ? allScenarios.filter(config => !completedIds.includes(config.scenario_id))
+            : allScenarios;
+
+        const evalNum = evalNameToNumber[this.props.currentTextEval];
+        if (evalNum === 16) {
+            const subpopId = 'April2026-subpopulation';
+            const regularsRemain = scenarios.some(c => c.scenario_id !== subpopId);
+            const subpopMissingFromRun = !scenarios.some(c => c.scenario_id === subpopId);
+            if (regularsRemain && subpopMissingFromRun && completedIds.includes(subpopId)) {
+                const subpopConfig = allScenarios.find(c => c.scenario_id === subpopId);
+                if (subpopConfig) {
+                    scenarios = [subpopConfig, ...scenarios];  
+                    this.setState({ resumedSubpop: true });
+                }
+            }
+        }
 
         this.setState({
             scenarios,
@@ -188,6 +221,8 @@ class TextBasedScenariosPage extends Component {
         }, () => {
             if (this.state.scenarios.length > 0) {
                 this.loadNextScenario();
+            } else {
+                this.handleAllScenariosCompleted()
             }
         });
     };
@@ -577,7 +612,7 @@ class TextBasedScenariosPage extends Component {
 
                 scenario.combinedSessionId = combinedSessionId;
                 scenario.subPopResult = subPopResult;
-                await this.uploadSingleScenario(scenario);
+                await this.uploadSingleScenario(scenario, this.state.resumedSubpop);
             } catch (e) {
                 console.error('Error processing eval 16 subpopulation:', e);
             }
@@ -652,7 +687,7 @@ class TextBasedScenariosPage extends Component {
         }
     }
 
-    uploadSingleScenario = async (scenario) => {
+    uploadSingleScenario = async (scenario, overwrite=false) => {
         const sanitizedData = this.sanitizeKeys(scenario);
 
         return new Promise(resolve => {
@@ -661,8 +696,9 @@ class TextBasedScenariosPage extends Component {
                 sanitizedData,
                 isUploadButtonEnabled: true,
             }, () => {
-                if (this.uploadButtonRef.current) {
-                    this.uploadButtonRef.current.click();
+                const ref = overwrite ? this.upsertButtonRef : this.uploadButtonRef
+                if (ref.current) {
+                    ref.current.click();
                 }
                 resolve();
             });
@@ -916,6 +952,22 @@ class TextBasedScenariosPage extends Component {
                                                 uploadSurveyResults({
                                                     variables: { results: this.state.sanitizedData }
                                                 })
+                                            }
+                                        }}></button>
+                                    </div>
+                                )}
+                            </Mutation>
+                        )}
+                        {!this.state.skipText && this.state.uploadData && (
+                            <Mutation mutation={UPSERT_SCENARIO_RESULT}>
+                                {(upsertScenarioResult) => (
+                                    <div style={{ display: 'none' }}>
+                                        <button ref={this.upsertButtonRef} disabled={!this.state.isUploadButtonEnabled} onClick={(e) => {
+                                            e.preventDefault();
+                                            if (this.state.isUploadButtonEnabled) {
+                                                upsertScenarioResult({
+                                                    variables: { result: this.state.sanitizedData }
+                                                });
                                             }
                                         }}></button>
                                     </div>

--- a/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/TextBasedScenariosPage.jsx
@@ -189,13 +189,14 @@ class TextBasedScenariosPage extends Component {
             // This should not be possible
             console.error("Error grabbing participant data")
             history.push('/login')
+            return
         }
 
         const allScenarios = this.scenariosFromLog(matchedLog);
 
         // logic for resuming a partial run. filter out completed scenarios to avoid duplicates
         const completedIds = this.props.completedScenarioIds || [];
-        const scenarios = completedIds.length > 0
+        let scenarios = completedIds.length > 0
             ? allScenarios.filter(config => !completedIds.includes(config.scenario_id))
             : allScenarios;
 

--- a/dashboard-ui/src/components/TextBasedScenarios/alreadyCompleteModal.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/alreadyCompleteModal.jsx
@@ -7,9 +7,9 @@ export default function AlreadyCompleteModal({ open, onClose, participantId }) {
             <div className="acp-card">
                 <div className="acp-accent" />
                 <div className="acp-body">
+                    {/* checkmark-in-circle icon */}
                     <div className="acp-icon" aria-hidden="true">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                             strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <svg className="acp-check" viewBox="0 0 24 24">
                             <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
                             <polyline points="22 4 12 14.01 9 11.01" />
                         </svg>

--- a/dashboard-ui/src/components/TextBasedScenarios/alreadyCompleteModal.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/alreadyCompleteModal.jsx
@@ -1,0 +1,16 @@
+import { Modal } from "@mui/material";
+import '../../css/admInfo.css';
+
+export default function AlreadyCompleteModal({open, onClose, participantId}) {
+    return (
+         <Modal open={open} onClose={onClose}>
+            <div className="adm-popup-body">
+                <h1>
+                You have already completed this portion of the experiment. 
+                If you think you are receiving this message in error, please speak with a moderator.
+                </h1>
+                <h3>Your Participant ID is {participantId}</h3>
+            </div>
+        </Modal>
+    )
+}

--- a/dashboard-ui/src/components/TextBasedScenarios/alreadyCompleteModal.jsx
+++ b/dashboard-ui/src/components/TextBasedScenarios/alreadyCompleteModal.jsx
@@ -1,16 +1,33 @@
 import { Modal } from "@mui/material";
-import '../../css/admInfo.css';
+import '../../css/alreadyCompleteModal.css';
 
-export default function AlreadyCompleteModal({open, onClose, participantId}) {
+export default function AlreadyCompleteModal({ open, onClose, participantId }) {
     return (
-         <Modal open={open} onClose={onClose}>
-            <div className="adm-popup-body">
-                <h1>
-                You have already completed this portion of the experiment. 
-                If you think you are receiving this message in error, please speak with a moderator.
-                </h1>
-                <h3>Your Participant ID is {participantId}</h3>
+        <Modal open={open} onClose={onClose} aria-labelledby="already-complete-title">
+            <div className="acp-card">
+                <div className="acp-accent" />
+                <div className="acp-body">
+                    <div className="acp-icon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                             strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+                            <polyline points="22 4 12 14.01 9 11.01" />
+                        </svg>
+                    </div>
+                    <h2 id="already-complete-title" className="acp-title">You're all set</h2>
+                    <p className="acp-message">
+                        You have already completed this portion of the experiment.
+                        If you think you are receiving this message in error, please
+                        speak with a moderator.
+                    </p>
+                    {participantId != null && (
+                        <div className="acp-pid">
+                            Your Participant ID is <strong>{participantId}</strong>
+                        </div>
+                    )}
+                    <button type="button" className="acp-btn" onClick={onClose}>Close</button>
+                </div>
             </div>
         </Modal>
-    )
+    );
 }

--- a/dashboard-ui/src/css/alreadyCompleteModal.css
+++ b/dashboard-ui/src/css/alreadyCompleteModal.css
@@ -84,3 +84,13 @@
     .acp-body { padding: 1.5rem 1.25rem 1.25rem; }
     .acp-title { font-size: 1.2rem; }
 }
+
+.acp-icon svg {
+    width: 30px;
+    height: 30px;
+    fill: none;
+    stroke: currentColor;      /* inherits #b15e2f from .acp-icon's color */
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}

--- a/dashboard-ui/src/css/alreadyCompleteModal.css
+++ b/dashboard-ui/src/css/alreadyCompleteModal.css
@@ -1,0 +1,86 @@
+.acp-card {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 90vw;
+    max-width: 460px;
+    background: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+    overflow: hidden;
+    outline: none;
+}
+
+.acp-accent {
+    height: 8px;
+    background: linear-gradient(135deg, #b15e2f 0%, #d67a4c 100%);
+}
+
+.acp-body {
+    padding: 2rem 2rem 1.75rem;
+    text-align: center;
+}
+
+.acp-icon {
+    width: 56px;
+    height: 56px;
+    margin: 0 auto 1.25rem;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(177, 94, 47, 0.12);
+    color: #b15e2f;
+}
+
+.acp-icon svg { width: 30px; height: 30px; }
+
+.acp-title {
+    margin: 0 0 0.75rem;
+    font-size: 1.375rem;
+    font-weight: 700;
+    color: #212529;
+}
+
+.acp-message {
+    margin: 0 0 1.5rem;
+    font-size: 0.95rem;
+    line-height: 1.55;
+    color: #495057;
+}
+
+.acp-pid {
+    display: inline-block;
+    margin-bottom: 1.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: 10px;
+    background: rgba(177, 94, 47, 0.08);
+    border: 1px solid rgba(177, 94, 47, 0.2);
+    font-size: 0.95rem;
+    color: #495057;
+}
+
+.acp-pid strong { color: #b15e2f; font-weight: 700; }
+
+.acp-btn {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border: none;
+    border-radius: 10px;
+    background: linear-gradient(135deg, #b15e2f 0%, #d67a4c 100%);
+    color: #fff;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(177, 94, 47, 0.3);
+    transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+
+.acp-btn:hover { transform: translateY(-1px); box-shadow: 0 6px 16px rgba(177, 94, 47, 0.4); }
+.acp-btn:active { transform: translateY(0); }
+
+@media (max-width: 480px) {
+    .acp-body { padding: 1.5rem 1.25rem 1.25rem; }
+    .acp-title { font-size: 1.2rem; }
+}

--- a/node-graphql/server.schema.js
+++ b/node-graphql/server.schema.js
@@ -83,6 +83,7 @@ const typeDefs = gql`
     getTextBasedConfigByEval(evalName: String!): [JSON] @complexity(value: 50)
     getMedicsByEval(evalNumber: Float): [JSON] @complexity(value: 100)
     getTcccResults(eval: String):  [JSON] @complexity(value:100)
+    getCompletedTextScenarios(pid: String): [String] @complexity(value: 10)
   }
 
   type Mutation {
@@ -108,7 +109,8 @@ const typeDefs = gql`
     updatePidBounds(lowPid: Int!, highPid: Int!): JSON,
     updateShowDemographics(showDemographics: Boolean!): JSON,
     deleteDataByPID(caller: JSON, pid: String): JSON,
-    updateScenarioResult(id: String!, updates: JSON!): JSON
+    updateScenarioResult(id: String!, updates: JSON!): JSON,
+    upsertScenarioResult(result: JSON): JSON,
   }
 
   directive @complexity(value: Int) on FIELD_DEFINITION
@@ -516,6 +518,13 @@ const resolvers = {
       return await context.db.collection('userScenarioResults').find({
         "participantID": { $not: /test/i }
       }).toArray().then(result => { return result; });
+    },
+    getCompletedTextScenarios: async (obj, args, context, inflow) => {
+      if (!args.pid) return [];
+      const docs = await context.db.collection('userScenarioResults')
+        .find({ participantID: args.pid }, { projection: { scenario_id: 1 } })
+        .toArray();
+      return docs.map(d => d.scenario_id).filter(Boolean);
     },
     getAllScenarioResultsByEval: async (obj, args, context, inflow) => {
       return await context.db.collection('userScenarioResults').find({
@@ -955,6 +964,16 @@ const resolvers = {
         if (result.participantID.toLowerCase().includes('test')) { continue }
         await context.db.collection('userScenarioResults').insertOne(result)
       }
+    },
+    upsertScenarioResult: async (obj, args, context, inflow) => {
+      const result = args.result;
+      if (!result || !result.participantID) return null;
+      if (result.participantID.toLowerCase().includes('test')) { return null; }
+      return await context.db.collection('userScenarioResults').updateOne(
+        { participantID: result.participantID, scenario_id: result.scenario_id, evalNumber: result.evalNumber },
+        { $set: result },
+        { upsert: true }
+      );
     },
     updatePidBounds: async (obj, args, context, info) => {
       const res = await context.db.collection('surveyVersion').findOneAndUpdate(


### PR DESCRIPTION
You'll want to point your `.env` file to your local ADEPT server and rebuild your dashboard container. Rebuild your Docker container even if you are already pointed locally, because I had to make some GraphQL schema changes. 

Prevents any user from taking the text-based scenarios with the same email address if they have a COMPLETE run already recorded for the current evaluation. 

If you try to take the text-based scenarios with the same email and already have a completed run, you should see:
<img width="1839" height="931" alt="Screenshot 2026-07-10 at 2 21 43 PM" src="https://github.com/user-attachments/assets/0343ae4e-4b0f-4ea7-aa28-35cb037da291" />

The point at which different text documents get uploaded varies by eval, depending on which scenarios share session IDs. For example, in our current eval, the trinary documents do not get uploaded until both are completed (since their probe responses share a session ID). So if a participant completed one and then exited the browser before completing the other, we won't have either of them. I point this out because the way I chose to handle this was to have them retake both in that case. 

To test this, you can take a complete run and then delete some of their documents (delete both of the trinary documents):
<img width="1139" height="716" alt="Screenshot 2026-07-10 at 2 30 53 PM" src="https://github.com/user-attachments/assets/60d9c8dd-33c0-4aa2-a0da-85e4afb5338d" />

Then update their participant log entry to only have 4 text entries (simulating that they clicked off during the trinary scenarios):
<img width="1162" height="478" alt="Screenshot 2026-07-10 at 2 31 37 PM" src="https://github.com/user-attachments/assets/9faabd2c-5d45-4465-a308-97711a72bf51" />

Then, if I go back to try to take the text-based scenarios again, I'll be prompted with the consent modal and then presented with the two scenarios I am missing:
<img width="1826" height="938" alt="Screenshot 2026-07-10 at 2 34 47 PM" src="https://github.com/user-attachments/assets/3ae3e5b2-2fde-4932-8034-c3ea65c6ad0a" />

Clicking through this as normal should result in the documents being scored as usual with the ADEPT server (can verify with `userScenarioResults`)