### PR TITLE
ITM-1355 Adding Additional Eval Sticky Selectors

### DIFF
--- a/dashboard-ui/src/components/Account/editEvals.jsx
+++ b/dashboard-ui/src/components/Account/editEvals.jsx
@@ -2,20 +2,12 @@ import gql from "graphql-tag";
 import React from "react";
 import { useMutation, useQuery } from "react-apollo";
 import { Button, Card, Modal, Form } from "react-bootstrap";
-import { IconButton, Switch } from '@material-ui/core';
+import { IconButton } from '@material-ui/core';
 import DeleteIcon from '@material-ui/icons/Delete';
-import store from "../../store/store";
-import { setEvals as setEvalsInStore } from "../../store/slices/configSlice";
 
 const GET_EVAL_DATA = gql`
     query GetAllEvalData {
         getAllEvalData
-    }
-`;
-
-const UPDATE_EVAL_DATA = gql`
-    mutation updateEvalData($caller: JSON!, $dataToUpdate: JSON!) {
-        updateEvalData(caller: $caller, dataToUpdate: $dataToUpdate) 
     }
 `;
 
@@ -31,26 +23,16 @@ const DELETE_EVAL = gql`
     }
 `;
 
-
-const pagePaths = [
-    '/', '/text-based-results', '/humanSimParticipant', '/humanProbeData',
-    '/human-results', '/results', '/adm-results', '/adm-probe-responses'
-];
-
 export function EditEvals({ caller }) {
     const { data: evalData, refetch: fetchEvalData } = useQuery(GET_EVAL_DATA, { fetchPolicy: 'no-cache' });
     const [evals, setEvals] = React.useState([]);
-    const [updateEvalData] = useMutation(UPDATE_EVAL_DATA);
     const [addNewEval] = useMutation(ADD_NEW_EVAL);
     const [deleteEval] = useMutation(DELETE_EVAL);
     const [showNewEvalForm, setShowNewEvalForm] = React.useState(false);
-    const [showEvalModal, setShowEvalModal] = React.useState(false);
     const [evalName, setEvalName] = React.useState('');
     const [evalNumber, setEvalNumber] = React.useState('');
-    const [selectedPages, setSelectedPages] = React.useState([]);
     const [showDeleteConfirmation, setShowDeleteConfirmation] = React.useState(false);
     const [evalToDelete, setEvalToDelete] = React.useState(null);
-    const [modalEval, setModalEval] = React.useState([]);
 
 
     React.useEffect(() => {
@@ -68,54 +50,13 @@ export function EditEvals({ caller }) {
         setEvalNumber(tmpEvals[0].evalNumber + 1);
     }
 
-    const handleCheckboxChange = (event) => {
-        const { value, checked } = event.target;
-        if (checked) {
-            setSelectedPages(prev => [...prev, value]);
-        } else {
-            setSelectedPages(prev => prev.filter(p => p !== value));
-        }
-    };
-
     const getEvalById = (evalId) => {
         return evals.find((x) => x._id == evalId);
     };
 
-    const updateEvalInStore = (evalId, pageToUpdate, e) => {
-        const evalDataInStore = store.getState()?.configs?.evals;
-        for (let evalData in evalDataInStore) {
-            if (evalData._id == evalId) {
-                evalData['pages'][pageToUpdate] = e.target.checked;
-                break;
-            }
-        }
-        store.dispatch(setEvalsInStore(evalDataInStore));
-    };
-
-    const updateEvalPagePermissions = async (evalId, pageToUpdate, e) => {
-        const evalToUpdate = getEvalById(evalId);
-        evalToUpdate['pages'][pageToUpdate] = e.target.checked;
-        try {
-            const res = await updateEvalData({
-                variables: {
-                    caller,
-                    dataToUpdate: evalToUpdate
-                }
-            });
-            if (res.data.updateEvalData.ok) {
-                updateEvalInStore(evalId, pageToUpdate, e);
-            }
-        } catch (error) {
-            console.error(`Could not update eval ${evalId}`, error);
-        }
-    };
-
-
     /* DELETE FUNCTIONS */
 
     const startDeleteProcess = (evalToDeleteData) => {
-        setShowEvalModal(false)
-        setModalEval([])
         setShowDeleteConfirmation(true);
         setEvalToDelete(evalToDeleteData);
     };
@@ -130,11 +71,6 @@ export function EditEvals({ caller }) {
             const res = await deleteEval({ variables: { caller, evalId: evalToDelete._id } });
             if (res.data.deleteEval.ok) {
                 setShowDeleteConfirmation(false);
-
-                if (showEvalModal) {
-                    setShowEvalModal(false);
-                    setModalEval([]);
-                }
                 
                 const refetchedData = await fetchEvalData();
                 updateLocalEvalData(refetchedData.data);
@@ -157,21 +93,6 @@ export function EditEvals({ caller }) {
         const newEval = {
             "evalNumber": parseInt(evalNumber),
             "evalName": evalName,
-            "pages": {
-                // Setting these to be true as a place holder until all toggles are removed
-                "rq1": true, 
-                "rq2": true,
-                "rq3": true,
-                "exploratoryAnalysis": true,
-                "admProbeResponses": selectedPages.includes('/adm-probe-responses'),
-                "admAlignment": selectedPages.includes('/adm-results'),
-                "admResults": selectedPages.includes('/results'),
-                "humanSimPlayByPlay": selectedPages.includes('/human-results'),
-                "humanSimProbes": selectedPages.includes('/humanProbeData'),
-                "participantLevelData": selectedPages.includes('/humanSimParticipant'),
-                "textResults": selectedPages.includes('/text-based-results'),
-                "programQuestions": selectedPages.includes('/')
-            }
         }
 
         try {
@@ -192,22 +113,7 @@ export function EditEvals({ caller }) {
         setShowNewEvalForm(false);
         setEvalName('');
         setEvalNumber('');
-        setSelectedPages([]);
     };
-
-    /* EVAL MODAL FUNCTIONS */
-
-    const evalModalToggle = (ev) => {
-        setShowEvalModal(true)
-        setModalEval(ev)
-    }
-
-    const onCancelSettings = () => {
-        setShowEvalModal(false)
-        setModalEval([])
-    }
-
-
 
     return <>
         <Card >
@@ -223,30 +129,6 @@ export function EditEvals({ caller }) {
                                 <th>
                                     Eval Number
                                 </th>
-                                <th className='switch-header' title='home page / program questions'>
-                                    /
-                                </th>
-                                <th className='switch-header' title='text scenario results'>
-                                    /text-based-results
-                                </th>
-                                <th className='switch-header' title='participant-level data'>
-                                    /humanSimParticipant
-                                </th>
-                                <th className='switch-header' title='human sim probe values'>
-                                    /humanProbeData
-                                </th>
-                                <th className='switch-header' title='detailed human sim output'>
-                                    /human-results
-                                </th>
-                                <th className='switch-header' title='adm history output'>
-                                    /results
-                                </th>
-                                <th className='switch-header' title='adm charts'>
-                                    /adm-results
-                                </th>
-                                <th className='switch-header' title='adm probe responses'>
-                                    /adm-probe-responses
-                                </th>
                                 <th className='action-header' title='only deletes the entry from the evalData collection'>
                                     Delete
                                 </th>
@@ -256,16 +138,8 @@ export function EditEvals({ caller }) {
                             {evals.map((evaluation) => {
                                 return (
                                     <tr key={evaluation._id}>
-                                        <td className='eval-name'onClick={() => evalModalToggle(evaluation)}>{evaluation.evalName}</td>
+                                        <td className='eval-name'>{evaluation.evalName}</td>
                                         <td>{evaluation.evalNumber}</td>
-                                        <td><Switch color='primary' checked={evaluation.pages.programQuestions} onChange={(e) => updateEvalPagePermissions(evaluation._id, 'programQuestions', e)} /></td>
-                                        <td><Switch color='primary' checked={evaluation.pages.textResults} onChange={(e) => updateEvalPagePermissions(evaluation._id, 'textResults', e)} /></td>
-                                        <td><Switch color='primary' checked={evaluation.pages.participantLevelData} onChange={(e) => updateEvalPagePermissions(evaluation._id, 'participantLevelData', e)} /></td>
-                                        <td><Switch color='primary' checked={evaluation.pages.humanSimProbes} onChange={(e) => updateEvalPagePermissions(evaluation._id, 'humanSimProbes', e)} /></td>
-                                        <td><Switch color='primary' checked={evaluation.pages.humanSimPlayByPlay} onChange={(e) => updateEvalPagePermissions(evaluation._id, 'humanSimPlayByPlay', e)} /></td>
-                                        <td><Switch color='primary' checked={evaluation.pages.admResults} onChange={(e) => updateEvalPagePermissions(evaluation._id, 'admResults', e)} /></td>
-                                        <td><Switch color='primary' checked={evaluation.pages.admAlignment} onChange={(e) => updateEvalPagePermissions(evaluation._id, 'admAlignment', e)} /></td>
-                                        <td><Switch color='primary' checked={evaluation.pages.admProbeResponses} onChange={(e) => updateEvalPagePermissions(evaluation._id, 'admProbeResponses', e)} /></td>
                                         <td><IconButton title='Delete' onClick={() => startDeleteProcess(evaluation)} children={<DeleteIcon className='delete-eval-btn' />} /></td>
                                     </tr>);
                             })}
@@ -275,84 +149,6 @@ export function EditEvals({ caller }) {
                 <Button onClick={() => setShowNewEvalForm(true)}>Add New Eval</Button>
             </Card.Body>
         </Card>
-
-        <Modal show={showEvalModal} onHide={onCancelSettings} centered>
-            <Modal.Header closeButton className="bg-light">
-                <Modal.Title>
-                    <strong>{modalEval.evalName}</strong>
-                </Modal.Title>
-            </Modal.Header>
-            <Modal.Body className="px-4">
-                <strong>Eval Number: {modalEval.evalNumber}</strong>
-
-                <div className="table-container">
-                    <table className="eval-modal-table">
-                        <tbody>
-                            <tr>
-                                <td className="table-label">
-                                    /
-                                </td>
-                                <td className="table-value">
-                                    <Switch color='primary' checked={modalEval.pages?.programQuestions} onChange={(e) => updateEvalPagePermissions(modalEval._id, 'programQuestions', e)} />
-                                </td>
-                                <td className="table-label">
-                                    /text-based-results
-                                </td>
-                                <td className="table-value">
-                                    <Switch color='primary' checked={modalEval.pages?.textResults} onChange={(e) => updateEvalPagePermissions(modalEval._id, 'textResults', e)} />
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="table-label">
-                                    /humanSimParticipant
-                                </td>
-                                <td className="table-value">
-                                    <Switch color='primary' checked={modalEval.pages?.participantLevelData} onChange={(e) => updateEvalPagePermissions(modalEval._id, 'participantLevelData', e)} />
-                                </td>
-                                <td className="table-label">
-                                    /humanProbeData
-                                </td>
-                                <td className="table-value">
-                                    <Switch color='primary' checked={modalEval.pages?.humanSimProbes} onChange={(e) => updateEvalPagePermissions(modalEval._id, 'humanSimProbes', e)} />
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="table-label">
-                                    /human-results
-                                </td>
-                                <td className="table-value">
-                                    <Switch color='primary' checked={modalEval.pages?.humanSimPlayByPlay} onChange={(e) => updateEvalPagePermissions(modalEval._id, 'humanSimPlayByPlay', e)} />
-                                </td>
-                                <td className="table-label">
-                                    /results
-                                </td>
-                                <td className="table-value">
-                                    <Switch color='primary' checked={modalEval.pages?.admResults} onChange={(e) => updateEvalPagePermissions(modalEval._id, 'admResults', e)} />
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="table-label">
-                                    /adm-results
-                                </td>
-                                <td className="table-value">
-                                    <Switch color='primary' checked={modalEval.pages?.admAlignment} onChange={(e) => updateEvalPagePermissions(modalEval._id, 'admAlignment', e)} />
-                                </td>
-                                <td className="table-label">
-                                    /adm-probe-responses
-                                </td>
-                                <td className="table-value">
-                                    <Switch color='primary' checked={modalEval.pages?.admProbeResponses} onChange={(e) => updateEvalPagePermissions(modalEval._id, 'admProbeResponses', e)} />
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-
-                <div className="text-center mt-4">
-                    <IconButton title='Delete' onClick={() => startDeleteProcess(modalEval)} children={<DeleteIcon className='delete-eval-btn' />} />
-                </div>
-            </Modal.Body>
-        </Modal>
 
         <Modal show={showNewEvalForm} onHide={onCancelCreate} centered>
             <Modal.Header closeButton className="bg-light">
@@ -383,24 +179,6 @@ export function EditEvals({ caller }) {
                             min={1}
                             required
                         />
-                    </Form.Group>
-
-                    <Form.Group controlId="pages" className="mt-4">
-                        <Form.Label>Add Dropdown to Pages:</Form.Label>
-                        <div className="checkbox-grid">
-                            {pagePaths.map((path, index) => (
-                                <Form.Check
-                                    key={index}
-                                    type="checkbox"
-                                    id={`page-${index}`}
-                                    label={path}
-                                    value={path}
-                                    checked={selectedPages.includes(path)}
-                                    onChange={handleCheckboxChange}
-                                    className="mb-1"
-                                />
-                            ))}
-                        </div>
                     </Form.Group>
 
                     <div className="text-center mt-4">

--- a/dashboard-ui/src/components/Account/editEvals.jsx
+++ b/dashboard-ui/src/components/Account/editEvals.jsx
@@ -93,6 +93,9 @@ export function EditEvals({ caller }) {
         const newEval = {
             "evalNumber": parseInt(evalNumber),
             "evalName": evalName,
+            "pages": {
+                "programQuestions": true
+            }
         }
 
         try {

--- a/dashboard-ui/src/components/AdmCharts/admChartPage.jsx
+++ b/dashboard-ui/src/components/AdmCharts/admChartPage.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import AdmCharts from './admCharts';
-import { PAGES, getEvalOptionsForPage } from '../Research/utils';
+import { getAllEvals } from '../Research/utils';
 
 class ADMChartPage extends React.Component {
 
     render() {
 
-        const evalOptions = getEvalOptionsForPage(PAGES.ADM_ALIGNMENT);
+        const evalOptions = getAllEvals();
 
         return (
             <AdmCharts evaluationOptions={evalOptions} />

--- a/dashboard-ui/src/components/AdmCharts/admCharts.jsx
+++ b/dashboard-ui/src/components/AdmCharts/admCharts.jsx
@@ -3,6 +3,8 @@ import ScoreChart from './scoreChart';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 import Select from 'react-select';
+import store from '../../store/store';
+import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
 const getScenarioNamesQueryName = "getScenarioNamesByEval";
 
@@ -15,8 +17,11 @@ class AdmCharts extends React.Component {
 
     constructor(props) {
         super();
+        const storedEval = store.getState()?.configs?.selectedResearchEval;
+        const initialEval = props.evaluationOptions.find(o => o.value === storedEval) ?? props.evaluationOptions[0];
         this.state = {
-            currentEval: props.evaluationOptions[0],
+            currentEval: initialEval,
+
         }
 
         this.selectEvaluation = this.selectEvaluation.bind(this);
@@ -26,6 +31,7 @@ class AdmCharts extends React.Component {
         this.setState({
             currentEval: target
         });
+        store.dispatch(setSelectedResearchEval(target.value));
     }
 
     getHeaderLabel(id, name) {
@@ -85,7 +91,7 @@ class AdmCharts extends React.Component {
 
                                 return (
                                     <div className="home-container">
-                                        {
+                                        {scenariosArray.length === 0 ? <p>This page is not available for the selected evaluation.</p> :
                                             scenariosArray.map(scenario =>
                                                 <div className='chart-home-container' key={"id_" + scenario.id}>
                                                     <div className='chart-header'>

--- a/dashboard-ui/src/components/AdmCharts/admProbeResponses.jsx
+++ b/dashboard-ui/src/components/AdmCharts/admProbeResponses.jsx
@@ -8,7 +8,9 @@ import { saveAs } from 'file-saver';
 import '../../css/results-page.css';
 import '../../css/aggregateResults.css';
 import { multiSort } from '../Results/utils';
-import { PAGES, getEvalOptionsForPage } from '../Research/utils';
+import { getAllEvals } from '../Research/utils';
+import { useSelector, useDispatch } from 'react-redux';
+import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
 const scenario_names_aggregation = gql`
     query getScenarioNamesByEval($evalNumber: Float!) {
@@ -147,9 +149,11 @@ const getKdmaParameter = (data, kdmaName, parameterName) => {
 const kdmaHasParam = (kdma, paramName) => kdma.parameters?.some(p => p.name === paramName);
 
 export const ADMProbeResponses = (props) => {
-    const evalOptions = getEvalOptionsForPage(PAGES.ADM_PROBE_RESPONSES);
+    const evalOptions = getAllEvals()
+    const dispatch = useDispatch();
+    const storedEval = useSelector(state => state.configs.selectedResearchEval);
+    const [currentEval, setCurrentEval] = useState(storedEval ?? evalOptions[0].value);
 
-    const [currentEval, setCurrentEval] = useState(evalOptions[0].value);
     const [currentScenario, setCurrentScenario] = useState("");
     const [queryString, setQueryString] = useState("adm_name");
     const [queryData, setQueryData] = useState({});
@@ -263,9 +267,11 @@ export const ADMProbeResponses = (props) => {
 
     const setEval = (target) => {
         setCurrentEval(target);
+        dispatch(setSelectedResearchEval(target));
         setCurrentScenario("");
         setQueryString("adm_name");
     };
+
 
     const formatScenarioString = (id) => {
         if (currentEval === 3) {
@@ -296,6 +302,8 @@ export const ADMProbeResponses = (props) => {
     const sortedScenarios = scenarioData?.getScenarioNamesByEval
         ?.filter(s => ![14, 11].includes(currentEval) || !s._id.id.toLowerCase().includes('af-mf'))
         ?.sort((a, b) => formatScenarioString(a._id.id).localeCompare(formatScenarioString(b._id.id)));
+
+    const noScenariosForEval = !scenarioLoading && !scenarioError && sortedScenarios?.length === 0;
 
     const getCurrentScenarioName = () => {
         const currentScenarioObj = sortedScenarios?.find(s => s._id.id === currentScenario);
@@ -519,9 +527,12 @@ export const ADMProbeResponses = (props) => {
                 {!currentScenario && currentEval && (
                     <div className="test-overview-area" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                         <div style={{ textAlign: 'center', color: '#666' }}>
+                            {noScenariosForEval ? (
+                            <h3>This page is not available for the selected evaluation</h3>
+                        ) : (
                             <h3>Please select a scenario to view probe responses</h3>
-                            <p>Choose from the available scenarios in the left panel</p>
-                        </div>
+                        )}
+                       </div>
                     </div>
                 )}
                 {currentScenario && (

--- a/dashboard-ui/src/components/AggregateResults/DataFunctions.js
+++ b/dashboard-ui/src/components/AggregateResults/DataFunctions.js
@@ -1613,6 +1613,7 @@ function getRatingsBySelectionStatus(data) {
 
 
 function populateDataSetP2(data) {
+    AGGREGATED_DATA["groupedSim"] = {};
     const pLog = data.getParticipantLog;
     const demographicsData = data.getDemographicsByEval ?? [];
     const results = [];

--- a/dashboard-ui/src/components/AggregateResults/aggregateResults.jsx
+++ b/dashboard-ui/src/components/AggregateResults/aggregateResults.jsx
@@ -11,7 +11,9 @@ import { DefinitionTable, loadDefinitionsSheet, getDefinitionHeaders } from './d
 import CloseIcon from '@material-ui/icons/Close';
 import Select from 'react-select';
 import { HEADER_SIM_DATA, ADEPT_HEADERS_DRE } from './aggregateHeaders';
-import { PAGES, getEvalOptionsForPage } from '../Research/utils';
+import { getAllEvals } from '../Research/utils';
+import { useSelector, useDispatch } from 'react-redux';
+import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
 
 const EXCLUDED_EVALS_HUMAN_PROBES = [8, 9, 10, 12];
@@ -27,7 +29,9 @@ const GET_SURVEY_RESULTS = gql`
 
 
 export default function AggregateResults({ type }) {
-    let evalOptions = type == 'HumanProbeData' ? getEvalOptionsForPage(PAGES.HUMAN_SIM_PROBES) : getEvalOptionsForPage(PAGES.PARTICIPANT_LEVEL_DATA);
+    let evalOptions = getAllEvals()
+    const dispatch = useDispatch();
+    const storedEval = useSelector(state => state.configs.selectedResearchEval);
     const fileType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=UTF-8';
     const fileExtension = '.xlsx';
 
@@ -40,16 +44,18 @@ export default function AggregateResults({ type }) {
     const [iframeTitle, setIframeTitle] = React.useState(null);
     const [definitionHeaders, setDefinitionHeaders] = React.useState([]);
 
+
     const { loading, error, data } = useQuery(GET_SURVEY_RESULTS, {
         variables: { "evalNumber": selectedEval }
         // only pulls from network, never cached
         //fetchPolicy: 'network-only',
     });
-
+    
     React.useEffect(() => {
-        evalOptions = type == 'HumanProbeData' ? getEvalOptionsForPage(PAGES.HUMAN_SIM_PROBES) : getEvalOptionsForPage(PAGES.PARTICIPANT_LEVEL_DATA);
-        setSelectedEval(evalOptions[0].value);
+        evalOptions = getAllEvals()
+        setSelectedEval(storedEval ?? evalOptions[0].value);
     }, [type]);
+
 
 
     React.useEffect(() => {
@@ -173,9 +179,12 @@ export default function AggregateResults({ type }) {
 
     function selectEvaluation(target) {
         setSelectedEval(target.value);
+        dispatch(setSelectedResearchEval(target.value));
     }
 
+
     const getHeadersEval4 = (headers, adeptScenario) => {
+        headers = headers ?? [];
         if (type == 'HumanProbeData' && EXCLUDED_EVALS_HUMAN_PROBES.includes(selectedEval)) {
             return [];
         }
@@ -286,7 +295,7 @@ export default function AggregateResults({ type }) {
                             }}
                         />
                     </div>
-                    {definitionHeaders.length > 0 ?
+                    {definitionHeaders.length > 0 ? (fullData.length === 0 ? <div className='resultTableSection'><p>This page is not available for the selected evaluation.</p></div> :
                         <div className='resultTableSection'>
                             <table className='itm-table'>
                                 <thead>
@@ -311,7 +320,7 @@ export default function AggregateResults({ type }) {
 
                                 </tbody>
                             </table>
-                        </div>
+                        </div>)
                         : <div className='resultTableSection'>Loading Variables...</div>
                     }
                 </div>
@@ -344,7 +353,9 @@ export default function AggregateResults({ type }) {
                         />
                     </div>
 
-                    {aggregateData["groupedSim"] !== undefined && sortedObjectKeys(Object.keys(aggregateData["groupedSim"]), selectedEval).map((objectKey, key) => {
+                    {Object.keys(aggregateData["groupedSim"] || {}).length === 0 ? <p style={{ marginLeft: '1.5rem' }}>This page is not available for the selected evaluation.</p> :
+                        sortedObjectKeys(Object.keys(aggregateData["groupedSim"]), selectedEval).map((objectKey, key) => {
+    
                         const headers = selectedEval === 3 ? HEADER_SIM_DATA[selectedEval === 6 ? 5 : selectedEval] : getHeadersEval4(HEADER_SIM_DATA[selectedEval === 6 ? 5 : selectedEval], objectKey.split('_')[0]);
                         const filteredHeaders = headers?.filter(header => hasDataInColumn(aggregateData["groupedSim"][objectKey], header));
 

--- a/dashboard-ui/src/components/HumanResults/humanResults.jsx
+++ b/dashboard-ui/src/components/HumanResults/humanResults.jsx
@@ -8,7 +8,9 @@ import { ToggleButton, ToggleButtonGroup } from 'react-bootstrap';
 import '../../css/humanResults.css';
 import Select from 'react-select';
 import { isPostMreEval } from "../AggregateResults/DataFunctions";
-import { PAGES, getEvalOptionsForPage } from "../Research/utils";
+import { getAllEvals } from "../Research/utils";
+import { useSelector, useDispatch } from 'react-redux';
+import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
 
 const GET_HUMAN_RESULTS = gql`
@@ -70,13 +72,18 @@ const EVAL_CONFIG = {
     8: { type: 'SUMMER', scenarios: SUMMER_SCENARIOS, showTeamToggle: false, showKdma: true },
     9: { type: 'SUMMER', scenarios: SUMMER_SCENARIOS, showTeamToggle: false, showKdma: true },
     10: { type: 'SUMMER', scenarios: SUMMER_SCENARIOS, showTeamToggle: false, showKdma: true },
+    12: { type: 'SUMMER', scenarios: SUMMER_SCENARIOS, showTeamToggle: false, showKdma: true },
+    16: { type: 'SUMMER', scenarios: SUMMER_SCENARIOS, showTeamToggle: false, showKdma: true },
 };
 
-const USE_OPEN_WORLD = [8, 9, 10];
+const USE_OPEN_WORLD = [8, 9, 10, 12, 16];
 
 export default function HumanResults() {
-    const evalOptions = getEvalOptionsForPage(PAGES.HUMAN_SIM_PLAY_BY_PLAY);
-    const [selectedEval, setSelectedEval] = React.useState(evalOptions[0].value);
+    const evalOptions = getAllEvals();
+    const dispatch = useDispatch();
+    const storedEval = useSelector(state => state.configs.selectedResearchEval);
+    const [selectedEval, setSelectedEval] = React.useState(storedEval ?? evalOptions[0].value);
+
 
     const { data } = useQuery(GET_HUMAN_RESULTS, {
         variables: { evalNumber: selectedEval },
@@ -104,7 +111,7 @@ export default function HumanResults() {
                     continue;
                 }
                 const version = entry.evalNumber;
-                const scene = USE_OPEN_WORLD.includes(version) ? entry?._id?.split('june2025-')[1] : version === 3 ? entry.data?.configData?.scene : entry.data?.configData?.narrative?.narrativeDescription.split(' ')[0];
+                const scene = USE_OPEN_WORLD.includes(version) ? entry?._id?.match(/[a-z]+-openworld$/)?.[0] : version === 3 ? entry.data?.configData?.scene : entry.data?.configData?.narrative?.narrativeDescription.split(' ')[0];
                 const pid = entry.data?.participantId;
                 if (scene && pid && entry.data?.actionList) {
                     const probes = simAlignment.filter((x) => !x.openWorld && pid === x.pid && (version === 3 ? MRE_ENV_MAP[scene].toLowerCase() === x.env : scene === x.scenario_id));
@@ -202,10 +209,15 @@ export default function HumanResults() {
     };
 
     function selectEvaluation(target) {
-        setSelectedEval(target.value);
-        setSelectedScene(null);
-        setSelectedPID(null);
+    setSelectedEval(target.value);
+    dispatch(setSelectedResearchEval(target.value));
+    setSelectedScene(null);
+    setSelectedPID(null);
+
     }
+
+
+    const noDataForEval = dataByScene && Object.keys(dataByScene).length === 0;
 
     return (<div className="human-results">
         <div className="hr-nav">
@@ -347,7 +359,8 @@ export default function HumanResults() {
                     </table>
                 </div>
             </div>
-            : <h2 className="not-found">Please select {evalConfig?.type === 'MRE' ? "an environment" : "a scenario"} and participant to view results</h2>
+            : noDataForEval ? <p>This page is not available for the selected evaluation.</p>
+                : <h2 className="not-found">Please select {evalConfig?.type === 'MRE' ? "an environment" : "a scenario"} and participant to view results</h2>
         }
     </div>);
 }

--- a/dashboard-ui/src/components/Research/ParticipantDemographics.jsx
+++ b/dashboard-ui/src/components/Research/ParticipantDemographics.jsx
@@ -10,6 +10,8 @@ import CloseIcon from '@material-ui/icons/Close';
 import { RQDefinitionTable } from './variables/rq-variables';
 import ph1File from './variables/Variable Definitions Demographics_PH1.xlsx'
 import ph2File from './variables/Variable Definitions Demographics_PH2.xlsx'
+import { useSelector, useDispatch } from 'react-redux'
+import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
 const PH1_DEFINITION_FILE = ph1File
 const PH2_DEFINITION_FILE = ph2File
@@ -172,8 +174,11 @@ function buildRowsForEval(evalNum, surveyData, demoData, isDemoCollection) {
 
 export function ParticipantDemographics() {
     const evalOptions = getAllEvals()
+    const dispatch = useDispatch();
+    const storedEval = useSelector(state => state.configs.selectedResearchEval);
+    const [selectedEval, setSelectedEval] = React.useState(storedEval ?? evalOptions[0]?.value ?? null)
+
     const client = useApolloClient()
-    const [selectedEval, setSelectedEval] = React.useState(evalOptions[0]?.value ?? null)
     const [formattedData, setFormattedData] = React.useState([])
     const [headers, setHeaders] = React.useState([])
     const [showDefinitions, setShowDefinitions] = React.useState(false);
@@ -231,7 +236,7 @@ export function ParticipantDemographics() {
         <div className="researchQuestion">
             <div className="rq-selection-section">
                 <Select
-                    onChange={(opt) => setSelectedEval(opt.value)}
+                    onChange={(opt) => { setSelectedEval(opt.value); dispatch(setSelectedResearchEval(opt.value)); }}
                     options={evalOptions}
                     defaultValue={evalOptions[0]}
                     placeholder="Select Evaluation"

--- a/dashboard-ui/src/components/Research/utils.js
+++ b/dashboard-ui/src/components/Research/utils.js
@@ -1145,7 +1145,7 @@ export const PAGES = {
 export function getEvalOptionsForPage(page) {
     const dropdownOptions = [];
     for (const evalData of store.getState()?.configs?.evals) {
-        if (evalData.pages[page]) {
+        if (evalData.pages?.[page]) {
             dropdownOptions.push({ value: evalData.evalNumber, label: evalData.evalName });
         }
     }

--- a/dashboard-ui/src/components/Results/resultsTable.jsx
+++ b/dashboard-ui/src/components/Results/resultsTable.jsx
@@ -33,7 +33,9 @@ import {
   extractKdmaPairsFromHistory,
   kdmaAcronym
 } from './utils';
-import { PAGES, getEvalOptionsForPage } from '../Research/utils';
+import { getAllEvals } from '../Research/utils';
+import store from '../../store/store';
+import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
 const getScenarioNamesQueryName = "getScenarioNamesByEval";
 const getPerformerADMByScenarioName = "getPerformerADMsForScenario";
@@ -111,13 +113,14 @@ function AutoFitText({ text, max = 16, min = 11, className = '' }) {
 
 class ResultsTable extends React.Component {
   constructor(props) {
-    const evalOptions = getEvalOptionsForPage(PAGES.ADM_RESULTS);
+    const evalOptions = getAllEvals();
+    const storedEval = store.getState()?.configs?.selectedResearchEval;
     super(props);
     this.state = {
       adm: "",
       scenario: "",
       evalOptions: evalOptions,
-      evalNumber: evalOptions[0].value,
+      evalNumber: storedEval ?? evalOptions[0].value,
       ADMQueryString: "history.parameters.adm_name",
       showScrollButton: false,
       alignmentTarget: null,
@@ -132,6 +135,7 @@ class ResultsTable extends React.Component {
       inspectorRoot: null,
       inspectorPath: [],
       inspectorRootLabel: 'Root',
+      noScenariosForEval: false,
     }
   }
 
@@ -172,8 +176,10 @@ class ResultsTable extends React.Component {
       scenario: "",
       ADMQueryString: target < 3 ? "history.parameters.ADM Name" : "history.parameters.adm_name",
       alignmentTarget: null,
-      selectedIndex: 0
+      selectedIndex: 0,
+      noScenariosForEval: false
     });
+    store.dispatch(setSelectedResearchEval(target));
   }
 
   setScenario(target) {
@@ -509,7 +515,8 @@ class ResultsTable extends React.Component {
                   <span className="nav-header-text">Scenario</span>
                 </div>
                 <div className="nav-menu">
-                  <Query query={scenario_names_aggregation} variables={{ "evalNumber": this.state.evalNumber }}>
+                  <Query query={scenario_names_aggregation} variables={{ "evalNumber": this.state.evalNumber }} 
+                  onCompleted={(data) => this.setState({ noScenariosForEval: data[getScenarioNamesQueryName].length === 0 })}>
                     {
                       ({ loading, error, data }) => {
                         if (loading) return <div>Loading ...</div>
@@ -800,9 +807,13 @@ class ResultsTable extends React.Component {
                   }
                 }
               </Query> :
-              <>
-                {this.renderRq2()}
-              </>
+              this.state.noScenariosForEval ? (
+                <p>This page is not available for the selected evaluation.</p>
+              ) : (
+                <>
+                  {this.renderRq2()}
+                </>
+              )
             }
           </div>
         </div>

--- a/dashboard-ui/src/components/TextBasedResults/TextBasedResultsPage.jsx
+++ b/dashboard-ui/src/components/TextBasedResults/TextBasedResultsPage.jsx
@@ -14,7 +14,9 @@ import XLSX from 'sheetjs-style';
 import Select from 'react-select';
 import NoSelection from './NoSelection';
 import { shortenAnswer, p2Attributes } from './util';
-import { PAGES, getEvalOptionsForPage } from '../Research/utils';
+import { getAllEvals } from '../Research/utils';
+import { useSelector, useDispatch } from 'react-redux';
+import { setSelectedResearchEval } from '../../store/slices/configSlice';
 
 const GET_SCENARIO_RESULTS_BY_EVAL = gql`
     query getAllScenarioResultsByEval($evalNumber: Float!){
@@ -449,8 +451,10 @@ export default function TextBasedResultsPage() {
     const [responsesByScenario, setByScenario] = React.useState(null);
     const [questionAnswerSets, setResults] = React.useState(null);
     const [participantBased, setParticipantBased] = React.useState(null);
-    const evalOptions = getEvalOptionsForPage(PAGES.TEXT_RESULTS);
-    const [selectedEval, setSelectedEval] = React.useState(evalOptions[0].value);
+    const evalOptions = getAllEvals()
+    const dispatch = useDispatch();
+    const storedEval = useSelector(state => state.configs.selectedResearchEval);
+    const [selectedEval, setSelectedEval] = React.useState(storedEval ?? evalOptions[0].value);
     const [scenarioOptions, setScenarioOptions] = React.useState([]);
     const { data: allTextBasedConfigsData, loading: configsLoading } = useQuery(GET_ALL_TEXT_BASED_CONFIGS, {
         fetchPolicy: 'cache-first'
@@ -689,12 +693,16 @@ export default function TextBasedResultsPage() {
 
     function selectEvaluation(option) {
         setSelectedEval(option.value);
+        dispatch(setSelectedResearchEval(option.value));
         setScenario(null);
     }
+
 
     if (configsLoading) {
         return <div>Loading configurations...</div>;
     }
+
+    const noDataForEval = !loading && !error && scenarioOptions.length === 0;
 
     return (<div className='text-results'>
         <div className='sidebar-options'>
@@ -741,7 +749,9 @@ export default function TextBasedResultsPage() {
                     </ToggleButtonGroup>
                 </div>
                 {dataFormat === 'text' ? <TextResultsSection /> : dataFormat === 'participants' ? <ParticipantView data={scenarioChosen && participantBased ? participantBased[scenarioChosen] : []} scenarioName={scenarioChosen} textBasedConfigs={filteredTextBasedConfigs} selectedEval={selectedEval} participantBased={participantBased} scenarioOptions={scenarioOptions} participantLog={participantLog} /> : <ChartedResultsSection />}
-            </div>) : (
+            </div>) : noDataForEval ? (
+            <p>This page is not available for the selected evaluation.</p>
+        ) : (
             <NoSelection />
         )}
     </div>);


### PR DESCRIPTION
This PR removes the admin per-page eval toggle in favor of query-based availability. Every eval shows in every dropdown, each page shows its own `no data available` message if it has nothing for the selected eval. It additionally migrates the sticky eval selector [from #470](https://github.com/NextCenturyCorporation/itm-evaluation-dashboard/pull/470) to the pages that didn't have it yet.

Previously every time when a new eval was added the pages to display the eval had to be toggled. Now the pages are query based, each page will read from its queries whether it has data to display for the selected eval, if it does not, it will display a `no data available` message.

The admin eval editor no longer has per-page switches, it only has eval name, eval number, and delete. Since moving to a query based approach, these toggles are redundant.

Also fixes /human-results for evals 12 and 16, which had real data but were stuck on "please select a scenario and participant" with an empty scenario menu.

To test:

Click around every page and check that all evals are available in the dropdown, also click around the pages to ensure the same eval is being displayed throughout the dashboard. Look in particular for `no data available` messages flashing before the data loads.

Each page should show a `no data available` message or the contents of the data.

Create a new eval, refresh your page and check that it shows up in every page dropdown. 

(The programQuestions page will be overhauled so that page is not a part of this update and the `TCCC` page has its own data pipeline so it will be unchanged)