### PR TITLE
ITM-1415: Dev Server GraphQL Build Fix

### DIFF
--- a/docker_setup/docker-compose-dev-server.yml
+++ b/docker_setup/docker-compose-dev-server.yml
@@ -33,8 +33,13 @@ services:
       - dashboard-net
 
   dashboard-server:
+    build:
+      context: ../node-graphql
+      dockerfile: Dockerfile
+      args:
+        USE_CORP_CA: "false"
+    image: dashboard-graphql:dev-server
     container_name: dashboard-graphql
-    image: dashboard-graphql
     restart: always
     volumes:
       - ../dashboard-ui/public/configs/dev-server/graphql-config.js:/usr/src/app/config.js


### PR DESCRIPTION
This is a quick fix that makes it so the GraphQL server gets properly rebuilt when using docker compose commands. This branch is already checked out and built on the dev server, so to test just go to:

https://darpaitm.caci.com/dev/login

And attempt to login. If your login in successful, then everything is working properly.