### PR TITLE
ITM-1427:  Fix empty PIDs that populate June 2025

### DIFF
--- a/dashboard-ui/src/components/Account/participantProgress.jsx
+++ b/dashboard-ui/src/components/Account/participantProgress.jsx
@@ -3,7 +3,7 @@ import '../../css/resultsTable.css';
 import '../../css/admInfo.css';
 import '../../css/repairAlignment.css';
 import { Autocomplete, TextField, Modal, Box, Snackbar, Alert } from "@mui/material";
-import {  VisibilityOff, Delete, Build, CheckCircle, Error } from '@material-ui/icons';
+import { VisibilityOff, Delete, Build, CheckCircle, Error } from '@material-ui/icons';
 import { useMutation, useQuery } from 'react-apollo'
 import gql from "graphql-tag";
 import { DownloadButtons } from "../Research/tables/download-buttons";
@@ -413,7 +413,11 @@ export function ParticipantProgressTable({ canViewProlific = false, isAdmin = fa
                 }
 
                 if (!evalNumber) {
-                    if (pid > 202506100) {
+                    const loggedEvalNumber = res['evalNum'];
+                    if (loggedEvalNumber) {
+                        obj['_phase'] = loggedEvalNumber >= 8 ? 2 : 1;
+                        obj['_evalNumber'] = loggedEvalNumber;
+                    } else if (pid > 202506100) {
                         obj['_phase'] = 2;
                         obj['_evalNumber'] = 8;
                     } else {
@@ -462,7 +466,7 @@ export function ParticipantProgressTable({ canViewProlific = false, isAdmin = fa
             if (canDeleteData(dataSet)) {
                 return <td key={`${dataSet['Participant ID']}-${header}`} className='white-cell delete-column'>
                     <button className="delete-btn" onClick={() => confirmDeletion(dataSet)}>
-                        <Delete/>
+                        <Delete />
                     </button>
                 </td>
             }


### PR DESCRIPTION
PIDs that were generated with no data attached to them were populating under `June 2025 Collaboration`. On dev, you'll see 82 entries under June 2025. On the feature branch, this should be down to 66:
http://localhost:3000/participant-progress-table
<img width="378" height="205" alt="Screenshot 2026-08-03 at 4 47 17 PM" src="https://github.com/user-attachments/assets/1c982e78-9da8-4659-9af3-a0589dab9aeb" />

The fallback logic for when there was no data associated with the PID was not taking into account that we have an `evalNum` field that gets attached to the participant when they are generated. These garbage rows still need to be deleted (I will do this on production), but they will no longer congregate under June 2025 Collab. 