### PR TITLE
Itm 1425: Virtualize RQ1 and RQ2 tables

### DIFF
--- a/dashboard-ui/src/components/Research/tables/ph2_rq22-rq23.jsx
+++ b/dashboard-ui/src/components/Research/tables/ph2_rq22-rq23.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useVirtualizer } from '@tanstack/react-virtual';
 import '../../../css/resultsTable.css';
 import { useQuery } from 'react-apollo'
 import gql from "graphql-tag";
@@ -109,7 +110,7 @@ export function PH2RQ2223({ evalNum }) {
     };
 
     const parseEval15Target = (target) => {
-        const targets = {'AF': '', 'MF': '', 'PS': '', 'SS': ''}
+        const targets = { 'AF': '', 'MF': '', 'PS': '', 'SS': '' }
         const regexp = /([A-Z]+)-?(\d+)/g
 
         const matchedTargets = [...String(target ?? '').matchAll(regexp)]
@@ -170,7 +171,7 @@ export function PH2RQ2223({ evalNum }) {
                 set constructions. So I needed to conditionally add more to the key for this eval
                 */
                 const scenarioKey = evalNum === 14 ? `${scenario}_${setConstruction}` : scenario;
-                const mapKey = evalNum === 14 
+                const mapKey = evalNum === 14
                     ? `${scenario}_${setConstruction}_${target}_${alignment}`
                     : `${scenario}_${target}_${alignment}`;
 
@@ -220,7 +221,7 @@ export function PH2RQ2223({ evalNum }) {
                         ? `P2${evalToName[evalNum]} Dynamic Set ${setMatch[1]}`
                         : `P2${evalToName[evalNum]} Observation Set ${setMatch[1]}`;
 
-                const actualScenario = evalNum === 14 && scenarioKey.includes('_') 
+                const actualScenario = evalNum === 14 && scenarioKey.includes('_')
                     ? scenarioKey.substring(0, scenarioKey.lastIndexOf('_'))
                     : scenarioKey;
 
@@ -228,11 +229,11 @@ export function PH2RQ2223({ evalNum }) {
                 for (const target of Object.keys(targets)) {
                     const alignedAdms = Object.keys(targets[target])
                         .filter(name => evalNum === 15
-                        ? !name.includes('OutlinesBaseline')
-                        : name.includes('aligned') || name.includes('ComparativeRegression') || name.includes('DirectRegression')
+                            ? !name.includes('OutlinesBaseline')
+                            : name.includes('aligned') || name.includes('ComparativeRegression') || name.includes('DirectRegression')
                         )
                         .map(name => ({ name, ...targets[target][name] }));
-                    
+
                     if (alignedAdms.length === 0) continue;
 
                     const parsed = evalNum === 15 ? parseEval15Target(target) : null;
@@ -244,15 +245,15 @@ export function PH2RQ2223({ evalNum }) {
                         ? (attribute.includes('-') ? '2D' : '1D')
                         : setConstruction;
 
-                    
+
                     let baselineMap = {};
                     if (evalNum === 15) {
                         for (const admName of Object.keys(targets[target])) {
                             if (admName.includes('OutlinesBaseline')) {
                                 const idx = admName.indexOf('OutlinesBaseline-');
                                 const rawSuffix = admName.slice(idx + 'OutlinesBaseline-'.length);
-                                const suffix = rawSuffix.includes('__') 
-                                    ? rawSuffix.split('__')[0] 
+                                const suffix = rawSuffix.includes('__')
+                                    ? rawSuffix.split('__')[0]
                                     : rawSuffix.replace(/_\d+(_\d+)*$/, '');
 
                                 baselineMap[suffix] = targets[target][admName];
@@ -313,7 +314,7 @@ export function PH2RQ2223({ evalNum }) {
                         entryObj['Aligned ADM Alignment score (ADM|target)'] = aligned.alignment;
                         entryObj['Aligned Server Session ID'] = aligned.adm?.results?.ta1_session_id ?? '-';
 
-                        const mapKey = evalNum === 14 
+                        const mapKey = evalNum === 14
                             ? `${actualScenario}_${setConstruction}_${target}_${aligned?.alignment}`
                             : `${actualScenario}_${target}_${aligned?.alignment}`;
                         const rawProbes = probeMap[mapKey] || [];
@@ -477,127 +478,156 @@ export function PH2RQ2223({ evalNum }) {
         }
     }, [formattedData, attributeFilters, targetFilters, setFilters, setConstructionFilters, admNamesFilters]);
 
-    if (loading || (dataRef.current !== evalNum && data?.getAllHistoryByEvalNumber?.length > 0)) return <p>Loading...</p>;
-    if (error) return <p>Error: {error.message}</p>;
-
     //eval 15 at least one filter before rendering rows due to dataset size
     const hasActiveFilters = attributeFilters.length > 0 || targetFilters.length > 0 ||
         setFilters.length > 0 || setConstructionFilters.length > 0 || admNamesFilters.length > 0;
     const shouldRenderRows = evalNum !== 15 || hasActiveFilters;
+
+    const tableContainerRef = React.useRef(null);
+    const rowVirtualizer = useVirtualizer({
+        count: shouldRenderRows ? filteredData.length : 0,
+        getScrollElement: () => tableContainerRef.current,
+        estimateSize: () => 36,
+        overscan: 10,
+    });
+
+    if (loading || (dataRef.current !== evalNum && data?.getAllHistoryByEvalNumber?.length > 0)) return <p>Loading...</p>;
+    if (error) return <p>Error: {error.message}</p>;
 
     return (
         <>
             {evalNum === 15 && !hasActiveFilters
                 ? <p className='filteredText'>
                     Select at least one filter to display results. Full data is available for download.
-                  </p>
+                </p>
                 : filteredData.length < formattedData.length &&
-                    <p className='filteredText'>
-                        Showing {filteredData.length} of {formattedData.length} rows based on filters
-                    </p>
+                <p className='filteredText'>
+                    Showing {filteredData.length} of {formattedData.length} rows based on filters
+                </p>
             }
             {formattedData.length === 0 ? <p>This table is not available for the selected evaluation.</p> :
-            <>
-            <section className='tableHeader'>
-                <div className="filters">
-                    <Autocomplete
-                        multiple
-                        options={attributes}
-                        value={attributeFilters}
-                        filterSelectedOptions
-                        size="small"
-                        renderInput={(params) => (
-                            <TextField {...params} label="Attributes" />
-                        )}
-                        onChange={(_, newVal) => setAttributeFilters(newVal)}
-                    />
+                <>
+                    <section className='tableHeader'>
+                        <div className="filters">
+                            <Autocomplete
+                                multiple
+                                options={attributes}
+                                value={attributeFilters}
+                                filterSelectedOptions
+                                size="small"
+                                renderInput={(params) => (
+                                    <TextField {...params} label="Attributes" />
+                                )}
+                                onChange={(_, newVal) => setAttributeFilters(newVal)}
+                            />
 
-                    <Autocomplete
-                        multiple
-                        options={targets}
-                        value={targetFilters}
-                        filterSelectedOptions
-                        size="small"
-                        renderInput={(params) => (
-                            <TextField {...params} label="Targets" />
-                        )}
-                        onChange={(_, newVal) => setTargetFilters(newVal)}
-                    />
-                    {(evalNum === 14 || evalNum === 15) && 
-                        <Autocomplete
-                        multiple
-                        options={setConstructions}
-                        value={setConstructionFilters}
-                        filterSelectedOptions
-                        size="small"
-                        renderInput={(params) => (
-                            <TextField {...params} label="Set Construction" />
-                        )}
-                        onChange={(_, newVal) => setSetConstructionFilters(newVal)}
-                    />
-                    }
+                            <Autocomplete
+                                multiple
+                                options={targets}
+                                value={targetFilters}
+                                filterSelectedOptions
+                                size="small"
+                                renderInput={(params) => (
+                                    <TextField {...params} label="Targets" />
+                                )}
+                                onChange={(_, newVal) => setTargetFilters(newVal)}
+                            />
+                            {(evalNum === 14 || evalNum === 15) &&
+                                <Autocomplete
+                                    multiple
+                                    options={setConstructions}
+                                    value={setConstructionFilters}
+                                    filterSelectedOptions
+                                    size="small"
+                                    renderInput={(params) => (
+                                        <TextField {...params} label="Set Construction" />
+                                    )}
+                                    onChange={(_, newVal) => setSetConstructionFilters(newVal)}
+                                />
+                            }
 
-                    {evalNum >= 15 &&
-                        <Autocomplete
-                        className='large-box'
-                        multiple
-                        options={admNames}
-                        value={admNamesFilters}
-                        filterSelectedOptions
-                        size="small"
-                        renderInput={(params) => (
-                            <TextField {...params} label="ADM Name" />
-                        )}
-                        onChange={(_, newVal) => setAdmNamesFilters(newVal)}
-                    />
-                    }
+                            {evalNum >= 15 &&
+                                <Autocomplete
+                                    className='large-box'
+                                    multiple
+                                    options={admNames}
+                                    value={admNamesFilters}
+                                    filterSelectedOptions
+                                    size="small"
+                                    renderInput={(params) => (
+                                        <TextField {...params} label="ADM Name" />
+                                    )}
+                                    onChange={(_, newVal) => setAdmNamesFilters(newVal)}
+                                />
+                            }
 
-                    <Autocomplete
-                        className='large-box'
-                        multiple
-                        options={sets}
-                        value={setFilters}
-                        filterSelectedOptions
-                        size="small"
-                        renderInput={(params) => (
-                            <TextField {...params} label="Set" />
-                        )}
-                        onChange={(_, newVal) => setSetFilters(newVal)}
-                    />
-                </div>
+                            <Autocomplete
+                                className='large-box'
+                                multiple
+                                options={sets}
+                                value={setFilters}
+                                filterSelectedOptions
+                                size="small"
+                                renderInput={(params) => (
+                                    <TextField {...params} label="Set" />
+                                )}
+                                onChange={(_, newVal) => setSetFilters(newVal)}
+                            />
+                        </div>
 
-                <DownloadButtons
-                    formattedData={formattedData}
-                    filteredData={filteredData}
-                    HEADERS={PH2_HEADERS}
-                    fileName={'RQ-22_and_RQ-23_PH2_data'}
-                    extraAction={openModal}
-                />
-            </section>
+                        <DownloadButtons
+                            formattedData={formattedData}
+                            filteredData={filteredData}
+                            HEADERS={PH2_HEADERS}
+                            fileName={'RQ-22_and_RQ-23_PH2_data'}
+                            extraAction={openModal}
+                        />
+                    </section>
 
-            <div className='resultTableSection'>
-                <table className='itm-table'>
-                    <thead>
-                        <tr>
-                            {PH2_HEADERS.map((val, index) => (
-                                <th key={'header-' + index}>{val}</th>
-                            ))}
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {shouldRenderRows && filteredData.map((dataSet, index) => (
-                            <tr key={`row-${index}`}>
-                                {PH2_HEADERS.map((val) => (
-                                    <td key={`cell-${index}-${val}`}>
-                                        {dataSet[val] ?? '-'}
-                                    </td>
-                                ))}
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
-            </div>
-            </>
+                    <div className='resultTableSection' ref={tableContainerRef}>
+                        <table className='itm-table'>
+                            <thead>
+                                <tr>
+                                    {PH2_HEADERS.map((val, index) => (
+                                        <th key={'header-' + index}>{val}</th>
+                                    ))}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {(rowVirtualizer.getVirtualItems()[0]?.start ?? 0) > 0 && (
+                                    <tr style={{ height: rowVirtualizer.getVirtualItems()[0].start }}>
+                                        <td style={{ padding: 0, border: 0 }} />
+                                    </tr>
+                                )}
+                                {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                                    const dataSet = filteredData[virtualRow.index];
+                                    return (
+                                        <tr
+                                            key={`row-${virtualRow.index}`}
+                                            data-index={virtualRow.index}
+                                            ref={rowVirtualizer.measureElement}
+                                            className={virtualRow.index % 2 === 0 ? 'row-even' : 'row-odd'}
+                                        >
+                                            {PH2_HEADERS.map((val) => (
+                                                <td key={`cell-${virtualRow.index}-${val}`}>
+                                                    {dataSet[val] ?? '-'}
+                                                </td>
+                                            ))}
+                                        </tr>
+                                    );
+                                })}
+                                {rowVirtualizer.getTotalSize() > 0 && (() => {
+                                    const items = rowVirtualizer.getVirtualItems();
+                                    const lastItem = items[items.length - 1];
+                                    const paddingBottom = lastItem
+                                        ? rowVirtualizer.getTotalSize() - (lastItem.start + lastItem.size)
+                                        : 0;
+                                    return paddingBottom > 0 ? <tr style={{ height: paddingBottom }}><td /></tr> : null;
+                                })()}
+                            </tbody>
+                        </table>
+                    </div>
+                </>
             }
 
             <Modal className='table-modal' open={showDefinitions} onClose={closeModal}>

--- a/dashboard-ui/src/components/Research/tables/ph2_rq22-rq23.jsx
+++ b/dashboard-ui/src/components/Research/tables/ph2_rq22-rq23.jsx
@@ -595,6 +595,7 @@ export function PH2RQ2223({ evalNum }) {
                             </thead>
                             <tbody>
                                 {(rowVirtualizer.getVirtualItems()[0]?.start ?? 0) > 0 && (
+                                    // spacer that accounts for where the user has scrolled to 
                                     <tr style={{ height: rowVirtualizer.getVirtualItems()[0].start }}>
                                         <td style={{ padding: 0, border: 0 }} />
                                     </tr>

--- a/dashboard-ui/src/components/Research/tables/rq134.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq134.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useVirtualizer } from '@tanstack/react-virtual';
 import '../../../css/resultsTable.css';
 import { useQuery } from 'react-apollo'
 import gql from "graphql-tag";
@@ -65,7 +66,7 @@ const HEADERS_PH1 = ['Delegator ID', 'ADM Order', 'Datasource', 'Delegator_grp',
 const HEADERS_PH2_JUNE_2025 = ['Delegator ID', 'Datasource', 'Delegator_grp', 'Delegator_mil', 'Delegator_Role', 'Trial_ID', 'Attribute', 'Probe Set Assessment', 'Probe Set Observation', 'ADM_Type', 'Target', 'Alignment score (ADM|target)', 'Alignment score (Delegator|target)', 'Server Session ID (Delegator)', 'ADM_Aligned_Status (Baseline/Misaligned/Aligned)', 'ADM Loading', 'Alignment score (Delegator|Observed_ADM (target))', 'Trust_Rating', 'Delegation preference (A/B)', 'Delegation preference (A/M)', 'Delegation (A/HH)', 'Delegation (A/HL)', 'Delegation (A/LH)', 'Delegation (A/LL)', 'Trustworthy_Rating', 'Agreement_Rating', 'SRAlign_Rating'];
 const HEADERS_PH2_SEPT_2025 = ['Delegator ID', 'Datasource', 'Delegator_grp', 'Delegator_mil', 'Delegator_Role', 'Trial_ID', 'Attribute', 'Probe Set Assessment', 'Probe Set Observation', 'ADM_Type', 'Target', 'Server Session ID (Delegator)', 'Alignment score (Delegator|Observed_ADM (target))', 'Trust_Rating', 'Delegation Preference (PSAF-1/PSAF-2)', 'Delegation Preference (PSAF-1/PSAF-3)', 'Delegation Preference (PSAF-1/PSAF-4)', 'Delegation Preference (PSAF-2/PSAF-3)', 'Delegation Preference (PSAF-2/PSAF-4)', 'Delegation Preference (PSAF-3/PSAF-4)', 'Trustworthy_Rating', 'Agreement_Rating', 'SRAlign_Rating'];
 const HEADERS_PH2_FEB_2026 = ['Delegator ID', 'Datasource', 'Delegator_grp', 'Delegator_mil', 'Trial_ID', 'Attribute', 'Probe Set Observation', 'Kitware Model', 'ADM_Type', 'Target', 'Alignment score (ADM|target)', 'Alignment score (Delegator|target)', 'Server Session ID (Delegator)', 'ADM_Aligned_Status (Baseline/Misaligned/Aligned)', 'ADM Loading', 'Alignment score (Delegator|Observed_ADM (target))', 'Trust_Rating', 'Delegation preference (A/B)', 'Delegation Percentage (Aligned/Baseline)', 'Delegation preference (A/M)', 'Delegation Percentage (Aligned/Misaligned)', 'Trustworthy_Rating', 'Agreement_Rating', 'SRAlign_Rating'];
-const HEADERS_PH2_APRIL_2026 = ['Delegator ID', 'Datasource', 'Delegator_grp', 'Delegator_mil', 'Trial_ID', 'Attribute', 'Kitware Model', 'ADM_Type', 'Target', 'Alignment score (ADM|target)', 'Alignment score (Delegator|target)', 'Server Session ID (Delegator)', 'ADM_Aligned_Status (Baseline/Misaligned/Aligned)', 'ADM Loading', 'Alignment score (Delegator|Observed_ADM (target))', 'Trust_Rating', 'Distrust_Rating', 'Trustworthy(INT)_Rating', 'Trustworthy(BEN)_Rating', 'Delegation1', 'Delegation2', 'Delegation preference (A/B)', 'Delegation Percentage (Aligned/Baseline)', 'Delegation Preference (AlignedSS/AlignedOS)', 'Delegation Percentage (AlignedSS/AlignedOS)','Delegation Preference (AlignedOS/Misaligned)', 'Delegation Percentage (AlignedOS/Misaligned)'];
+const HEADERS_PH2_APRIL_2026 = ['Delegator ID', 'Datasource', 'Delegator_grp', 'Delegator_mil', 'Trial_ID', 'Attribute', 'Kitware Model', 'ADM_Type', 'Target', 'Alignment score (ADM|target)', 'Alignment score (Delegator|target)', 'Server Session ID (Delegator)', 'ADM_Aligned_Status (Baseline/Misaligned/Aligned)', 'ADM Loading', 'Alignment score (Delegator|Observed_ADM (target))', 'Trust_Rating', 'Distrust_Rating', 'Trustworthy(INT)_Rating', 'Trustworthy(BEN)_Rating', 'Delegation1', 'Delegation2', 'Delegation preference (A/B)', 'Delegation Percentage (Aligned/Baseline)', 'Delegation Preference (AlignedSS/AlignedOS)', 'Delegation Percentage (AlignedSS/AlignedOS)', 'Delegation Preference (AlignedOS/Misaligned)', 'Delegation Percentage (AlignedOS/Misaligned)'];
 const HEADERS_PH2_JUNE_2026 = ['Delegator ID', 'Datasource', 'Delegator_grp', 'Delegator_mil', 'Trial_ID', 'Attribute', 'Kitware Model', 'ADM_Type', 'Target', 'Alignment score (ADM|target)', 'Alignment score (Delegator|target)', 'Server Session ID (Delegator)', 'ADM_Aligned_Status (Baseline/Misaligned/Aligned)', 'ADM Loading', 'Alignment score (Delegator|Observed_ADM (target))', 'Trust_Rating', 'Distrust_Rating', 'Trustworthy(INT)_Rating', 'Trustworthy(BEN)_Rating', 'Delegation1', 'Delegation2', 'Delegation preference (A/B)', 'Delegation Percentage (Aligned/Baseline)', 'Delegation preference (A/M)', 'Delegation Percentage (Aligned/Misaligned)', 'Alignment score (DelegatorTRI|Observed_ADM (target))'];
 export function RQ134({ evalNum, tableTitle }) {
     // -------------------------- State: filters, toggles, and table data --------------------------
@@ -387,13 +388,13 @@ export function RQ134({ evalNum, tableTitle }) {
     ]);
 
     const allFetched = fetchedSurveyEvals.includes(evalNum) &&
-                   fetchedScenarioEvals.includes(evalNum) &&
-                   fetchedComparisonEvals.includes(evalNum);
+        fetchedScenarioEvals.includes(evalNum) &&
+        fetchedComparisonEvals.includes(evalNum);
 
     const allLoaded = !loadingParticipantLog && !loadingSurveyResults && !loadingTextResults &&
-                  !loadingADMs && !loadingMedics && !loadingComparisonData && !loadingSim;
+        !loadingADMs && !loadingMedics && !loadingComparisonData && !loadingSim;
 
-    React.useEffect(() =>{
+    React.useEffect(() => {
         if (allFetched && allLoaded && processedForEval !== evalNum) {
             setProcessedForEval(evalNum)
         }
@@ -552,9 +553,17 @@ export function RQ134({ evalNum, tableTitle }) {
         console.log(errors);
         return <QueryErrorMessage errors={errors} />;
     }
-    
+
     if (loadingParticipantLog || loadingSurveyResults || loadingTextResults || loadingADMs || loadingMedics || loadingComparisonData || loadingSim || formattedData.length === 0 && processedForEval !== evalNum) return <p>Loading...</p>;
 
+    // init virtualizer
+    const tableContainerRef = React.useRef(null);
+    const rowVirtualizer = useVirtualizer({
+        count: filteredData.length,
+        getScrollElement: () => tableContainerRef.current,
+        estimateSize: () => 36,
+        overscan: 10,
+    });
 
     return (<>
         <h2 className='rq134-header'>{tableTitle}
@@ -582,233 +591,254 @@ export function RQ134({ evalNum, tableTitle }) {
                 <span className='reset-btn' onClick={clearFilters}>(Reset Filters)</span>
             </p>
         }
-        {formattedData.length === 0 && processedForEval === evalNum ? <p>This table is not available for the selected evaluation.</p>: formattedData.length > 0 ?
-        <>
-        <section className='tableHeader'>
-            <div className='complexHeader'>
-                <div className="too-many-filters">
-                    {evalNum < 8 && (
-                        <>
+        {formattedData.length === 0 && processedForEval === evalNum ? <p>This table is not available for the selected evaluation.</p> : formattedData.length > 0 ?
+            <>
+                <section className='tableHeader'>
+                    <div className='complexHeader'>
+                        <div className="too-many-filters">
+                            {evalNum < 8 && (
+                                <>
+                                    <Autocomplete
+                                        multiple
+                                        options={ta1s}
+                                        value={ta1Filters}
+                                        size="small"
+                                        limitTags={2}
+                                        renderInput={(params) => (
+                                            <TextField
+                                                {...params}
+                                                label="TA1"
+                                                placeholder=""
+                                            />
+                                        )}
+                                        onChange={(_, newVal) => setTA1Filters(newVal)}
+                                    />
+                                    <Autocomplete
+                                        multiple
+                                        options={ta2s}
+                                        value={ta2Filters}
+                                        size="small"
+                                        limitTags={2}
+                                        renderInput={(params) => (
+                                            <TextField
+                                                {...params}
+                                                label="TA2"
+                                                placeholder=""
+                                            />
+                                        )}
+                                        onChange={(_, newVal) => setTA2Filters(newVal)}
+                                    />
+                                    <Autocomplete
+                                        multiple
+                                        options={scenarios}
+                                        value={scenarioFilters}
+                                        size="small"
+                                        limitTags={2}
+                                        renderInput={(params) => (
+                                            <TextField
+                                                {...params}
+                                                label="Scenarios"
+                                                placeholder=""
+                                            />
+                                        )}
+                                        onChange={(_, newVal) => setScenarioFilters(newVal)}
+                                    />
+                                </>
+                            )}
+                            {evalNum >= 8 && evalNum < 12 && (
+                                <>
+                                    <Autocomplete
+                                        multiple
+                                        options={probeSetAssessments.sort()}
+                                        value={probeSetAssessmentFilters}
+                                        size="small"
+                                        limitTags={2}
+                                        getOptionLabel={(option) => String(option)}
+                                        renderInput={(params) => (
+                                            <TextField
+                                                {...params}
+                                                label="Probe Set Assessment"
+                                                placeholder=""
+                                            />
+                                        )}
+                                        onChange={(_, newVal) => setProbeSetAssessmentFilters(newVal)}
+                                    />
+                                    <Autocomplete
+                                        multiple
+                                        options={probeSetObservations.sort()}
+                                        value={probeSetObservationFilters}
+                                        size="small"
+                                        limitTags={2}
+                                        getOptionLabel={(option) => String(option)}
+                                        renderInput={(params) => (
+                                            <TextField
+                                                {...params}
+                                                label="Probe Set Observation"
+                                                placeholder=""
+                                            />
+                                        )}
+                                        onChange={(_, newVal) => setProbeSetObservationFilters(newVal)}
+                                    />
+                                </>
+                            )}
                             <Autocomplete
                                 multiple
-                                options={ta1s}
-                                value={ta1Filters}
+                                options={targets}
+                                value={targetFilters}
                                 size="small"
                                 limitTags={2}
                                 renderInput={(params) => (
                                     <TextField
                                         {...params}
-                                        label="TA1"
+                                        label="Targets"
                                         placeholder=""
                                     />
                                 )}
-                                onChange={(_, newVal) => setTA1Filters(newVal)}
+                                onChange={(_, newVal) => setTargetFilters(newVal)}
                             />
                             <Autocomplete
                                 multiple
-                                options={ta2s}
-                                value={ta2Filters}
+                                options={attributes}
+                                value={attributeFilters}
                                 size="small"
                                 limitTags={2}
                                 renderInput={(params) => (
                                     <TextField
                                         {...params}
-                                        label="TA2"
+                                        label="Attributes"
                                         placeholder=""
                                     />
                                 )}
-                                onChange={(_, newVal) => setTA2Filters(newVal)}
+                                onChange={(_, newVal) => setAttributeFilters(newVal)}
                             />
                             <Autocomplete
                                 multiple
-                                options={scenarios}
-                                value={scenarioFilters}
+                                options={admTypes}
+                                value={admTypeFilters}
                                 size="small"
                                 limitTags={2}
                                 renderInput={(params) => (
                                     <TextField
                                         {...params}
-                                        label="Scenarios"
+                                        label="ADM Types"
                                         placeholder=""
                                     />
                                 )}
-                                onChange={(_, newVal) => setScenarioFilters(newVal)}
-                            />
-                        </>
-                    )}
-                    {evalNum >= 8 && evalNum < 12 && (
-                        <>
-                            <Autocomplete
-                                multiple
-                                options={probeSetAssessments.sort()}
-                                value={probeSetAssessmentFilters}
-                                size="small"
-                                limitTags={2}
-                                getOptionLabel={(option) => String(option)}
-                                renderInput={(params) => (
-                                    <TextField
-                                        {...params}
-                                        label="Probe Set Assessment"
-                                        placeholder=""
-                                    />
-                                )}
-                                onChange={(_, newVal) => setProbeSetAssessmentFilters(newVal)}
+                                onChange={(_, newVal) => setAdmTypeFilters(newVal)}
                             />
                             <Autocomplete
                                 multiple
-                                options={probeSetObservations.sort()}
-                                value={probeSetObservationFilters}
+                                options={delGrps}
+                                value={delGrpFilters}
                                 size="small"
                                 limitTags={2}
-                                getOptionLabel={(option) => String(option)}
                                 renderInput={(params) => (
                                     <TextField
                                         {...params}
-                                        label="Probe Set Observation"
+                                        label="Delegator_grp"
                                         placeholder=""
                                     />
                                 )}
-                                onChange={(_, newVal) => setProbeSetObservationFilters(newVal)}
+                                onChange={(_, newVal) => setDelGrpFilters(newVal)}
                             />
-                        </>
-                    )}
-                    <Autocomplete
-                        multiple
-                        options={targets}
-                        value={targetFilters}
-                        size="small"
-                        limitTags={2}
-                        renderInput={(params) => (
-                            <TextField
-                                {...params}
-                                label="Targets"
-                                placeholder=""
+                            <Autocomplete
+                                multiple
+                                options={delMils}
+                                value={delMilFilters}
+                                size="small"
+                                limitTags={2}
+                                renderInput={(params) => (
+                                    <TextField
+                                        {...params}
+                                        label="Delegator_mil"
+                                        placeholder=""
+                                    />
+                                )}
+                                onChange={(_, newVal) => setDelMilFilters(newVal)}
                             />
-                        )}
-                        onChange={(_, newVal) => setTargetFilters(newVal)}
-                    />
-                    <Autocomplete
-                        multiple
-                        options={attributes}
-                        value={attributeFilters}
-                        size="small"
-                        limitTags={2}
-                        renderInput={(params) => (
-                            <TextField
-                                {...params}
-                                label="Attributes"
-                                placeholder=""
+                        </div>
+                        <div className='largeInputs'>
+                            <Autocomplete
+                                multiple
+                                options={headers}
+                                size="small"
+                                limitTags={1}
+                                value={columnsToHide}
+                                renderInput={(params) => (
+                                    <TextField
+                                        {...params}
+                                        label="Hidden Columns"
+                                        placeholder=""
+                                    />
+                                )}
+                                onChange={(_, newVal) => setColumnsToHide(newVal)}
                             />
-                        )}
-                        onChange={(_, newVal) => setAttributeFilters(newVal)}
-                    />
-                    <Autocomplete
-                        multiple
-                        options={admTypes}
-                        value={admTypeFilters}
-                        size="small"
-                        limitTags={2}
-                        renderInput={(params) => (
-                            <TextField
-                                {...params}
-                                label="ADM Types"
-                                placeholder=""
-                            />
-                        )}
-                        onChange={(_, newVal) => setAdmTypeFilters(newVal)}
-                    />
-                    <Autocomplete
-                        multiple
-                        options={delGrps}
-                        value={delGrpFilters}
-                        size="small"
-                        limitTags={2}
-                        renderInput={(params) => (
-                            <TextField
-                                {...params}
-                                label="Delegator_grp"
-                                placeholder=""
-                            />
-                        )}
-                        onChange={(_, newVal) => setDelGrpFilters(newVal)}
-                    />
-                    <Autocomplete
-                        multiple
-                        options={delMils}
-                        value={delMilFilters}
-                        size="small"
-                        limitTags={2}
-                        renderInput={(params) => (
-                            <TextField
-                                {...params}
-                                label="Delegator_mil"
-                                placeholder=""
-                            />
-                        )}
-                        onChange={(_, newVal) => setDelMilFilters(newVal)}
-                    />
-                </div>
-                <div className='largeInputs'>
-                    <Autocomplete
-                        multiple
-                        options={headers}
-                        size="small"
-                        limitTags={1}
-                        value={columnsToHide}
-                        renderInput={(params) => (
-                            <TextField
-                                {...params}
-                                label="Hidden Columns"
-                                placeholder=""
-                            />
-                        )}
-                        onChange={(_, newVal) => setColumnsToHide(newVal)}
-                    />
-                    <TextField label="Search PIDs" size="small" value={searchPid} onInput={updatePidSearch}></TextField>
-                </div>
+                            <TextField label="Search PIDs" size="small" value={searchPid} onInput={updatePidSearch}></TextField>
+                        </div>
 
-            </div>
+                    </div>
 
-            <DownloadButtons
-                formattedData={refineData(formattedData)}
-                filteredData={refineData(filteredData)}
-                HEADERS={getFilteredHeaders()}
-                fileName={'RQ-134 data'}
-                extraAction={openModal}
-            />
+                    <DownloadButtons
+                        formattedData={refineData(formattedData)}
+                        filteredData={refineData(filteredData)}
+                        HEADERS={getFilteredHeaders()}
+                        fileName={'RQ-134 data'}
+                        extraAction={openModal}
+                    />
 
-        </section>
-        <div className='resultTableSection'>
-            <table className='itm-table'>
-                <thead>
-                    <tr>
-                        {headers.map((val, index) => {
-                            return (!columnsToHide.includes(val) && <th key={'header-' + index} className='rq134Header' style={{ zIndex: val === headers.filter((x) => !columnsToHide.includes(x))[0] ? 1 : 0 }}>
-                                {val} <button className='hide-header' onClick={() => hideColumn(val)}><VisibilityOffIcon size={'small'} /></button>
-                            </th>);
-                        })}
-                    </tr>
-                </thead>
-                <tbody>
-                    {filteredData.map((dataSet, index) => {
-                        return (<tr key={dataSet['Delegator ID'] + '-' + index} className={index % 2 === 0 ? 'row-even' : 'row-odd'}>
-                            {headers.map((val) => {
-                                return (!columnsToHide.includes(val) && <td key={dataSet['Delegator ID'] + '-' + val}>
-                                    {typeof dataSet[val] === 'string' ? dataSet[val]?.replaceAll('"', "") : dataSet[val] ?? '-'}
-                                </td>);
+                </section>
+                <div className='resultTableSection' ref={tableContainerRef}>
+                    <table className='itm-table'>
+                        <thead>
+                            <tr>
+                                {headers.map((val, index) => {
+                                    return (!columnsToHide.includes(val) && <th key={'header-' + index} className='rq134Header' style={{ zIndex: val === headers.filter((x) => !columnsToHide.includes(x))[0] ? 1 : 0 }}>
+                                        {val} <button className='hide-header' onClick={() => hideColumn(val)}><VisibilityOffIcon size={'small'} /></button>
+                                    </th>);
+                                })}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {(rowVirtualizer.getVirtualItems()[0]?.start ?? 0) > 0 && (
+                                <tr style={{ height: rowVirtualizer.getVirtualItems()[0].start }}>
+                                    <td style={{ padding: 0, border: 0 }} />
+                                </tr>
+                            )}
+                            {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                                const dataSet = filteredData[virtualRow.index];
+                                return (
+                                    <tr
+                                        key={dataSet['Delegator ID'] + '-' + virtualRow.index}
+                                        data-index={virtualRow.index}
+                                        ref={rowVirtualizer.measureElement}
+                                        className={virtualRow.index % 2 === 0 ? 'row-even' : 'row-odd'}
+                                    >
+                                        {headers.map((val) => {
+                                            return (!columnsToHide.includes(val) && <td key={dataSet['Delegator ID'] + '-' + val}>
+                                                {typeof dataSet[val] === 'string' ? dataSet[val]?.replaceAll('"', "") : dataSet[val] ?? '-'}
+                                            </td>);
+                                        })}
+                                    </tr>
+                                );
                             })}
-                        </tr>);
-                    })}
-                </tbody>
-            </table>
-        </div>
-        </>
-        :null
+                            {rowVirtualizer.getTotalSize() > 0 && (() => {
+                                const items = rowVirtualizer.getVirtualItems();
+                                const lastItem = items[items.length - 1];
+                                const paddingBottom = lastItem
+                                    ? rowVirtualizer.getTotalSize() - (lastItem.start + lastItem.size)
+                                    : 0;
+                                return paddingBottom > 0 ? <tr style={{ height: paddingBottom }}><td /></tr> : null;
+                            })()}
+                        </tbody>
+                    </table>
+                </div>
+            </>
+            : null
         }
         <Modal className='table-modal' open={showDefinitions} onClose={closeModal}>
             <div className='modal-body'>
                 <span className='close-icon' onClick={closeModal}><CloseIcon /></span>
-                <RQDefinitionTable downloadName={`Definitions_RQ134_eval${evalNum}.xlsx`} xlFile={DEFINITION_FILE_MAP[evalNum] ?? dreDefinitionXLFile}  />
+                <RQDefinitionTable downloadName={`Definitions_RQ134_eval${evalNum}.xlsx`} xlFile={DEFINITION_FILE_MAP[evalNum] ?? dreDefinitionXLFile} />
             </div>
         </Modal>
     </>);

--- a/dashboard-ui/src/components/Research/tables/rq134.jsx
+++ b/dashboard-ui/src/components/Research/tables/rq134.jsx
@@ -538,6 +538,15 @@ export function RQ134({ evalNum, tableTitle }) {
         return headers.filter(x => !columnsToHide.includes(x) && (shouldShowTruncationError || x !== 'Truncation Error'));
     };
 
+    // init virtualizer
+    const tableContainerRef = React.useRef(null);
+    const rowVirtualizer = useVirtualizer({
+        count: filteredData.length,
+        getScrollElement: () => tableContainerRef.current,
+        estimateSize: () => 36,
+        overscan: 10,
+    });
+
     // catch any errors that return true and save in an array to display in the QueryErrorMessage component
     const errors = [
         errorParticipantLog,
@@ -555,15 +564,6 @@ export function RQ134({ evalNum, tableTitle }) {
     }
 
     if (loadingParticipantLog || loadingSurveyResults || loadingTextResults || loadingADMs || loadingMedics || loadingComparisonData || loadingSim || formattedData.length === 0 && processedForEval !== evalNum) return <p>Loading...</p>;
-
-    // init virtualizer
-    const tableContainerRef = React.useRef(null);
-    const rowVirtualizer = useVirtualizer({
-        count: filteredData.length,
-        getScrollElement: () => tableContainerRef.current,
-        estimateSize: () => 36,
-        overscan: 10,
-    });
 
     return (<>
         <h2 className='rq134-header'>{tableTitle}


### PR DESCRIPTION
This adds virtualization to the RQ1 and RQ2 tables. I think this will help with load times on production a lot. It should also limit lag when scrolling through the table itself. Only the rows visible in the viewport (and a buffer outside of that) will be rendered. This is opposed to every single DOM element of the table needing to be rendered on page load.

RQ1: http://localhost:3000/research-results/rq1

RQ2: http://localhost:3000/research-results/rq2

Check the code, that the tables still populate as expected, downloads work, etc.